### PR TITLE
Remove install artifact overwrite prompt

### DIFF
--- a/packages/cli/src/__tests__/services/install/install.service.test.ts
+++ b/packages/cli/src/__tests__/services/install/install.service.test.ts
@@ -90,7 +90,7 @@ describe('install service', () => {
     expect(report.warnings).toEqual([]);
   });
 
-  it('prompts and skips conflicting artifacts when overwrite is not confirmed', async () => {
+  it('reinstalls existing generated artifacts without prompting for overwrite', async () => {
     mockTemplateManager.checkEnvironmentExists
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true);
@@ -101,29 +101,17 @@ describe('install service', () => {
 
     const report = await reconcileAndInstall(installConfig, {});
 
-    expect(mockConfirm).toHaveBeenCalledTimes(1);
-    expect(report.environments.skipped).toBe(1);
-    expect(report.phases.skipped).toBe(1);
-    expect(report.skills.installed).toBe(1);
-    expect(mockConfigManager.update).toHaveBeenCalledWith({
-      skills: [{ registry: 'codeaholicguy/ai-devkit', name: 'debug' }],
-    });
-  });
-
-  it('overwrites conflicting artifacts when overwrite is confirmed via prompt', async () => {
-    mockTemplateManager.checkEnvironmentExists
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true);
-    mockTemplateManager.fileExists
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true);
-    mockConfirm.mockResolvedValue(true);
-
-    const report = await reconcileAndInstall(installConfig, {});
-
-    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockTemplateManager.checkEnvironmentExists).not.toHaveBeenCalled();
+    expect(mockTemplateManager.fileExists).not.toHaveBeenCalled();
     expect(report.environments.installed).toBe(1);
     expect(report.phases.installed).toBe(1);
+    expect(report.skills.installed).toBe(1);
+    expect(mockConfigManager.update).toHaveBeenCalledWith({
+      environments: ['codex'],
+      phases: ['requirements'],
+      skills: [{ registry: 'codeaholicguy/ai-devkit', name: 'debug' }],
+    });
   });
 
   it('auto-overwrites and does not prompt when --overwrite is set', async () => {

--- a/packages/cli/src/services/install/install.service.ts
+++ b/packages/cli/src/services/install/install.service.ts
@@ -5,7 +5,6 @@ import { TemplateManager } from '../../lib/TemplateManager.js';
 import { InstallConfigData } from '../../util/config.js';
 import { installMcpServers, McpInstallReport } from './mcp/index.js';
 import type { DevKitConfig } from '../../types.js';
-import { confirm } from '@inquirer/prompts';
 
 export interface InstallRunOptions {
   overwrite?: boolean;
@@ -42,9 +41,6 @@ export async function reconcileAndInstall(
     warnings: []
   };
 
-  const hasConflicts = await hasOverwriteConflicts(templateManager, config);
-  const shouldOverwrite = await resolveOverwritePolicy(options, hasConflicts);
-
   let projectConfig = await configManager.read();
   if (!projectConfig) {
     await configManager.create();
@@ -61,12 +57,6 @@ export async function reconcileAndInstall(
 
   for (const envCode of config.environments) {
     try {
-      const exists = await templateManager.checkEnvironmentExists(envCode);
-      if (exists && !shouldOverwrite) {
-        report.environments.skipped += 1;
-        continue;
-      }
-
       await templateManager.setupMultipleEnvironments([envCode]);
       report.environments.installed += 1;
       successfulEnvironments.push(envCode);
@@ -80,12 +70,6 @@ export async function reconcileAndInstall(
 
   for (const phase of config.phases) {
     try {
-      const exists = await templateManager.fileExists(phase);
-      if (exists && !shouldOverwrite) {
-        report.phases.skipped += 1;
-        continue;
-      }
-
       await templateManager.copyPhaseTemplate(phase);
       await configManager.addPhase(phase);
       report.phases.installed += 1;
@@ -161,41 +145,4 @@ export function getInstallExitCode(report: InstallReport, options: InstallRunOpt
   }
 
   return 0;
-}
-
-async function hasOverwriteConflicts(
-  templateManager: TemplateManager,
-  config: InstallConfigData
-): Promise<boolean> {
-  for (const env of config.environments) {
-    if (await templateManager.checkEnvironmentExists(env)) {
-      return true;
-    }
-  }
-
-  for (const phase of config.phases) {
-    if (await templateManager.fileExists(phase)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-async function resolveOverwritePolicy(
-  options: InstallRunOptions,
-  hasConflicts: boolean
-): Promise<boolean> {
-  if (!hasConflicts) {
-    return false;
-  }
-
-  if (options.overwrite) {
-    return true;
-  }
-
-  return confirm({
-    message: 'Existing install artifacts were found. Overwrite them?',
-    default: false
-  });
 }


### PR DESCRIPTION
## Summary
- remove the broad install artifact existence preflight and overwrite prompt
- make environment and phase template installation idempotently reinstall generated artifacts
- keep MCP-specific conflict prompting unchanged