### PR TITLE
fix(security): validate FEATURE arg in check-status.sh to prevent path traversal

### DIFF
--- a/skills/dev-lifecycle/scripts/check-status.sh
+++ b/skills/dev-lifecycle/scripts/check-status.sh
@@ -10,6 +10,12 @@ if [[ $# -lt 1 ]]; then
 fi
 
 FEATURE="$1"
+
+if [[ ! "$FEATURE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "Error: feature name must contain only letters, digits, hyphens, and underscores"
+  exit 1
+fi
+
 DOCS="docs/ai"
 
 exists() { [[ -f "$1" ]]; }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/dev-lifecycle/scripts/check-status.sh`, the `FEATURE` argument (line 12) is interpolated directly into file paths like `feature-${FEATURE}.md` without any input validation. A maliciously crafted feature name such as `../../etc/passwd` or `../secrets/config` would cause the script to access unintended files outside the `docs/ai/` directory.

While the script only performs read operations (`[[ -f ... ]]` and `grep`), path traversal can still leak information about the existence and content of files outside the intended scope.

## Fix

Added a one-line guard immediately after reading `FEATURE="$1"` that rejects any feature name not matching `^[a-zA-Z0-9_-]+$`:

```bash
if [[ ! "$FEATURE" =~ ^[a-zA-Z0-9_-]+$ ]]; then
  echo "Error: feature name must contain only letters, digits, hyphens, and underscores"
  exit 1
fi
```

This allows all valid feature names (letters, digits, hyphens, underscores) while blocking path traversal sequences. The error message tells users what format is expected.

## Impact

Low severity. No code execution risk — purely a file-read path traversal guard. The fix is minimal and backwards-compatible with all valid feature name formats.