### PR TITLE
feat(channel): forward Claude Code permission prompts to Telegram as interactive buttons

### DIFF
--- a/packages/agent-manager/src/terminal/TtyWriter.ts
+++ b/packages/agent-manager/src/terminal/TtyWriter.ts
@@ -32,6 +32,70 @@ export class TtyWriter {
      * @param message Text to send
      * @throws Error if terminal type is unsupported or send fails
      */
+    static async captureOutput(location: TerminalLocation, lines = 30): Promise<string> {
+        switch (location.type) {
+            case TerminalType.TMUX:
+                return TtyWriter.captureViaTmux(location.identifier, lines);
+            case TerminalType.ITERM2:
+                return TtyWriter.captureViaITerm2(location.tty, lines);
+            case TerminalType.TERMINAL_APP:
+                return TtyWriter.captureViaTerminalApp(location.tty, lines);
+            default:
+                return '';
+        }
+    }
+
+    private static async captureViaTmux(identifier: string, lines: number): Promise<string> {
+        try {
+            const { stdout } = await execFileAsync('tmux', ['capture-pane', '-t', identifier, '-p', '-J']);
+            return stdout.split('\n').slice(-lines).join('\n');
+        } catch {
+            return '';
+        }
+    }
+
+    private static async captureViaITerm2(tty: string, lines: number): Promise<string> {
+        const script = `
+tell application "iTerm"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s is "${tty}" then
+          return contents of s
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell
+return ""`;
+        try {
+            const { stdout } = await execFileAsync('osascript', ['-e', script]);
+            return stdout.split('\n').slice(-lines).join('\n');
+        } catch {
+            return '';
+        }
+    }
+
+    private static async captureViaTerminalApp(tty: string, lines: number): Promise<string> {
+        const script = `
+tell application "Terminal"
+  repeat with w in windows
+    repeat with t in tabs of w
+      if tty of t is "${tty}" then
+        return contents of t
+      end if
+    end repeat
+  end repeat
+end tell
+return ""`;
+        try {
+            const { stdout } = await execFileAsync('osascript', ['-e', script]);
+            return stdout.split('\n').slice(-lines).join('\n');
+        } catch {
+            return '';
+        }
+    }
+
     static async send(location: TerminalLocation, message: string): Promise<void> {
         switch (location.type) {
             case TerminalType.TMUX:

--- a/packages/channel-connector/src/adapters/ChannelAdapter.ts
+++ b/packages/channel-connector/src/adapters/ChannelAdapter.ts
@@ -26,7 +26,9 @@ export interface ChannelAdapter {
     /**
      * Send a message with an inline keyboard to a specific chat.
      */
-    sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<void>;
+    sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<number>;
+
+    removeKeyboard(chatId: string, messageId: number): Promise<void>;
 
     /**
      * Register a handler for inline keyboard button presses.

--- a/packages/channel-connector/src/adapters/ChannelAdapter.ts
+++ b/packages/channel-connector/src/adapters/ChannelAdapter.ts
@@ -28,7 +28,7 @@ export interface ChannelAdapter {
      */
     sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<number>;
 
-    removeKeyboard(chatId: string, messageId: number): Promise<void>;
+    resolveKeyboard(chatId: string, messageId: number, label: string): Promise<void>;
 
     /**
      * Register a handler for inline keyboard button presses.

--- a/packages/channel-connector/src/adapters/ChannelAdapter.ts
+++ b/packages/channel-connector/src/adapters/ChannelAdapter.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from '../types';
+import type { IncomingMessage, KeyboardButton, CallbackQuery } from '../types';
 
 /**
  * Interface for messaging platform adapters.
@@ -22,6 +22,16 @@ export interface ChannelAdapter {
      * (e.g., chunking at 4096 chars for Telegram).
      */
     sendMessage(chatId: string, text: string): Promise<void>;
+
+    /**
+     * Send a message with an inline keyboard to a specific chat.
+     */
+    sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<void>;
+
+    /**
+     * Register a handler for inline keyboard button presses.
+     */
+    onCallbackQuery(handler: (query: CallbackQuery) => Promise<void>): void;
 
     /**
      * Register a handler for incoming text messages.

--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -86,9 +86,12 @@ export class TelegramAdapter implements ChannelAdapter {
         return result.message_id;
     }
 
-    async removeKeyboard(chatId: string, messageId: number): Promise<void> {
+    async resolveKeyboard(chatId: string, messageId: number, label: string): Promise<void> {
         try {
-            await this.bot.telegram.editMessageReplyMarkup(chatId, messageId, undefined, { inline_keyboard: [] });
+            await this.bot.telegram.editMessageText(chatId, messageId, undefined, label, {
+                parse_mode: 'HTML',
+                reply_markup: { inline_keyboard: [] },
+            });
         } catch {
             // Message may already be gone
         }

--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -1,6 +1,6 @@
 import { Telegraf } from 'telegraf';
 import type { ChannelAdapter } from './ChannelAdapter';
-import type { IncomingMessage } from '../types';
+import type { IncomingMessage, KeyboardButton, CallbackQuery } from '../types';
 
 export const TELEGRAM_CHANNEL_TYPE = 'telegram';
 export const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
@@ -17,6 +17,7 @@ export class TelegramAdapter implements ChannelAdapter {
 
     private bot: Telegraf;
     private messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null;
+    private callbackHandler: ((query: CallbackQuery) => Promise<void>) | null = null;
     private running = false;
 
     constructor(options: TelegramAdapterOptions) {
@@ -43,6 +44,16 @@ export class TelegramAdapter implements ChannelAdapter {
             }
         });
 
+        this.bot.on('callback_query', async (ctx) => {
+            if (!this.callbackHandler || !('data' in ctx.callbackQuery)) return;
+            await ctx.answerCbQuery();
+            await this.callbackHandler({
+                id: String(ctx.callbackQuery.id),
+                chatId: String(ctx.callbackQuery.message?.chat.id ?? ''),
+                data: ctx.callbackQuery.data ?? '',
+            });
+        });
+
         await this.bot.launch();
         this.running = true;
     }
@@ -62,6 +73,20 @@ export class TelegramAdapter implements ChannelAdapter {
             const html = markdownToHtml(chunk);
             await this.bot.telegram.sendMessage(chatId, html, { parse_mode: 'HTML' });
         }
+    }
+
+    async sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<void> {
+        const inlineKeyboard = buttons.map(row =>
+            row.map(btn => ({ text: btn.text, callback_data: btn.callbackData }))
+        );
+        await this.bot.telegram.sendMessage(chatId, text, {
+            parse_mode: 'HTML',
+            reply_markup: { inline_keyboard: inlineKeyboard },
+        });
+    }
+
+    onCallbackQuery(handler: (query: CallbackQuery) => Promise<void>): void {
+        this.callbackHandler = handler;
     }
 
     onMessage(handler: (msg: IncomingMessage) => Promise<void>): void {

--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -75,14 +75,23 @@ export class TelegramAdapter implements ChannelAdapter {
         }
     }
 
-    async sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<void> {
+    async sendKeyboard(chatId: string, text: string, buttons: KeyboardButton[][]): Promise<number> {
         const inlineKeyboard = buttons.map(row =>
             row.map(btn => ({ text: btn.text, callback_data: btn.callbackData }))
         );
-        await this.bot.telegram.sendMessage(chatId, text, {
+        const result = await this.bot.telegram.sendMessage(chatId, text, {
             parse_mode: 'HTML',
             reply_markup: { inline_keyboard: inlineKeyboard },
         });
+        return result.message_id;
+    }
+
+    async removeKeyboard(chatId: string, messageId: number): Promise<void> {
+        try {
+            await this.bot.telegram.editMessageReplyMarkup(chatId, messageId, undefined, { inline_keyboard: [] });
+        } catch {
+            // Message may already be gone
+        }
     }
 
     onCallbackQuery(handler: (query: CallbackQuery) => Promise<void>): void {

--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -59,7 +59,8 @@ export class TelegramAdapter implements ChannelAdapter {
     async sendMessage(chatId: string, text: string): Promise<void> {
         const chunks = chunkMessage(text, TELEGRAM_MAX_MESSAGE_LENGTH);
         for (const chunk of chunks) {
-            await this.bot.telegram.sendMessage(chatId, chunk);
+            const html = markdownToHtml(chunk);
+            await this.bot.telegram.sendMessage(chatId, html, { parse_mode: 'HTML' });
         }
     }
 
@@ -107,4 +108,45 @@ function chunkMessage(text: string, maxLen: number): string[] {
     }
 
     return chunks;
+}
+
+function escapeHtml(text: string): string {
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Convert standard Markdown to Telegram HTML.
+ * Handles code blocks first to prevent formatting inside them.
+ */
+function markdownToHtml(text: string): string {
+    const codeBlocks: string[] = [];
+    const inlineCodes: string[] = [];
+
+    let result = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+        const escaped = escapeHtml(code.trimEnd());
+        const block = lang
+            ? `<pre><code class="language-${lang}">${escaped}</code></pre>`
+            : `<pre><code>${escaped}</code></pre>`;
+        codeBlocks.push(block);
+        return `\x00CODE${codeBlocks.length - 1}\x00`;
+    });
+
+    result = result.replace(/`([^`]+)`/g, (_, code) => {
+        inlineCodes.push(`<code>${escapeHtml(code)}</code>`);
+        return `\x00INLINE${inlineCodes.length - 1}\x00`;
+    });
+
+    result = escapeHtml(result);
+
+    result = result
+        .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
+        .replace(/__(.+?)__/g, '<b>$1</b>')
+        .replace(/\*(.+?)\*/g, '<i>$1</i>')
+        .replace(/_(.+?)_/g, '<i>$1</i>')
+        .replace(/~~(.+?)~~/g, '<s>$1</s>');
+
+    result = result.replace(/\x00CODE(\d+)\x00/g, (_, i) => codeBlocks[parseInt(i)]);
+    result = result.replace(/\x00INLINE(\d+)\x00/g, (_, i) => inlineCodes[parseInt(i)]);
+
+    return result;
 }

--- a/packages/channel-connector/src/types.ts
+++ b/packages/channel-connector/src/types.ts
@@ -1,3 +1,14 @@
+export interface KeyboardButton {
+    text: string;
+    callbackData: string;
+}
+
+export interface CallbackQuery {
+    id: string;
+    chatId: string;
+    data: string;
+}
+
 /**
  * An incoming message from a messaging platform.
  * Generic — no agent-specific concepts.

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -105,6 +105,23 @@ function setupInputHandler(
     });
 }
 
+const SYSTEM_TAGS = [
+    'command-name',
+    'command-message',
+    'command-args',
+    'local-command-stdout',
+    'system-reminder',
+    'user-prompt-submit-hook',
+];
+
+function stripSystemTags(content: string): string {
+    let result = content;
+    for (const tag of SYSTEM_TAGS) {
+        result = result.replace(new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, 'g'), '');
+    }
+    return result.trim();
+}
+
 function startOutputPolling(
     telegram: TelegramAdapter,
     agentAdapter: AgentAdapter,
@@ -137,8 +154,10 @@ function startOutputPolling(
 
             for (const msg of newMessages) {
                 if (msg.role !== 'user' && msg.content) {
-                    await telegram.sendMessage(chatIdRef.value, msg.content);
-                    debug(`Sent agent response to Telegram (role: ${msg.role}, length: ${msg.content.length})`);
+                    const cleaned = stripSystemTags(msg.content);
+                    if (!cleaned) continue;
+                    await telegram.sendMessage(chatIdRef.value, cleaned);
+                    debug(`Sent agent response to Telegram (role: ${msg.role}, length: ${cleaned.length})`);
                 }
             }
         } catch {

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -122,6 +122,68 @@ function stripSystemTags(content: string): string {
     return result.trim();
 }
 
+const PERMISSION_PATTERNS = [
+    /Allow\s+.+\?/i,
+    /Do you want to (allow|proceed|continue)/i,
+    /›\s*(Yes|No)/,
+    /❯\s*(Yes|No)/,
+    /\(y\/n\)/i,
+];
+
+function detectPermissionPrompt(output: string): string | null {
+    const lines = output.split('\n').filter(l => l.trim());
+    for (let i = 0; i < lines.length; i++) {
+        if (PERMISSION_PATTERNS.some(p => p.test(lines[i]))) {
+            const start = Math.max(0, i - 4);
+            const end = Math.min(lines.length, i + 2);
+            return lines
+                .slice(start, end)
+                .map(l => l.replace(/[^\x20-\x7E]/g, '').trim())
+                .filter(Boolean)
+                .join('\n');
+        }
+    }
+    return null;
+}
+
+function startPermissionPolling(
+    telegram: TelegramAdapter,
+    terminalLocation: TerminalLocation,
+    chatIdRef: { value: string | null },
+): NodeJS.Timeout {
+    let lastPromptText: string | null = null;
+
+    return setInterval(async () => {
+        if (!chatIdRef.value) return;
+        try {
+            const output = await TtyWriter.captureOutput(terminalLocation);
+            const prompt = detectPermissionPrompt(output);
+
+            if (prompt && prompt !== lastPromptText) {
+                lastPromptText = prompt;
+                const escaped = prompt
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;');
+                await telegram.sendKeyboard(
+                    chatIdRef.value,
+                    `⚠️ <b>Claude Code cần xác nhận:</b>\n\n<pre>${escaped}</pre>`,
+                    [[
+                        { text: '✅ Yes', callbackData: 'permission:yes' },
+                        { text: '❌ No', callbackData: 'permission:no' },
+                    ]],
+                );
+                debug('Permission prompt detected, sent keyboard to Telegram');
+            } else if (!prompt && lastPromptText) {
+                lastPromptText = null;
+                debug('Permission prompt resolved');
+            }
+        } catch {
+            // Terminal may not be accessible
+        }
+    }, AGENT_POLL_INTERVAL_MS);
+}
+
 function startOutputPolling(
     telegram: TelegramAdapter,
     agentAdapter: AgentAdapter,
@@ -166,11 +228,16 @@ function startOutputPolling(
     }, AGENT_POLL_INTERVAL_MS);
 }
 
-function setupGracefulShutdown(manager: ChannelManager, pollInterval: NodeJS.Timeout): void {
+function setupGracefulShutdown(
+    manager: ChannelManager,
+    pollInterval: NodeJS.Timeout,
+    permissionPollInterval: NodeJS.Timeout,
+): void {
     const shutdown = async () => {
         debug('Shutdown signal received');
         ui.info('\nShutting down...');
         clearInterval(pollInterval);
+        clearInterval(permissionPollInterval);
         debug('Output polling stopped');
         await manager.stopAll();
         debug('ChannelManager stopped');
@@ -390,11 +457,19 @@ export function registerChannelCommand(program: Command): void {
                 setupInputHandler(telegram, terminalLocation, chatIdRef);
                 debug(`Starting output polling (interval: ${AGENT_POLL_INTERVAL_MS}ms)`);
                 const pollInterval = startOutputPolling(telegram, agentAdapter, agent, chatIdRef);
+                const permissionPollInterval = startPermissionPolling(telegram, terminalLocation, chatIdRef);
+
+                telegram.onCallbackQuery(async (query) => {
+                    if (!query.data.startsWith('permission:')) return;
+                    const answer = query.data === 'permission:yes' ? 'y' : 'n';
+                    debug(`Permission callback: ${query.data} → sending "${answer}" to terminal`);
+                    await TtyWriter.send(terminalLocation, answer);
+                });
 
                 // Start the bot
                 const manager = new ChannelManager();
                 manager.registerAdapter(telegram);
-                setupGracefulShutdown(manager, pollInterval);
+                setupGracefulShutdown(manager, pollInterval, permissionPollInterval);
 
                 ui.success(`Bridge started: Telegram @${telegramConfig.botUsername} <-> Agent "${agent.name}" (PID: ${agent.pid})`);
                 ui.info('Send a message to your Telegram bot to start chatting.');

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -180,7 +180,7 @@ function startPermissionPolling(
             } else if (!prompt && lastPromptText) {
                 lastPromptText = null;
                 if (keyboardRef.messageId) {
-                    await telegram.removeKeyboard(keyboardRef.chatId!, keyboardRef.messageId);
+                    await telegram.resolveKeyboard(keyboardRef.chatId!, keyboardRef.messageId, '✅ Đã xử lý tại terminal');
                     keyboardRef.messageId = null;
                 }
                 debug('Permission prompt resolved');
@@ -469,11 +469,12 @@ export function registerChannelCommand(program: Command): void {
 
                 telegram.onCallbackQuery(async (query) => {
                     if (!query.data.startsWith('permission:')) return;
+                        const answer = query.data === 'permission:yes' ? 'y' : 'n';
                     if (keyboardRef.messageId) {
-                        await telegram.removeKeyboard(keyboardRef.chatId!, keyboardRef.messageId);
+                        const label = answer === 'y' ? '✅ Đã xác nhận: Yes' : '❌ Đã xác nhận: No';
+                        await telegram.resolveKeyboard(keyboardRef.chatId!, keyboardRef.messageId, label);
                         keyboardRef.messageId = null;
                     }
-                    const answer = query.data === 'permission:yes' ? 'y' : 'n';
                     debug(`Permission callback: ${query.data} → sending "${answer}" to terminal`);
                     await TtyWriter.send(terminalLocation, answer);
                 });

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -150,6 +150,7 @@ function startPermissionPolling(
     telegram: TelegramAdapter,
     terminalLocation: TerminalLocation,
     chatIdRef: { value: string | null },
+    keyboardRef: { chatId: string | null; messageId: number | null },
 ): NodeJS.Timeout {
     let lastPromptText: string | null = null;
 
@@ -165,7 +166,7 @@ function startPermissionPolling(
                     .replace(/&/g, '&amp;')
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;');
-                await telegram.sendKeyboard(
+                const messageId = await telegram.sendKeyboard(
                     chatIdRef.value,
                     `⚠️ <b>Claude Code cần xác nhận:</b>\n\n<pre>${escaped}</pre>`,
                     [[
@@ -173,9 +174,15 @@ function startPermissionPolling(
                         { text: '❌ No', callbackData: 'permission:no' },
                     ]],
                 );
+                keyboardRef.chatId = chatIdRef.value;
+                keyboardRef.messageId = messageId;
                 debug('Permission prompt detected, sent keyboard to Telegram');
             } else if (!prompt && lastPromptText) {
                 lastPromptText = null;
+                if (keyboardRef.messageId) {
+                    await telegram.removeKeyboard(keyboardRef.chatId!, keyboardRef.messageId);
+                    keyboardRef.messageId = null;
+                }
                 debug('Permission prompt resolved');
             }
         } catch {
@@ -457,10 +464,15 @@ export function registerChannelCommand(program: Command): void {
                 setupInputHandler(telegram, terminalLocation, chatIdRef);
                 debug(`Starting output polling (interval: ${AGENT_POLL_INTERVAL_MS}ms)`);
                 const pollInterval = startOutputPolling(telegram, agentAdapter, agent, chatIdRef);
-                const permissionPollInterval = startPermissionPolling(telegram, terminalLocation, chatIdRef);
+                const keyboardRef = { chatId: null as string | null, messageId: null as number | null };
+                const permissionPollInterval = startPermissionPolling(telegram, terminalLocation, chatIdRef, keyboardRef);
 
                 telegram.onCallbackQuery(async (query) => {
                     if (!query.data.startsWith('permission:')) return;
+                    if (keyboardRef.messageId) {
+                        await telegram.removeKeyboard(keyboardRef.chatId!, keyboardRef.messageId);
+                        keyboardRef.messageId = null;
+                    }
                     const answer = query.data === 'permission:yes' ? 'y' : 'n';
                     debug(`Permission callback: ${query.data} → sending "${answer}" to terminal`);
                     await TtyWriter.send(terminalLocation, answer);


### PR DESCRIPTION
## Problem

When Claude Code requires user approval (bash commands, file operations, etc.),
the agent blocks and waits for terminal input. Users controlling agents remotely
via the Telegram bridge had no way to approve or reject these prompts without
being at their terminal.

## Solution

The bridge now detects permission prompts from the terminal output and forwards
them to Telegram as inline keyboard messages with Yes/No buttons. Tapping a
button sends the corresponding keystroke back to the agent terminal. After
responding, the keyboard message updates to show the confirmation result.

## Changes

- **TtyWriter**: add `captureOutput()` to read terminal content via tmux, iTerm2, and Terminal.app
- **TelegramAdapter**: add `sendKeyboard()`, `resolveKeyboard()`, and `onCallbackQuery()` for inline keyboard support  
- **ChannelAdapter**: extend interface with new keyboard methods
- **channel**: add `startPermissionPolling()` with prompt detection, keyboard tracking, and callback handler

## Demo

1. Bridge detects permission prompt → sends Telegram message with ✅ Yes / ❌ No buttons
2. User taps a button → keystroke forwarded to terminal → message updates to "✅ Đã xác nhận: Yes"
3. If user answers at terminal directly → message updates to "✅ Đã xử lý tại terminal"

## Notes

- Builds on top of `fix/strip-system-tags-from-telegram-messages`
- Prompt detection uses terminal capture (tmux/iTerm2/Terminal.app) — same terminals supported by `agent open`