### PR TITLE
fix(channel): strip system tags and render Markdown for Telegram messages

### DIFF
--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -59,7 +59,8 @@ export class TelegramAdapter implements ChannelAdapter {
     async sendMessage(chatId: string, text: string): Promise<void> {
         const chunks = chunkMessage(text, TELEGRAM_MAX_MESSAGE_LENGTH);
         for (const chunk of chunks) {
-            await this.bot.telegram.sendMessage(chatId, chunk);
+            const html = markdownToHtml(chunk);
+            await this.bot.telegram.sendMessage(chatId, html, { parse_mode: 'HTML' });
         }
     }
 
@@ -107,4 +108,45 @@ function chunkMessage(text: string, maxLen: number): string[] {
     }
 
     return chunks;
+}
+
+function escapeHtml(text: string): string {
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Convert standard Markdown to Telegram HTML.
+ * Handles code blocks first to prevent formatting inside them.
+ */
+function markdownToHtml(text: string): string {
+    const codeBlocks: string[] = [];
+    const inlineCodes: string[] = [];
+
+    let result = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+        const escaped = escapeHtml(code.trimEnd());
+        const block = lang
+            ? `<pre><code class="language-${lang}">${escaped}</code></pre>`
+            : `<pre><code>${escaped}</code></pre>`;
+        codeBlocks.push(block);
+        return `\x00CODE${codeBlocks.length - 1}\x00`;
+    });
+
+    result = result.replace(/`([^`]+)`/g, (_, code) => {
+        inlineCodes.push(`<code>${escapeHtml(code)}</code>`);
+        return `\x00INLINE${inlineCodes.length - 1}\x00`;
+    });
+
+    result = escapeHtml(result);
+
+    result = result
+        .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
+        .replace(/__(.+?)__/g, '<b>$1</b>')
+        .replace(/\*(.+?)\*/g, '<i>$1</i>')
+        .replace(/_(.+?)_/g, '<i>$1</i>')
+        .replace(/~~(.+?)~~/g, '<s>$1</s>');
+
+    result = result.replace(/\x00CODE(\d+)\x00/g, (_, i) => codeBlocks[parseInt(i)]);
+    result = result.replace(/\x00INLINE(\d+)\x00/g, (_, i) => inlineCodes[parseInt(i)]);
+
+    return result;
 }

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -105,6 +105,23 @@ function setupInputHandler(
     });
 }
 
+const SYSTEM_TAGS = [
+    'command-name',
+    'command-message',
+    'command-args',
+    'local-command-stdout',
+    'system-reminder',
+    'user-prompt-submit-hook',
+];
+
+function stripSystemTags(content: string): string {
+    let result = content;
+    for (const tag of SYSTEM_TAGS) {
+        result = result.replace(new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, 'g'), '');
+    }
+    return result.trim();
+}
+
 function startOutputPolling(
     telegram: TelegramAdapter,
     agentAdapter: AgentAdapter,
@@ -137,8 +154,10 @@ function startOutputPolling(
 
             for (const msg of newMessages) {
                 if (msg.role !== 'user' && msg.content) {
-                    await telegram.sendMessage(chatIdRef.value, msg.content);
-                    debug(`Sent agent response to Telegram (role: ${msg.role}, length: ${msg.content.length})`);
+                    const cleaned = stripSystemTags(msg.content);
+                    if (!cleaned) continue;
+                    await telegram.sendMessage(chatIdRef.value, cleaned);
+                    debug(`Sent agent response to Telegram (role: ${msg.role}, length: ${cleaned.length})`);
                 }
             }
         } catch {


### PR DESCRIPTION
 ## Problem

  When using `ai-devkit channel start`, two issues affect Telegram message quality:

  1. **System tags leak**: Claude Code injects structured XML tags (`<command-name>`, `<command-message>`, `<local-command-stdout>`,
  `<system-reminder>`, etc.) into the conversation for the UI layer. Without filtering, these tags appear verbatim in Telegram
  messages, making responses unreadable.

  2. **Markdown not rendered**: Claude Code responses use standard Markdown formatting (`**bold**`, `_italic_`, `` `code` ``, code
  blocks) which Telegram displays as raw text by default.

  ## Solution

  - Add `stripSystemTags()` in `channel.ts` to remove known system tags from agent output before forwarding to Telegram. Regular
  message content is preserved.
  - Add `markdownToHtml()` in `TelegramAdapter.ts` to convert standard Markdown to Telegram HTML, sending messages with `parse_mode:
  'HTML'`. Code blocks are extracted first to prevent formatting replacements inside them.

  ## System tags stripped
  - `command-name`
  - `command-message`
  - `command-args`
  - `local-command-stdout`
  - `system-reminder`
  - `user-prompt-submit-hook`