### PR TITLE
fix(security): pin root devDependencies to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@nx/js": "^22.4.0",
-    "husky": "^9.1.7",
-    "nx": "^22.4.0"
+    "@nx/js": "22.6.5",
+    "husky": "9.1.7",
+    "nx": "22.6.5"
   },
   "engines": {
     "node": ">=20.20.0"


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The root `package.json` declares devDependencies with `^` (caret) ranges:

```json
"@nx/js": "^22.4.0",
"husky": "^9.1.7",
"nx": "^22.4.0"
```

The `^` operator allows npm to silently install any compatible minor or patch version. If any of these packages (or their dependencies) is compromised at a minor/patch release, `npm install` on a fresh checkout without a lock file would pull in the malicious version.

## Fix

Pins each devDependency to the exact version currently resolved in `package-lock.json`:

| Package | Before | After |
|---------|--------|-------|
| `@nx/js` | `^22.4.0` | `22.6.5` |
| `husky` | `^9.1.7` | `9.1.7` |
| `nx` | `^22.4.0` | `22.6.5` |

These are the versions already locked in `package-lock.json`, so no behavior changes for developers using `npm ci`. This only affects fresh `npm install` runs in environments without the lock file.

## Impact

Low severity. Supply chain hardening — eliminates a window where a compromised minor/patch release could be silently installed in CI or contributor environments that don't use `npm ci`.