### PR TITLE
Send message to agent

### DIFF
--- a/docs/ai/design/feature-agent-send.md
+++ b/docs/ai/design/feature-agent-send.md
@@ -13,15 +13,16 @@ graph TD
     CLI["CLI: agent send &lt;msg&gt; --id &lt;id&gt;"]
     AM[AgentManager]
     Resolve["resolveAgent()"]
-    TTY["getProcessTty(pid)"]
-    Writer["TtyWriter.send(tty, message)"]
-    Device["/dev/ttysXXX"]
+    Find["TerminalFocusManager.findTerminal(pid)"]
+    Writer["TtyWriter.send(location, message)"]
 
     CLI --> AM
     AM --> Resolve
-    Resolve -->|matched agent| TTY
-    TTY -->|tty path| Writer
-    Writer -->|write message + CR| Device
+    Resolve -->|matched agent| Find
+    Find -->|TerminalLocation| Writer
+    Writer -->|dispatch| Tmux["tmux send-keys"]
+    Writer -->|dispatch| ITerm["iTerm2: write text"]
+    Writer -->|dispatch| TermApp["Terminal.app: System Events keystroke"]
 ```
 
 The flow is:
@@ -29,14 +30,14 @@ The flow is:
 2. `AgentManager.listAgents()` detects all running agents
 3. `AgentManager.resolveAgent(id, agents)` finds the target
 4. If agent status is not `waiting`, print a warning but continue
-5. `getProcessTty(pid)` resolves the agent's TTY device
-6. `TtyWriter.send(tty, message)` writes message + `\r` to the TTY
+5. `TerminalFocusManager.findTerminal(pid)` identifies the terminal emulator and session
+6. `TtyWriter.send(location, message)` dispatches to the correct send mechanism
 
 ## Data Models
 
 No new data models needed. Reuses existing:
 - `AgentInfo` (from `AgentAdapter.ts`) - contains `pid`, `name`, `slug`, `status`
-- `ProcessInfo` (from `AgentAdapter.ts`) - contains `tty`
+- `TerminalLocation` (from `TerminalFocusManager.ts`) - contains `type`, `identifier`, `tty`
 
 ## API Design
 
@@ -49,40 +50,49 @@ ai-devkit agent send <message> --id <identifier>
 - `<message>`: Required positional argument. The text to send.
 - `--id <identifier>`: Required flag. Agent name, slug, or partial match string.
 
-### New Module: TtyWriter
+### Module: TtyWriter
 
 Location: `packages/agent-manager/src/terminal/TtyWriter.ts`
 
 ```typescript
 export class TtyWriter {
   /**
-   * Send a message to a TTY device
-   * @param tty - Short TTY name (e.g., "ttys030")
+   * Send a message as keyboard input to a terminal session.
+   * Dispatches to the correct mechanism based on terminal type.
+   *
+   * @param location - Terminal location from TerminalFocusManager.findTerminal()
    * @param message - Text to send
-   * @param appendCR - Whether to append \r (carriage return) to trigger submit (default: true)
-   * @throws Error if TTY is not writable
+   * @throws Error if terminal type is unsupported or send fails
    */
-  static async send(tty: string, message: string, appendCR?: boolean): Promise<void>;
+  static async send(location: TerminalLocation, message: string): Promise<void>;
 }
 ```
 
-Implementation: Opens `/dev/${tty}` for writing via `fs.writeFile` and writes `message + '\r'`. Uses `\r` (carriage return) instead of `\n` because interactive CLIs like Claude Code run in raw terminal mode where Enter sends CR (0x0D), not LF (0x0A).
+### Per-terminal mechanisms
+
+| Terminal | Method | How Enter is sent |
+|----------|--------|-------------------|
+| tmux | `tmux send-keys -t <pane> "msg" Enter` | tmux `Enter` key literal |
+| iTerm2 | AppleScript `write text "msg"` | `write text` auto-appends newline |
+| Terminal.app | System Events `keystroke "msg"` + `key code 36` | `key code 36` = Return key |
 
 ## Component Breakdown
 
 ### 1. TtyWriter (new) - `agent-manager` package
-- Single static method `send(tty, message, appendCR)`
-- Opens TTY device file for writing
-- Writes message (+ optional `\r` to trigger submit)
-- Validates TTY exists and is writable before writing
+- Single static method `send(location, message)`
+- Dispatches to `sendViaTmux`, `sendViaITerm2`, or `sendViaTerminalApp`
+- tmux: uses `execFile('tmux', ['send-keys', ...])` — no shell
+- iTerm2: uses `execFile('osascript', ['-e', script])` — no shell
+- Terminal.app: uses `execFile('osascript', ['-e', script])` with System Events `keystroke` + `key code 36` — no shell
+- Throws descriptive error for unsupported terminal types (`UNKNOWN`)
 
 ### 2. CLI `agent send` subcommand (new) - `cli` package
 - Registers under existing `agentCommand`
 - Parses `<message>` positional arg and `--id` required option
 - Uses `AgentManager` to list and resolve agent
 - Warns if agent status is not `waiting` (but still proceeds)
-- Uses `getProcessTty()` to get TTY
-- Uses `TtyWriter.send()` to deliver message
+- Uses `TerminalFocusManager.findTerminal(pid)` to identify terminal
+- Uses `TtyWriter.send(location, message)` to deliver message
 - Displays success/error feedback via `ui`
 
 ### 3. Export from agent-manager (update)
@@ -93,15 +103,25 @@ Implementation: Opens `/dev/${tty}` for writing via `fs.writeFile` and writes `m
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Delivery mechanism | TTY write | Cross-terminal-emulator, fast, no dependency on tmux/AppleScript |
+| Delivery mechanism | Terminal-native input injection | Writing to `/dev/ttysXXX` only outputs to terminal display, doesn't inject input. Must go through the terminal emulator. |
 | Agent identification | `--id` flag only | Explicit, avoids confusion with positional args |
-| Auto-submit | Append `\r` (CR) | Interactive CLIs run in raw mode where Enter = `\r` (0x0D), not `\n` (0x0A). Appending `\r` triggers submit. |
-| Embedded newlines | Send as-is (single write) | Write the entire message in one TTY write, then append `\r`. No line-by-line splitting. |
-| Module location | `TtyWriter` in agent-manager | Reusable by other features; keeps terminal logic together |
+| tmux send | `tmux send-keys` + `Enter` | Standard tmux API for injecting keystrokes into a pane |
+| iTerm2 send | AppleScript `write text` | Writes to session as typed input, auto-appends newline |
+| Terminal.app send | System Events `keystroke` + `key code 36` | `do script` runs a new shell command (wrong). `keystroke` types into the foreground process and `key code 36` sends Return. |
+| Shell safety | `execFile` for all subprocess calls | `execFile` bypasses the shell entirely, preventing command injection from message content (e.g., single quotes, backticks). |
+| AppleScript escaping | Escape `\` and `"` for double-quoted strings | Prevents AppleScript string breakout. Combined with `execFile`, no shell escaping needed. |
+| Embedded newlines | Send as-is | Each emulator handles the message as a single input. No splitting. |
+| Module location | `TtyWriter` in agent-manager | Reusable by other features; keeps terminal logic together with `TerminalFocusManager` |
 
 ## Non-Functional Requirements
 
-- **Performance**: TTY write is near-instant; no meaningful latency concern
-- **Security**: Only writes to TTY devices the current user has permission to access (OS-level enforcement)
-- **Reliability**: Validates TTY exists before writing; clear error on failure
-- **Portability**: Works on macOS and Linux (both use `/dev/ttyXXX` convention)
+- **Performance**: All mechanisms are near-instant (exec a single command)
+- **Security**: All subprocesses use `execFile` (no shell). AppleScript strings are escaped for `\` and `"`. No command injection vector.
+- **Reliability**: Terminal type is detected first; unsupported types fail with clear error. Each emulator method validates session was found.
+- **Portability**: Works on macOS (tmux, iTerm2, Terminal.app). Linux supported via tmux. Other Linux terminals are unsupported (returns `UNKNOWN`).
+
+## Known Limitations
+
+- **`UNKNOWN` terminal type**: If the agent runs in a terminal we can't identify (Warp, VS Code terminal, Alacritty without tmux), `send` fails. Users must use tmux in these cases.
+- **Terminal.app `keystroke`**: Requires Terminal.app to be brought to foreground (the script activates it). This briefly steals focus.
+- **iTerm2 `write text`**: Auto-appends a newline. Messages with embedded newlines will submit multiple lines.

--- a/docs/ai/implementation/feature-agent-send.md
+++ b/docs/ai/implementation/feature-agent-send.md
@@ -10,14 +10,17 @@ description: Implementation notes for the agent send feature
 
 | File | Purpose |
 |------|---------|
-| `packages/agent-manager/src/terminal/TtyWriter.ts` | Core TTY write module |
+| `packages/agent-manager/src/terminal/TtyWriter.ts` | Terminal-native input sender (tmux/iTerm2/Terminal.app) |
 | `packages/agent-manager/src/terminal/index.ts` | Export TtyWriter |
 | `packages/agent-manager/src/index.ts` | Package export |
 | `packages/cli/src/commands/agent.ts` | CLI `agent send` subcommand |
 
 ## Implementation Notes
 
-- `TtyWriter.send()` uses `fs.promises.writeFile` to write to `/dev/${tty}`
+- **Why not direct TTY write**: Writing to `/dev/ttysXXX` outputs to the terminal display, NOT to process input. Terminal emulators own the master side of the PTY — only they can inject keyboard input.
+- **tmux**: `tmux send-keys -t <identifier> "message" Enter` — standard tmux API
+- **iTerm2**: AppleScript `write text "message"` — auto-appends newline
+- **Terminal.app**: System Events `keystroke "message"` + `key code 36` (Return). NOT `do script` which runs a shell command. Requires briefly focusing the Terminal.app window.
+- **Security**: All subprocesses use `execFile` (no shell), preventing injection from message content (single quotes, backticks, etc.). AppleScript strings escaped for `\` and `"`.
 - Agent resolution reuses existing `AgentManager.resolveAgent()` method
-- TTY lookup reuses existing `getProcessTty()` from `utils/process.ts`
-- Error handling follows existing patterns in `agent open` command
+- Terminal detection reuses existing `TerminalFocusManager.findTerminal()` from the `agent open` command

--- a/docs/ai/planning/feature-agent-send.md
+++ b/docs/ai/planning/feature-agent-send.md
@@ -8,48 +8,54 @@ description: Task breakdown for implementing the agent send command
 
 ## Milestones
 
-- [ ] Milestone 1: TtyWriter core module in agent-manager
-- [ ] Milestone 2: CLI `agent send` subcommand
-- [ ] Milestone 3: Tests and validation
+- [x] Milestone 1: TtyWriter core module in agent-manager
+- [x] Milestone 2: CLI `agent send` subcommand
+- [x] Milestone 3: Tests and validation
 
 ## Task Breakdown
 
 ### Phase 1: Core Module
 
-- [ ] Task 1.1: Create `TtyWriter` class in `packages/agent-manager/src/terminal/TtyWriter.ts`
-  - Static `send(tty, message, appendNewline)` method
-  - Validate TTY exists (`/dev/${tty}`) and is writable
-  - Write message + optional newline to TTY device file
-  - Throw descriptive errors on failure
+- [x] Task 1.1: Create `TtyWriter` class in `packages/agent-manager/src/terminal/TtyWriter.ts`
+  - Static `send(location, message)` method accepting `TerminalLocation`
+  - Dispatches to tmux (`send-keys`), iTerm2 (`write text`), or Terminal.app (`keystroke` + `key code 36`)
+  - All subprocesses via `execFile` (no shell) to prevent command injection
+  - Throws descriptive errors for unsupported terminal types or send failures
 
-- [ ] Task 1.2: Export `TtyWriter` from agent-manager package
+- [x] Task 1.2: Export `TtyWriter` from agent-manager package
   - Add to `packages/agent-manager/src/terminal/index.ts`
   - Add to `packages/agent-manager/src/index.ts`
 
 ### Phase 2: CLI Command
 
-- [ ] Task 2.1: Add `agent send` subcommand in `packages/cli/src/commands/agent.ts`
+- [x] Task 2.1: Add `agent send` subcommand in `packages/cli/src/commands/agent.ts`
   - Register `send <message>` command with `--id <identifier>` required option
   - Instantiate `AgentManager`, register adapters, list agents
   - Resolve agent by `--id` using `resolveAgent()`
-  - Handle: not found, ambiguous match, no TTY
-  - Get TTY via `getProcessTty(pid)`
-  - Send message via `TtyWriter.send()`
+  - Handle: not found, ambiguous match, no terminal, unsupported terminal
+  - Find terminal via `TerminalFocusManager.findTerminal(pid)`
+  - Send message via `TtyWriter.send(location, message)`
   - Display success/error feedback
 
 ### Phase 3: Tests
 
-- [ ] Task 3.1: Unit tests for `TtyWriter`
-  - Test successful TTY write
-  - Test TTY not found error
-  - Test TTY not writable error
-  - Test newline append behavior
+- [x] Task 3.1: Unit tests for `TtyWriter`
+  - Test tmux send-keys with correct args
+  - Test tmux failure handling
+  - Test iTerm2 AppleScript via execFile (no shell)
+  - Test iTerm2 escaping of `\` and `"`
+  - Test iTerm2 session not found
+  - Test Terminal.app uses `keystroke` + `key code 36` (not `do script`)
+  - Test Terminal.app execFile for shell injection prevention
+  - Test Terminal.app tab not found
+  - Test unsupported terminal type throws error
 
-- [ ] Task 3.2: Unit tests for `agent send` CLI command
+- [x] Task 3.2: Unit tests for `agent send` CLI command
   - Test successful send flow
   - Test agent not found
   - Test ambiguous agent match
-  - Test missing required args
+  - Test non-waiting agent warning
+  - Test terminal not found for agent
 
 ## Dependencies
 
@@ -62,6 +68,7 @@ description: Task breakdown for implementing the agent send command
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| TTY write permission denied | Medium | High | Clear error message; document permission requirements |
-| TTY path differs across platforms | Low | Medium | Use `/dev/${tty}` convention; test on macOS and Linux |
-| Agent has no TTY (background process) | Low | Medium | Check for valid TTY before attempting write |
+| Unsupported terminal type | Medium | High | Clear error message listing supported terminals; recommend tmux as universal fallback |
+| Terminal.app keystroke steals focus | Medium | Low | Documented as known limitation; brief focus steal is acceptable |
+| Command injection via message content | Low | High | All subprocesses use `execFile` (no shell); AppleScript strings escaped for `\` and `"` |
+| Agent has no TTY (background process) | Low | Medium | Check for valid TTY before attempting terminal lookup |

--- a/docs/ai/requirements/feature-agent-send.md
+++ b/docs/ai/requirements/feature-agent-send.md
@@ -21,7 +21,7 @@ The existing `agent list` command shows waiting agents, and `agent open` can foc
 **Primary goals:**
 - Allow users to send text input to a running agent's terminal via CLI
 - Support identifying target agents via `--id` flag (name, slug, or partial match)
-- Auto-append `\r` (carriage return) so the message is submitted immediately in raw-mode terminals
+- Auto-submit the message via the terminal emulator's native input mechanism (tmux send-keys, AppleScript write text / keystroke)
 
 **Non-goals:**
 - Interactive/bidirectional communication with agents
@@ -43,28 +43,31 @@ The existing `agent list` command shows waiting agents, and `agent open` can foc
 4. **Edge cases:**
    - Agent is not in waiting state (warn but still allow send)
    - Agent ID matches multiple agents (error with disambiguation list)
-   - Agent's TTY is not writable (clear error message)
+   - Agent's terminal type is unsupported (clear error message)
    - Agent not found (clear error message)
 
 ## Success Criteria
 
-- `ai-devkit agent send "<message>" --id <identifier>` delivers the message + `\r` (carriage return) to the correct agent's TTY, triggering submit in raw-mode CLIs
+- `ai-devkit agent send "<message>" --id <identifier>` delivers the message as keyboard input to the agent's terminal and submits it
 - The command resolves agents by name, slug, or partial match via `--id`
-- Clear error messages for: agent not found, ambiguous match, TTY not writable
+- Clear error messages for: agent not found, ambiguous match, unsupported terminal type, terminal not found
 - Works in tmux, iTerm2, and Terminal.app environments
 - Message delivery is confirmed with success output
 
 ## Constraints & Assumptions
 
-- **Platform**: macOS primary (TTY write via `/dev/ttysXXX`), Linux secondary
-- **Permissions**: Requires write access to the target TTY device
-- **Delivery mechanism**: Direct TTY write (writing to `/dev/ttysXXX`)
-- **Assumes**: The agent process has a valid TTY (not a background/daemon process)
-- **Depends on**: Existing `AgentManager`, `AgentAdapter`, and process detection infrastructure
+- **Platform**: macOS primary (tmux, iTerm2, Terminal.app), Linux via tmux only
+- **Delivery mechanism**: Terminal-native input injection (not TTY device write, which only outputs to display)
+- **Supported terminals**: tmux, iTerm2, Terminal.app. Other terminals (Warp, VS Code, Alacritty without tmux) are unsupported.
+- **Security**: All subprocess calls use `execFile` (no shell) to prevent command injection
+- **Assumes**: The agent process has a valid TTY and runs in a supported terminal emulator
+- **Depends on**: Existing `AgentManager`, `AgentAdapter`, `TerminalFocusManager`, and process detection infrastructure
 
 ## Questions & Open Items
 
 - ~Agent identification approach~ -> Resolved: explicit `--id` flag only
-- ~Delivery mechanism~ -> Resolved: TTY write
-- ~Auto-Enter behavior~ -> Resolved: always auto-append `\r` (carriage return). Raw-mode terminals (like Claude Code) use CR as Enter, not LF.
-- ~Embedded newlines~ -> Resolved: send message as-is (single TTY write), append `\r` at end. No splitting or special interpretation.
+- ~Delivery mechanism~ -> Resolved: terminal-native input injection (tmux send-keys, AppleScript write text / keystroke). Direct TTY write was rejected — it only writes to terminal display, not input.
+- ~Auto-Enter behavior~ -> Resolved: each terminal mechanism handles Enter natively (tmux `Enter`, iTerm2 auto-newline, Terminal.app `key code 36`).
+- ~Embedded newlines~ -> Resolved: send message as-is. No splitting or special interpretation.
+- ~Command injection risk~ -> Resolved: all subprocess calls use `execFile` (no shell). AppleScript strings escaped for `\` and `"`.
+- ~Terminal.app `do script`~ -> Resolved: replaced with System Events `keystroke` + `key code 36`. `do script` runs a new shell command, not input to the foreground process.

--- a/docs/ai/testing/feature-agent-send.md
+++ b/docs/ai/testing/feature-agent-send.md
@@ -12,18 +12,28 @@ Unit tests for both the core `TtyWriter` module and the CLI command integration.
 
 ## Test Cases
 
-### TtyWriter Unit Tests
-- Writes message + newline to TTY device file
-- Writes message without newline when `appendNewline=false`
-- Throws error when TTY device does not exist
-- Throws error when TTY device is not writable
+### TtyWriter Unit Tests (`agent-manager`)
+- tmux: sends message via `tmux send-keys` with correct args
+- tmux: throws on tmux failure
+- iTerm2: sends via `osascript` with `execFile` (not `exec`/shell)
+- iTerm2: escapes `\` and `"` in message
+- iTerm2: throws when session not found
+- Terminal.app: sends via System Events `keystroke` + `key code 36` (NOT `do script`)
+- Terminal.app: uses `execFile` to prevent shell injection
+- Terminal.app: throws when tab not found
+- Unknown terminal: throws descriptive error
 
-### CLI `agent send` Tests
+### CLI `agent send` Tests (`cli`)
 - Sends message successfully to a resolved agent
-- Errors when `--id` flag is missing
 - Errors when no agent matches the given ID
 - Handles ambiguous agent match (multiple matches)
-- Errors when agent has no valid TTY
+- Warns when agent is not in waiting state but still sends
+- Errors when terminal cannot be found for agent
+
+## Coverage Results
+
+- **agent-manager**: 63 tests, all passing (9 TtyWriter-specific)
+- **cli**: 361 tests, all passing (5 agent send-specific)
 
 ## Coverage Target
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-devkit",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-devkit",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",

--- a/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { TtyWriter } from '../../terminal/TtyWriter';
+import { TerminalType } from '../../terminal/TerminalFocusManager';
+import type { TerminalLocation } from '../../terminal/TerminalFocusManager';
+import { execFile } from 'child_process';
+
+jest.mock('child_process', () => {
+    const actual = jest.requireActual<typeof import('child_process')>('child_process');
+    return {
+        ...actual,
+        execFile: jest.fn(),
+    };
+});
+
+const mockedExecFile = execFile as unknown as jest.Mock;
+
+function mockExecFileSuccess(stdout = '') {
+    mockedExecFile.mockImplementation((...args: unknown[]) => {
+        const cb = args[args.length - 1] as (err: Error | null, result: { stdout: string }, stderr: string) => void;
+        cb(null, { stdout }, '');
+    });
+}
+
+function mockExecFileError(message: string) {
+    mockedExecFile.mockImplementation((...args: unknown[]) => {
+        const cb = args[args.length - 1] as (err: Error | null, result: null, stderr: string) => void;
+        cb(new Error(message), null, '');
+    });
+}
+
+describe('TtyWriter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('tmux', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.TMUX,
+            identifier: 'main:0.1',
+            tty: '/dev/ttys030',
+        };
+
+        it('sends message via tmux send-keys', async () => {
+            mockExecFileSuccess();
+
+            await TtyWriter.send(location, 'continue');
+
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'tmux',
+                ['send-keys', '-t', 'main:0.1', 'continue', 'Enter'],
+                expect.any(Function),
+            );
+        });
+
+        it('throws on tmux failure', async () => {
+            mockExecFileError('tmux not running');
+
+            await expect(TtyWriter.send(location, 'hello'))
+                .rejects.toThrow('tmux not running');
+        });
+    });
+
+    describe('iTerm2', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.ITERM2,
+            identifier: '/dev/ttys030',
+            tty: '/dev/ttys030',
+        };
+
+        it('sends message via osascript with execFile (no shell)', async () => {
+            mockExecFileSuccess('ok');
+
+            await TtyWriter.send(location, 'hello');
+
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'osascript',
+                ['-e', expect.stringContaining('write text "hello"')],
+                expect.any(Function),
+            );
+        });
+
+        it('escapes special characters in message', async () => {
+            mockExecFileSuccess('ok');
+
+            await TtyWriter.send(location, 'say "hi" \\ there');
+
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'osascript',
+                ['-e', expect.stringContaining('write text "say \\"hi\\" \\\\ there"')],
+                expect.any(Function),
+            );
+        });
+
+        it('throws when session not found', async () => {
+            mockExecFileSuccess('not_found');
+
+            await expect(TtyWriter.send(location, 'test'))
+                .rejects.toThrow('iTerm2 session not found');
+        });
+    });
+
+    describe('Terminal.app', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.TERMINAL_APP,
+            identifier: '/dev/ttys030',
+            tty: '/dev/ttys030',
+        };
+
+        it('sends message via System Events keystroke (not do script)', async () => {
+            mockExecFileSuccess('ok');
+
+            await TtyWriter.send(location, 'hello');
+
+            const scriptArg = (mockedExecFile.mock.calls[0] as unknown[])[1] as string[];
+            const script = scriptArg[1];
+            // Must use keystroke, NOT do script
+            expect(script).toContain('keystroke "hello"');
+            expect(script).toContain('key code 36');
+            expect(script).not.toContain('do script');
+        });
+
+        it('uses execFile to avoid shell injection', async () => {
+            mockExecFileSuccess('ok');
+
+            await TtyWriter.send(location, "don't stop");
+
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'osascript',
+                ['-e', expect.any(String)],
+                expect.any(Function),
+            );
+        });
+
+        it('throws when tab not found', async () => {
+            mockExecFileSuccess('not_found');
+
+            await expect(TtyWriter.send(location, 'test'))
+                .rejects.toThrow('Terminal.app tab not found');
+        });
+    });
+
+    describe('unsupported terminal', () => {
+        it('throws for unknown terminal type', async () => {
+            const location: TerminalLocation = {
+                type: TerminalType.UNKNOWN,
+                identifier: '',
+                tty: '/dev/ttys030',
+            };
+
+            await expect(TtyWriter.send(location, 'test'))
+                .rejects.toThrow('Cannot send input: unsupported terminal type');
+        });
+    });
+});

--- a/packages/agent-manager/src/index.ts
+++ b/packages/agent-manager/src/index.ts
@@ -7,6 +7,7 @@ export type { AgentAdapter, AgentType, AgentInfo, ProcessInfo } from './adapters
 
 export { TerminalFocusManager, TerminalType } from './terminal/TerminalFocusManager';
 export type { TerminalLocation } from './terminal/TerminalFocusManager';
+export { TtyWriter } from './terminal/TtyWriter';
 
 export { listProcesses, getProcessCwd, getProcessTty, isProcessRunning, getProcessInfo } from './utils/process';
 export type { ListProcessesOptions } from './utils/process';

--- a/packages/agent-manager/src/terminal/TtyWriter.ts
+++ b/packages/agent-manager/src/terminal/TtyWriter.ts
@@ -1,0 +1,112 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { TerminalLocation } from './TerminalFocusManager';
+import { TerminalType } from './TerminalFocusManager';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Escape a string for safe use inside an AppleScript double-quoted string.
+ * Backslashes and double quotes must be escaped.
+ */
+function escapeAppleScript(text: string): string {
+    return text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export class TtyWriter {
+    /**
+     * Send a message as keyboard input to a terminal session.
+     *
+     * Dispatches to the correct mechanism based on terminal type:
+     * - tmux: `tmux send-keys`
+     * - iTerm2: AppleScript `write text`
+     * - Terminal.app: System Events `keystroke` + `key code 36` (Return)
+     *
+     * All AppleScript is executed via `execFile('osascript', ['-e', script])`
+     * to avoid shell interpolation and command injection.
+     *
+     * @param location Terminal location from TerminalFocusManager.findTerminal()
+     * @param message Text to send
+     * @throws Error if terminal type is unsupported or send fails
+     */
+    static async send(location: TerminalLocation, message: string): Promise<void> {
+        switch (location.type) {
+            case TerminalType.TMUX:
+                return TtyWriter.sendViaTmux(location.identifier, message);
+            case TerminalType.ITERM2:
+                return TtyWriter.sendViaITerm2(location.tty, message);
+            case TerminalType.TERMINAL_APP:
+                return TtyWriter.sendViaTerminalApp(location.tty, message);
+            default:
+                throw new Error(
+                    `Cannot send input: unsupported terminal type "${location.type}". ` +
+                    'Supported: tmux, iTerm2, Terminal.app.'
+                );
+        }
+    }
+
+    private static async sendViaTmux(identifier: string, message: string): Promise<void> {
+        await execFileAsync('tmux', ['send-keys', '-t', identifier, message, 'Enter']);
+    }
+
+    private static async sendViaITerm2(tty: string, message: string): Promise<void> {
+        const escaped = escapeAppleScript(message);
+        const script = `
+tell application "iTerm"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s is "${tty}" then
+          tell s to write text "${escaped}"
+          return "ok"
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell
+return "not_found"`;
+
+        const { stdout } = await execFileAsync('osascript', ['-e', script]);
+        if (stdout.trim() !== 'ok') {
+            throw new Error(`iTerm2 session not found for TTY ${tty}`);
+        }
+    }
+
+    private static async sendViaTerminalApp(tty: string, message: string): Promise<void> {
+        const escaped = escapeAppleScript(message);
+        // Use System Events keystroke to type into the foreground process,
+        // NOT Terminal.app's "do script" which runs a new shell command.
+        // First activate Terminal and select the correct tab, then type via System Events.
+        const script = `
+tell application "Terminal"
+  set targetFound to false
+  repeat with w in windows
+    repeat with i from 1 to count of tabs of w
+      set t to tab i of w
+      if tty of t is "${tty}" then
+        set selected tab of w to t
+        set index of w to 1
+        activate
+        set targetFound to true
+        exit repeat
+      end if
+    end repeat
+    if targetFound then exit repeat
+  end repeat
+  if not targetFound then return "not_found"
+end tell
+delay 0.1
+tell application "System Events"
+  tell process "Terminal"
+    keystroke "${escaped}"
+    key code 36
+  end tell
+end tell
+return "ok"`;
+
+        const { stdout } = await execFileAsync('osascript', ['-e', script]);
+        if (stdout.trim() !== 'ok') {
+            throw new Error(`Terminal.app tab not found for TTY ${tty}`);
+        }
+    }
+}

--- a/packages/agent-manager/src/terminal/index.ts
+++ b/packages/agent-manager/src/terminal/index.ts
@@ -1,3 +1,4 @@
 export { TerminalFocusManager } from './TerminalFocusManager';
 export { TerminalType } from './TerminalFocusManager';
 export type { TerminalLocation } from './TerminalFocusManager';
+export { TtyWriter } from './TtyWriter';

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { AgentManager, AgentStatus, TerminalFocusManager } from '@ai-devkit/agent-manager';
+import { AgentManager, AgentStatus, TerminalFocusManager, TtyWriter } from '@ai-devkit/agent-manager';
 import { registerAgentCommand } from '../../commands/agent';
 import { ui } from '../../util/terminal-ui';
 
@@ -23,11 +23,14 @@ const mockSpinner: any = {
 
 const mockPrompt: any = jest.fn();
 
+const mockTtyWriterSend = jest.fn<(location: any, message: string) => Promise<void>>().mockResolvedValue(undefined);
+
 jest.mock('@ai-devkit/agent-manager', () => ({
   AgentManager: jest.fn(() => mockManager),
   ClaudeCodeAdapter: jest.fn(),
   CodexAdapter: jest.fn(),
   TerminalFocusManager: jest.fn(() => mockFocusManager),
+  TtyWriter: { send: (location: any, message: string) => mockTtyWriterSend(location, message) },
   AgentStatus: {
     RUNNING: 'running',
     WAITING: 'waiting',
@@ -48,6 +51,7 @@ jest.mock('../../util/terminal-ui', () => ({
     text: jest.fn(),
     table: jest.fn(),
     info: jest.fn(),
+    success: jest.fn(),
     warning: jest.fn(),
     error: jest.fn(),
     breakline: jest.fn(),
@@ -57,10 +61,12 @@ jest.mock('../../util/terminal-ui', () => ({
 
 describe('agent command', () => {
   let logSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as any);
   });
 
   it('outputs JSON for list --json', async () => {
@@ -186,5 +192,103 @@ Waiting on user input`,
     expect(mockFocusManager.findTerminal).toHaveBeenCalledWith(10);
     expect(mockFocusManager.focusTerminal).toHaveBeenCalled();
     expect(mockSpinner.succeed).toHaveBeenCalledWith('Focused repo-a!');
+  });
+
+  it('sends message to a resolved agent', async () => {
+    const agent = {
+      name: 'repo-a',
+      status: AgentStatus.WAITING,
+      summary: 'Waiting',
+      lastActive: new Date(),
+      pid: 10,
+    };
+    const location = { type: 'tmux', identifier: '0:1.0', tty: '/dev/ttys030' };
+    mockManager.listAgents.mockResolvedValue([agent]);
+    mockManager.resolveAgent.mockReturnValue(agent);
+    mockFocusManager.findTerminal.mockResolvedValue(location);
+    mockTtyWriterSend.mockResolvedValue(undefined);
+
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'send', 'continue', '--id', 'repo-a']);
+
+    expect(mockManager.resolveAgent).toHaveBeenCalledWith('repo-a', [agent]);
+    expect(mockFocusManager.findTerminal).toHaveBeenCalledWith(10);
+    expect(mockTtyWriterSend).toHaveBeenCalledWith(location, 'continue');
+    expect(ui.success).toHaveBeenCalledWith('Sent message to repo-a.');
+  });
+
+  it('shows error when send target agent is not found', async () => {
+    mockManager.listAgents.mockResolvedValue([
+      { name: 'repo-a', status: AgentStatus.RUNNING, summary: 'A', lastActive: new Date(), pid: 1 },
+    ]);
+    mockManager.resolveAgent.mockReturnValue(null);
+
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'send', 'hello', '--id', 'missing']);
+
+    expect(ui.error).toHaveBeenCalledWith('No agent found matching "missing".');
+  });
+
+  it('shows error when send matches multiple agents', async () => {
+    const agents = [
+      { name: 'repo-a', status: AgentStatus.WAITING, summary: 'A', lastActive: new Date(), pid: 1 },
+      { name: 'repo-ab', status: AgentStatus.RUNNING, summary: 'B', lastActive: new Date(), pid: 2 },
+    ];
+    mockManager.listAgents.mockResolvedValue(agents);
+    mockManager.resolveAgent.mockReturnValue(agents);
+
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'send', 'hello', '--id', 'repo']);
+
+    expect(ui.error).toHaveBeenCalledWith('Multiple agents match "repo":');
+    expect(ui.info).toHaveBeenCalledWith('Please use a more specific identifier.');
+  });
+
+  it('warns when agent is not waiting but still sends', async () => {
+    const agent = {
+      name: 'repo-a',
+      status: AgentStatus.RUNNING,
+      summary: 'Running',
+      lastActive: new Date(),
+      pid: 10,
+    };
+    const location = { type: 'tmux', identifier: '0:1.0', tty: '/dev/ttys030' };
+    mockManager.listAgents.mockResolvedValue([agent]);
+    mockManager.resolveAgent.mockReturnValue(agent);
+    mockFocusManager.findTerminal.mockResolvedValue(location);
+    mockTtyWriterSend.mockResolvedValue(undefined);
+
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'send', 'continue', '--id', 'repo-a']);
+
+    expect(ui.warning).toHaveBeenCalledWith(
+      'Agent "repo-a" is not waiting for input (status: running). Sending anyway.'
+    );
+    expect(mockTtyWriterSend).toHaveBeenCalled();
+    expect(ui.success).toHaveBeenCalledWith('Sent message to repo-a.');
+  });
+
+  it('shows error when terminal cannot be found', async () => {
+    const agent = {
+      name: 'repo-a',
+      status: AgentStatus.WAITING,
+      summary: 'Waiting',
+      lastActive: new Date(),
+      pid: 10,
+    };
+    mockManager.listAgents.mockResolvedValue([agent]);
+    mockManager.resolveAgent.mockReturnValue(agent);
+    mockFocusManager.findTerminal.mockResolvedValue(null);
+
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'send', 'hello', '--id', 'repo-a']);
+
+    expect(ui.error).toHaveBeenCalledWith('Cannot find terminal for agent "repo-a" (PID: 10).');
+    expect(mockTtyWriterSend).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -7,6 +7,7 @@ import {
     CodexAdapter,
     AgentStatus,
     TerminalFocusManager,
+    TtyWriter,
     type AgentInfo,
 } from '@ai-devkit/agent-manager';
 import { ui } from '../util/terminal-ui';
@@ -187,6 +188,60 @@ export function registerAgentCommand(program: Command): void {
 
             } catch (error: any) {
                 ui.error(`Failed to open agent: ${error.message}`);
+                process.exit(1);
+            }
+        });
+
+    agentCommand
+        .command('send <message>')
+        .description('Send a message to a running agent')
+        .requiredOption('--id <identifier>', 'Agent name, slug, or partial match')
+        .action(async (message, options) => {
+            try {
+                const manager = new AgentManager();
+                manager.registerAdapter(new ClaudeCodeAdapter());
+                manager.registerAdapter(new CodexAdapter());
+
+                const agents = await manager.listAgents();
+                if (agents.length === 0) {
+                    ui.error('No running agents found.');
+                    return;
+                }
+
+                const resolved = manager.resolveAgent(options.id, agents);
+
+                if (!resolved) {
+                    ui.error(`No agent found matching "${options.id}".`);
+                    ui.info('Available agents:');
+                    agents.forEach(a => console.log(`  - ${a.name}`));
+                    return;
+                }
+
+                if (Array.isArray(resolved)) {
+                    ui.error(`Multiple agents match "${options.id}":`);
+                    resolved.forEach(a => console.log(`  - ${a.name} (${formatStatus(a.status)})`));
+                    ui.info('Please use a more specific identifier.');
+                    return;
+                }
+
+                const agent = resolved as AgentInfo;
+
+                if (agent.status !== AgentStatus.WAITING) {
+                    ui.warning(`Agent "${agent.name}" is not waiting for input (status: ${agent.status}). Sending anyway.`);
+                }
+
+                const focusManager = new TerminalFocusManager();
+                const location = await focusManager.findTerminal(agent.pid);
+                if (!location) {
+                    ui.error(`Cannot find terminal for agent "${agent.name}" (PID: ${agent.pid}).`);
+                    return;
+                }
+
+                await TtyWriter.send(location, message);
+                ui.success(`Sent message to ${agent.name}.`);
+
+            } catch (error: any) {
+                ui.error(`Failed to send message: ${error.message}`);
                 process.exit(1);
             }
         });


### PR DESCRIPTION
## Summary

- Add `agent send <message> --id <identifier>` CLI command to send text input to a running
AI agent's terminal without switching context
- Add `TtyWriter` module in `agent-manager` that injects keyboard input via terminal-native
 mechanisms: tmux `send-keys`, iTerm2 AppleScript `write text`, and Terminal.app System
Events `keystroke` + `key code 36`
- All subprocess calls use `execFile` (no shell) to prevent command injection; AppleScript
strings escaped for `\` and `"`

## Details

### Problem
When managing multiple AI agents across terminals, users must manually switch to each
terminal to provide input (e.g., "continue", "yes"). The existing `agent list` shows
waiting agents and `agent open` focuses a terminal, but there was no way to send input
programmatically.

### Solution
Terminal-native input injection through each emulator's API:

| Terminal | Method | Enter |
|----------|--------|-------|
| tmux | `tmux send-keys -t <pane> "msg" Enter` | tmux `Enter` literal |
| iTerm2 | AppleScript `write text "msg"` | Auto-appends newline |
| Terminal.app | System Events `keystroke "msg"` + `key code 36` | Return key code |

### Design decisions
- **Why not direct TTY write**: Writing to `/dev/ttysXXX` outputs to the terminal display,
not to process input. Only the terminal emulator (master side of PTY) can inject keyboard
input.
- **Why not `do script` for Terminal.app**: `do script` runs a new shell command, not input
 to the foreground process.
- **Security**: `execFile` bypasses the shell entirely, preventing injection from message
content containing quotes, backticks, etc.

