### PR TITLE
feat(skills): add dev-pr workflow skill

### DIFF
--- a/packages/cli/src/__tests__/commands/skill.test.ts
+++ b/packages/cli/src/__tests__/commands/skill.test.ts
@@ -107,6 +107,10 @@ describe('skill command', () => {
       global: undefined,
       environments: undefined,
     });
+    expect(mockAddSkill).toHaveBeenCalledWith('codeaholicguy/ai-devkit', 'dev-pr', {
+      global: undefined,
+      environments: undefined,
+    });
   });
 
   it('exits when skill add has neither registry nor --built-in', async () => {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -22,6 +22,7 @@ export const BUILTIN_SKILL_NAMES = [
   'dev-implementation',
   'dev-testing',
   'dev-review',
+  'dev-pr',
   'structured-debug',
   'document-code',
   'memory',

--- a/skills/dev-pr/SKILL.md
+++ b/skills/dev-pr/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: dev-pr
+description: AI DevKit · Publish a ready feature branch for review. Use when the user wants to sync, push, and open or update a code review request on GitHub, GitLab, or another Git host.
+---
+
+# Dev PR
+
+Publish an already-reviewed branch for code review. Keep this separate from commit creation: if the branch has uncommitted changes, stop and ask the user to run the commit workflow first.
+
+## Contract
+
+1. Verify repository context with `git status -sb`, `git branch --show-current`, and `git remote -v`.
+2. Confirm the branch is not the base branch and has committed changes to publish.
+3. Fetch the remote before comparing or rebasing.
+4. Rebase the feature branch onto the latest remote base branch before push/review.
+5. Resolve conflicts carefully, preserving intended behavior, then rerun relevant validation.
+6. Push safely. Use `--force-with-lease` only when a rebase rewrote an already-pushed branch.
+7. Open or update the host's review request: PR, merge request, or equivalent.
+8. Report review URL, branch, HEAD SHA, validation results, push mode, and risks.
+
+## Publish Workflow
+
+1. Inspect local context:
+   - `git status -sb`
+   - `git branch --show-current`
+   - `git remote -v`
+2. If uncommitted changes exist, stop. Do not stage, amend, squash, or commit in this skill.
+3. Identify the remote and base branch from repo conventions, upstream config, or user instruction; default to `origin/main` only when that matches the repo.
+4. Fetch the remote, inspect the delta, and rebase onto the remote base branch.
+5. If conflicts occur, inspect conflicted files and `git diff`, resolve minimally, validate when useful, `git add`, then continue the rebase. Stop if the correct resolution is unclear.
+6. Run relevant validation for the changed surface.
+7. Push:
+   - First push: set upstream.
+   - Normal update: plain push.
+   - Rebased already-pushed branch: `--force-with-lease`.
+8. Open or update the review request using the host's tool/API/UI (`gh`, `glab`, forge CLI, web UI, or project-specific workflow).
+9. Write a concise review description. Include enough for reviewers to understand:
+   - Summary: what changed, why, and how.
+   - Validation: how it was verified.
+   - Risks: notable risks or "none known".
+10. Report:
+   - Review URL and state
+   - Branch and HEAD SHA
+   - Validation commands and exit codes
+   - Push mode, including whether `--force-with-lease` was used
+   - Risks, follow-ups, or blockers

--- a/skills/dev-pr/agents/openai.yaml
+++ b/skills/dev-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dev PR"
+  short_description: "AI DevKit · Publish a ready branch for code review"
+  default_prompt: "Use $dev-pr to sync this ready branch, push safely, and open or update the review request."

--- a/skills/index.json
+++ b/skills/index.json
@@ -760,6 +760,13 @@
       "lastIndexed": 1782001853267
     },
     {
+      "name": "dev-pr",
+      "registry": "codeaholicguy/ai-devkit",
+      "path": "skills/dev-pr",
+      "description": "AI DevKit · Publish a ready feature branch for review. Use when the user wants to sync, push, and open or update a code review request on GitHub, GitLab, or another Git host.",
+      "lastIndexed": 1782001853267
+    },
+    {
       "name": "dev-testing",
       "registry": "codeaholicguy/ai-devkit",
       "path": "skills/dev-testing",

--- a/web/content/docs/1-getting-started.md
+++ b/web/content/docs/1-getting-started.md
@@ -112,7 +112,7 @@ Terminal commands still start with `ai-devkit`; skills are used by the agent ins
 | Skill | Purpose |
 |---------|---------|
 | `dev-lifecycle` | Orchestrate worktree setup, requirements, design, planning, implementation, testing, and review |
-| `dev-worktree`, `dev-requirements`, `dev-design`, `dev-planning`, `dev-implementation`, `dev-testing`, `dev-review` | Run focused lifecycle phases directly |
+| `dev-worktree`, `dev-requirements`, `dev-design`, `dev-planning`, `dev-implementation`, `dev-testing`, `dev-review`, `dev-pr` | Run focused lifecycle and publish-for-review phases directly |
 | `dev-commit` | Commit only intended, verified changes with a conventional message |
 | `tdd` | Add or change behavior test-first |
 | `verify` | Require fresh command output before completion claims |

--- a/web/content/docs/7-skills.md
+++ b/web/content/docs/7-skills.md
@@ -29,7 +29,7 @@ AI DevKit ships with a core set of skills in its default registry:
 | `document-code` | Document code entry points with structured analysis and dependency mapping |
 | `dev-commit` | Commit only intended, verified changes with a conventional message |
 | `dev-lifecycle` | Orchestrate the SDLC workflow and route to phase skills |
-| `dev-worktree`, `dev-requirements`, `dev-design`, `dev-planning`, `dev-implementation`, `dev-testing`, `dev-review` | Run focused SDLC phases directly |
+| `dev-worktree`, `dev-requirements`, `dev-design`, `dev-planning`, `dev-implementation`, `dev-testing`, `dev-review`, `dev-pr` | Run focused SDLC and publish-for-review phases directly |
 | `structured-debug` | Follow a disciplined debugging and RCA process before implementing fixes |
 | `memory` | Use AI DevKit memory operations via CLI patterns when needed |
 | `simplify-implementation` | Simplify and refactor complex code paths for maintainability |

--- a/web/lib/skills/built-in.ts
+++ b/web/lib/skills/built-in.ts
@@ -289,6 +289,20 @@ export const builtInSkills: BuiltInSkill[] = [
     ],
     relatedAgents: ["Claude Code", "Codex", "Cursor", "opencode"],
   },
+  {
+    name: "dev-pr",
+    title: "Dev PR",
+    category: "Workflow",
+    summary: "Publish a reviewed feature branch for code review.",
+    description:
+      "Use dev-pr after implementation, testing, and final review are complete. It syncs with the remote base branch, handles rebase conflicts carefully, reruns validation, pushes safely, and opens or updates the host review request.",
+    useCases: [
+      "Rebase a ready feature branch before review",
+      "Push safely after validation",
+      "Open or update a PR, merge request, or equivalent with clear status and risks",
+    ],
+    relatedAgents: ["Claude Code", "Codex", "Cursor", "opencode"],
+  },
 ];
 
 export function getBuiltInSkill(name: string): BuiltInSkill | undefined {


### PR DESCRIPTION
## Summary
- Add the built-in `dev-pr` skill for provider-neutral publish-for-review workflows.
- Keep guidance concise and generic for GitHub, GitLab, or other Git hosts.
- Register it in the CLI built-in install list, public built-in skill catalog, and skill index.
- Cover `skill add --built-in` so installs include `dev-pr`.