### PR TITLE
Fix Telegram delivery reliability

### DIFF
--- a/packages/channel-connector/src/__tests__/adapters/TelegramAdapter.test.ts
+++ b/packages/channel-connector/src/__tests__/adapters/TelegramAdapter.test.ts
@@ -1,4 +1,5 @@
 import * as telegrafModule from 'telegraf';
+import * as telegramHtml from '../../utils/telegramHtml.js';
 import { TelegramAdapter } from '../../adapters/TelegramAdapter.js';
 import type { IncomingMessage } from '../../types.js';
 
@@ -253,6 +254,32 @@ describe('TelegramAdapter', () => {
             expect(plainChunk).toContain('a < b && c > d');
             expect(plainChunk).not.toContain('&lt;');
             expect(plainChunk).not.toContain('&amp;');
+        });
+
+        it('should deliver nested lists without throwing', async () => {
+            const bot = getMockBot();
+
+            await adapter.sendMessage('12345', '- agent\n  - Status');
+
+            expect(bot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+            expect(bot.telegram.sendMessage.mock.calls[0][1]).toContain('Status');
+        });
+
+        it('should send plain text when markdown formatting throws', async () => {
+            const bot = getMockBot();
+            const formatter = vi.spyOn(telegramHtml, 'markdownToTelegramHtml')
+                .mockImplementationOnce(() => {
+                    throw new Error('formatter failed');
+                });
+
+            await adapter.sendMessage('12345', '- agent\n  - Status');
+
+            expect(bot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+            expect(bot.telegram.sendMessage.mock.calls[0][0]).toBe('12345');
+            expect(bot.telegram.sendMessage.mock.calls[0][1]).toBe('- agent\n  - Status');
+            expect(bot.telegram.sendMessage.mock.calls[0][2]).toBeUndefined();
+
+            formatter.mockRestore();
         });
 
         it('should propagate non-parse-entities errors without falling back', async () => {

--- a/packages/channel-connector/src/__tests__/utils/telegramHtml.test.ts
+++ b/packages/channel-connector/src/__tests__/utils/telegramHtml.test.ts
@@ -40,6 +40,14 @@ describe('markdownToTelegramHtml', () => {
         expect(out).not.toContain('<ul>');
     });
 
+    it('renders nested lists without throwing', () => {
+        const out = markdownToTelegramHtml('- agent\n  - Status');
+
+        expect(out).toContain('• agent');
+        expect(out).toContain('• Status');
+        expect(out).not.toContain('<ul>');
+    });
+
     it('renders ordered lists with numbers', () => {
         const out = markdownToTelegramHtml('1. one\n2. two');
         expect(out).toContain('1. one');

--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -61,9 +61,17 @@ export class TelegramAdapter implements ChannelAdapter {
      * mid-tag and produce a partial render in the second chunk.
      */
     async sendMessage(chatId: string, text: string): Promise<void> {
-        const html = markdownToTelegramHtml(text);
-        const chunks = chunkMessage(html, TELEGRAM_MAX_MESSAGE_LENGTH);
-        for (const chunk of chunks) {
+        let html: string;
+        try {
+            html = markdownToTelegramHtml(text);
+        } catch {
+            for (const chunk of chunkMessage(text, TELEGRAM_MAX_MESSAGE_LENGTH)) {
+                await this.bot.telegram.sendMessage(chatId, chunk);
+            }
+            return;
+        }
+
+        for (const chunk of chunkMessage(html, TELEGRAM_MAX_MESSAGE_LENGTH)) {
             try {
                 await this.bot.telegram.sendMessage(chatId, chunk, { parse_mode: TELEGRAM_PARSE_MODE });
             } catch (error) {

--- a/packages/channel-connector/src/utils/telegramHtml.ts
+++ b/packages/channel-connector/src/utils/telegramHtml.ts
@@ -40,7 +40,7 @@ const renderer: RendererObject = {
         const startNum = typeof start === 'number' ? start : 1;
         const lines = items.map((item, i) => {
             const marker = ordered ? `${startNum + i}.` : '•';
-            const inner = this.parser.parseInline(item.tokens).trimEnd();
+            const inner = this.parser.parse(item.tokens).trimEnd();
             return `${marker} ${inner}`;
         });
         return `${lines.join('\n')}\n\n`;


### PR DESCRIPTION
## Summary
- fall back to plain Telegram sends when Markdown-to-HTML formatting throws
- parse list item block tokens in Telegram HTML rendering so nested lists do not crash rich formatting
- only advance the channel runner cursor after skipped messages or successful Telegram sends, so failed sends retry

## Validation
- git diff --check passed
- npm test --workspace @ai-devkit/channel-connector -- --runInBand blocked: vitest not found
- npm test --workspace packages/cli -- --runInBand blocked: vitest not found
- npm run typecheck --workspace @ai-devkit/channel-connector blocked by missing deps/types: Node types, telegraf, marked
- npm run typecheck --workspace packages/cli blocked: package has no typecheck script