### PR TITLE
feat(channel): render AskUserQuestion as Telegram inline keyboard

### DIFF
--- a/docs/ai/design/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/design/2026-06-29-feature-telegram-question-buttons.md
@@ -1,0 +1,162 @@
+---
+phase: design
+title: System Design & Architecture
+description: Define the technical architecture, components, and data models
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+
+```mermaid
+graph TD
+  Agent[Claude Code Agent] -->|hook writes agent-request| Hook[(agent-request JSONL)]
+  Hook -->|poll| Runner[channel-runner.ts]
+  Runner -->|tryHandle| Service[AskUserQuestionService]
+  Service -->|sendInlineKeyboard| Adapter[TelegramAdapter]
+  Adapter -->|HTML + reply_markup| TG[Telegram Chat]
+  TG -->|callback_query| Adapter
+  Adapter -->|onCallback| Runner
+  Runner -->|handleCallback| Service
+  Service -->|sendKey digit| TTY[TtyWriter.sendKey]
+  TTY -->|raw keystroke| Agent
+```
+
+| Component | Responsibility |
+|---|---|
+| `channel-runner.ts` | Orchestrate. Route `AskUserQuestion` to the service; register adapter callback handler; inject `TtyWriter.sendKey` as the agent-write callback. |
+| `AskUserQuestionService` (new, in `ask-user-question.ts`) | Parse input, render the keyboard, track an in-memory session per `questionId`, resolve the digit on tap, write to the agent. |
+| `TelegramAdapter` | Adds 4 methods: `sendInlineKeyboard`, `editInlineKeyboard`, `answerCallback`, `onCallback`. |
+| `TtyWriter.sendKey` (new) | Send a single raw keystroke to the agent's terminal, bypassing bracketed paste and auto-Enter. |
+
+## Data Models
+
+```ts
+// ask-user-question.ts (internal)
+
+interface QuestionOption {
+    label: string;
+    description?: string;
+}
+
+interface QuestionSpec {
+    question: string;
+    header?: string;
+    options: QuestionOption[];
+}
+
+interface ActiveSession {
+    questionId: string;     // short base36 counter, never sent to agent
+    chatId: string;
+    spec: QuestionSpec;
+    messageId: number | null;
+}
+
+// callback_data encoding (≤64 bytes):
+//   q:<questionId>:o:<optionIdx>
+// questionId is base36 counter (1-2 chars), optionIdx is decimal — well under 64 bytes.
+```
+
+```ts
+// channel-connector/src/types.ts (new exports)
+
+export interface InlineKeyboardButton {
+    text: string;
+    callbackData: string;
+}
+export type InlineKeyboard = InlineKeyboardButton[][]; // rows of buttons
+
+export interface IncomingCallback {
+    channelType: string;
+    chatId: string;
+    userId: string;
+    messageId: number;
+    callbackData: string;
+    callbackQueryId: string;
+    timestamp: Date;
+}
+export type CallbackHandler = (callback: IncomingCallback) => Promise<void>;
+```
+
+## API Design
+
+### TelegramAdapter additions
+
+```ts
+class TelegramAdapter implements ChannelAdapter {
+    // existing: start, stop, sendMessage, onMessage, isHealthy
+
+    /** Send a message with an inline keyboard. Returns the Telegram message_id. */
+    async sendInlineKeyboard(chatId: string, html: string, keyboard: InlineKeyboard): Promise<number>;
+
+    /** Replace (or remove with `null`) the keyboard on an existing message. */
+    async editInlineKeyboard(chatId: string, messageId: number, keyboard: InlineKeyboard | null): Promise<void>;
+
+    /** Ack a callback_query, optionally with a transient toast. */
+    async answerCallback(callbackQueryId: string, text?: string): Promise<void>;
+
+    /** Register a handler for inline-keyboard taps. */
+    onCallback(handler: CallbackHandler): void;
+}
+```
+
+`ChannelAdapter` (the abstract interface) stays minimal — keyboard methods live only on the concrete `TelegramAdapter`. Promote to the interface if a second platform needs them.
+
+### TtyWriter addition
+
+```ts
+class TtyWriter {
+    static async send(location, message): Promise<void>;     // existing: bracketed paste + Enter
+    static async sendKey(location, key): Promise<void>;       // NEW: raw single keystroke
+}
+```
+
+- **tmux** path: `tmux send-keys -t <id> <key>` — direct, no paste buffer.
+- **iTerm2 / Terminal.app**: focus the target session/tab, then `tell application "System Events" to keystroke "<key>"`. Requires macOS Accessibility permission.
+
+### ask-user-question.ts service
+
+```ts
+export class AskUserQuestionService {
+    constructor(telegram: KeyboardChannel, sendToAgent: SendToAgent);
+
+    /** Returns true if it owned the request; false → caller falls back to plain text. */
+    tryHandle(toolInput: Record<string, unknown>, chatId: string): Promise<boolean>;
+
+    /** Resolve an inline-keyboard tap, write the digit to the agent, clear the keyboard. */
+    handleCallback(cb: IncomingCallback): Promise<void>;
+}
+```
+
+`KeyboardChannel` is a 3-method subset of `TelegramAdapter` (`sendInlineKeyboard`, `editInlineKeyboard`, `answerCallback`) — kept narrow so unit tests can supply a tiny stub.
+
+`SendToAgent = (key: string) => Promise<void>` — in production wired to `(key) => TtyWriter.sendKey(terminalLocation, key)`.
+
+## Component Breakdown
+
+- `packages/channel-connector/src/types.ts` — add `InlineKeyboardButton`, `InlineKeyboard`, `IncomingCallback`, `CallbackHandler`.
+- `packages/channel-connector/src/index.ts` — re-export new types.
+- `packages/channel-connector/src/adapters/TelegramAdapter.ts` — 4 new methods + `bot.on('callback_query', ...)` wiring.
+- `packages/agent-manager/src/terminal/TtyWriter.ts` — new `sendKey` static method (tmux + iTerm2 + Terminal.app paths).
+- `packages/cli/src/services/channel/ask-user-question.ts` (new) — service, parser, formatter, keyboard builder, escape helper.
+- `packages/cli/src/services/channel/channel-runner.ts`:
+  - `startOutputPolling` accepts optional `askUserQuestionService`.
+  - Polling loop offers `AskUserQuestion` payloads to the service; on `false` (multi-select / multi-question / malformed) falls back to `formatPromptMessage`.
+  - `runChannelBridge` constructs the service with `TtyWriter.sendKey` and registers `telegram.onCallback`.
+
+## Design Decisions
+
+- **Single-select, single-question only.** Multi-select toggle + Submit and multi-question advance require sequencing keystrokes through the picker with timing assumptions; sending the wrong key at the wrong moment puts garbage in the agent's prompt. Reject those shapes at the parser; let the caller fall back to plain `[Question]` text where the user can free-text reply.
+- **Digit keystroke via `sendKey`, not text via `send`.** The host picker reads stdin in raw mode. `TtyWriter.send` wraps payloads in bracketed paste markers `\e[200~ ... \e[201~`, which the inner TUI routes to the focused text input ("Other"), not to the picker's digit hotkey. `sendKey` sends a raw keystroke that the picker captures and selects+confirms immediately.
+- **Process-memory state.** Bridge restart drops in-flight questions; on tap of a stale button we ack with a "Question expired" toast. Acceptable per requirements; avoids file-IO complexity.
+- **`questionId` is a short base36 counter.** Keeps `callback_data` ≤64 bytes and contains no PII.
+- **HTML escaping at the body builder.** Telegraf does not auto-escape; all user-controlled fields go through `escapeHtml` before insertion.
+- **Defense-in-depth on `chatId`.** The adapter delivers all callbacks; the runner filters by `chatIdRef.value`; the service re-checks `session.chatId`. Three independent gates.
+- **Keep `ChannelAdapter` interface minimal.** Inline keyboards are Telegram-specific; the runner imports `TelegramAdapter` directly. Revisit if a second adapter needs them.
+
+## Non-Functional Requirements
+
+- **Performance.** Callbacks are human-rate. No batching needed.
+- **Security.** HTML-escape every user-controlled field; AppleScript-escape every `sendKey` payload; reject callbacks whose `chatId` doesn't match the authorized chat.
+- **Reliability.** Callback handler errors must not crash the bridge: every external call (`editInlineKeyboard`, `answerCallback`, `sendToAgent`) is wrapped in try/catch + `debug` logging.
+- **Backwards compatibility.** Non-AskUserQuestion tool prompts unchanged. The legacy plain-text `[Question] <text>` path remains as the fallback.

--- a/docs/ai/design/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/design/2026-06-29-feature-telegram-question-buttons.md
@@ -25,9 +25,9 @@ graph TD
 | Component | Responsibility |
 |---|---|
 | `channel-runner.ts` | Orchestrate. Route `AskUserQuestion` to the service; register adapter callback handler; inject `TtyWriter.sendKey` as the agent-write callback. |
-| `AskUserQuestionService` (new, in `ask-user-question.ts`) | Parse input, render the keyboard, track an in-memory session per `questionId`, resolve the digit on tap, write to the agent. |
+| `AskUserQuestionService` (new, in `ask-user-question.ts`) | Parse input, render the keyboard (numbered options + Skip for single-select; Skip-only for multi-select), track an in-memory session per `questionId`, resolve the digit or Esc on tap, write to the agent. |
 | `TelegramAdapter` | Adds 4 methods: `sendInlineKeyboard`, `editInlineKeyboard`, `answerCallback`, `onCallback`. |
-| `TtyWriter.sendKey` (new) | Send a single raw keystroke to the agent's terminal, bypassing bracketed paste and auto-Enter. |
+| `TtyWriter.sendKey` (new) | Send a single raw keystroke to the agent's terminal, bypassing bracketed paste and auto-Enter. Translates the Esc byte (`\x1b`) to the backend-native representation. |
 
 ## Data Models
 
@@ -43,6 +43,7 @@ interface QuestionSpec {
     question: string;
     header?: string;
     options: QuestionOption[];
+    multiSelect: boolean;
 }
 
 interface ActiveSession {
@@ -53,8 +54,9 @@ interface ActiveSession {
 }
 
 // callback_data encoding (≤64 bytes):
-//   q:<questionId>:o:<optionIdx>
-// questionId is base36 counter (1-2 chars), optionIdx is decimal — well under 64 bytes.
+//   q:<questionId>:o:<optionIdx>   — option tap (single-select keyboards only)
+//   q:<questionId>:skip            — Skip tap (every keyboard)
+// questionId is a base36 counter (1-2 chars); optionIdx is decimal — both well under 64 bytes.
 ```
 
 ```ts
@@ -141,13 +143,15 @@ export class AskUserQuestionService {
 - `packages/cli/src/services/channel/ask-user-question.ts` (new) — service, parser, formatter, keyboard builder, escape helper.
 - `packages/cli/src/services/channel/channel-runner.ts`:
   - `startOutputPolling` accepts optional `askUserQuestionService`.
-  - Polling loop offers `AskUserQuestion` payloads to the service; on `false` (multi-select / multi-question / malformed) falls back to `formatPromptMessage`.
+  - Polling loop offers `AskUserQuestion` payloads to the service; on `false` (multi-question / malformed) falls back to `formatPromptMessage`.
   - `runChannelBridge` constructs the service with `TtyWriter.sendKey` and registers `telegram.onCallback`.
 
 ## Design Decisions
 
-- **Single-select, single-question only.** Multi-select toggle + Submit and multi-question advance require sequencing keystrokes through the picker with timing assumptions; sending the wrong key at the wrong moment puts garbage in the agent's prompt. Reject those shapes at the parser; let the caller fall back to plain `[Question]` text where the user can free-text reply.
-- **Digit keystroke via `sendKey`, not text via `send`.** The host picker reads stdin in raw mode. `TtyWriter.send` wraps payloads in bracketed paste markers `\e[200~ ... \e[201~`, which the inner TUI routes to the focused text input ("Other"), not to the picker's digit hotkey. `sendKey` sends a raw keystroke that the picker captures and selects+confirms immediately.
+- **Single-question scope.** Multi-question payloads require sequencing keystrokes across pickers with timing assumptions; we reject them at the parser and fall back to plain `[Question]` text where the user can free-text reply.
+- **Multi-select is supported as Skip + chat reply, not toggle/Submit.** Driving multi-select toggles through the picker is just as fragile as multi-question. Instead, render the question and numbered options as a read-only formatted message with a `Skip`-only keyboard, plus a hint asking the user to reply in chat. The existing `onMessage` → `TtyWriter.send` path delivers the typed reply.
+- **Skip on every keyboard.** A `Skip` button is appended to every keyboard. On tap it sends the Esc byte (`\x1b`) via `sendKey`, which translates per backend (tmux `Escape`, AppleScript `key code 53`, wezterm literal byte).
+- **Digit keystroke via `sendKey`, not text via `send`.** The host picker reads stdin in raw mode. `TtyWriter.send` wraps payloads in bracketed paste markers `\e[200~ ... \e[201~`, which the inner TUI routes to the focused text input ("Other"), not to the picker's digit hotkey. `sendKey` sends a raw keystroke that the picker captures and selects+confirms immediately. Free-text replies (for the multi-select chat-reply path) intentionally use `send` so they reach the picker's text-input field.
 - **Process-memory state.** Bridge restart drops in-flight questions; on tap of a stale button we ack with a "Question expired" toast. Acceptable per requirements; avoids file-IO complexity.
 - **`questionId` is a short base36 counter.** Keeps `callback_data` ≤64 bytes and contains no PII.
 - **HTML escaping at the body builder.** Telegraf does not auto-escape; all user-controlled fields go through `escapeHtml` before insertion.

--- a/docs/ai/implementation/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/implementation/2026-06-29-feature-telegram-question-buttons.md
@@ -16,24 +16,32 @@ description: What was actually built for telegram-question-buttons
 
 ## Test Files Changed
 
-- `packages/cli/src/__tests__/services/channel/ask-user-question.test.ts` (new) — 22 tests covering parser, escapeHtml, body formatter, keyboard builder, single-select / multi-select flow, multi-question sequencing, stale callback, chatId mismatch.
+- `packages/cli/src/__tests__/services/channel/ask-user-question.test.ts` (new) — tests covering parser (single-select, multi-select, multi-question reject, malformed), escapeHtml, body formatter (header omit, multi-select hint, HTML escape), keyboard builder (single-select numbered + Skip; multi-select Skip-only), service flow (option tap, Skip tap, stale callback, chatId mismatch, malformed, out-of-range).
 - `packages/cli/src/__tests__/services/channel/channel-runner.test.ts` — replaced the two raw-JSON assertions with inline-keyboard assertions; added malformed-payload fallback test.
 - `packages/cli/src/__tests__/commands/channel.test.ts` — widened the `mockTelegramAdapter` shape to include the new keyboard methods.
 - `packages/channel-connector/src/__tests__/adapters/TelegramAdapter.test.ts` — added stub methods (`editMessageReplyMarkup`, `answerCbQuery`) and `_triggerCallback` helper to the mocked bot; added 6 tests for the new adapter methods.
 
 ## Scope
 
-**Supported:** single-select, single-question `AskUserQuestion` payloads only.
+**Supported:**
+- Single-select, single-question `AskUserQuestion` payloads: numbered option buttons + Skip button.
+- Multi-select single-question payloads (`multiSelect: true`): Skip-only keyboard; user types the answer in chat.
+- `Skip` button on every keyboard — sends Esc (`\x1b`) to dismiss the picker.
 
 **Deliberately unsupported (fall back to plain `[Question]` text):**
-- `multiSelect: true` on any question.
-- `questions` array with length ≠ 1.
+- `questions` array with length ≠ 1 (multi-question payloads).
 
-Rationale: driving multi-select or multi-question through the TTY picker is fragile — it requires the bridge to sequence digit + Enter keystrokes across multiple turns, with timing assumptions about when the next picker opens. Sending the wrong key at the wrong moment puts garbage into the agent's prompt. The fallback path still works for those cases; the user can type a free-text reply.
+Rationale: driving multi-question through the TTY picker is fragile — it requires the bridge to sequence digit + Enter keystrokes across multiple turns, with timing assumptions about when the next picker opens. The fallback path still works for those cases; the user can type a free-text reply.
+
+Multi-select was originally in the unsupported list for the same reason. We now support it as a chat-reply flow (no option buttons, just Skip) because the existing free-text path already handles arbitrary user input correctly and the Skip button gives the user a clean dismiss.
 
 ## Callback Data Format
 
-`callback_data` shape: `q:<id>:o:<idx>` (option tap). Bounded ≤64 bytes (Telegram cap). `<id>` is a base36-encoded monotonic counter; never sent to the agent.
+Two shapes, each bounded ≤64 bytes (Telegram cap):
+- `q:<id>:o:<idx>` — option tap (single-select keyboards only)
+- `q:<id>:skip` — Skip tap (every keyboard)
+
+`<id>` is a base36-encoded monotonic counter; never sent to the agent.
 
 ## State Model
 
@@ -41,21 +49,29 @@ In-memory `Map<questionId, ActiveSession>` on the service instance. Each session
 
 ## Final Answer Delivery
 
-When the user taps option N, the bridge writes the digit `String(optionIdx + 1)` to the agent's TTY via the new `TtyWriter.sendKey` — **not** `TtyWriter.send`, and **not** the option label.
+The bridge writes the resolved answer to the agent's TTY via the new `TtyWriter.sendKey` — **not** `TtyWriter.send`, and **not** the option label.
 
-`TtyWriter.send` was unusable here because it wraps the payload in bracketed paste markers and auto-appends Enter — the picker would see a paste of "1\n", which lands in the "Other" free-text field rather than triggering the digit hotkey.
+| User action | Sent to agent | Toast |
+|---|---|---|
+| Tap option N (single-select) | digit `String(optionIdx + 1)` | option `label` |
+| Tap Skip (any keyboard) | Esc byte `\x1b` | "Skipped" |
+| Type free-text in Telegram chat | the typed text (via existing `onMessage` → `TtyWriter.send` path) | n/a |
+
+`TtyWriter.send` was unusable for option taps because it wraps the payload in bracketed paste markers and auto-appends Enter — the picker would see a paste of "1\n", which lands in the "Other" free-text field rather than triggering the digit hotkey. `TtyWriter.send` is still the right path for free-text replies because the picker's text-input field *is* the intended destination there.
 
 `TtyWriter.sendKey` sends a raw keystroke:
-- **tmux:** `tmux send-keys -t <id> <key>` (single call, no paste buffer, no auto-Enter).
-- **iTerm2 / Terminal.app:** focus the target session/tab, then `System Events keystroke "<key>"`. Requires Accessibility permissions on macOS.
+- **tmux:** `tmux send-keys -t <id> <key>` (single call, no paste buffer, no auto-Enter). For `\x1b` it sends the named key `Escape`.
+- **WezTerm:** `wezterm cli send-text --pane-id <id> --no-paste <key>` (Esc byte passes through literally).
+- **iTerm2 / Terminal.app:** focus the target session/tab, then `System Events keystroke "<key>"` (typeable chars) or `key code 53` (Esc). Requires Accessibility permissions on macOS.
 
-The Telegram toast shown to the user displays the option's `label` (for human-readable confirmation); the agent's TTY receives only the digit keystroke.
+The Esc translation logic is centralized in `appleScriptKeyAction()` so adding more non-typeable keys (arrows, F-keys) later is a one-line addition.
 
 ## Out-of-Scope / Deferred
 
 - Persistent sessions across bridge restarts.
 - Multi-tenant chat support (bridge is single-authorized-chat by design).
-- Multi-select / multi-question support (intentionally deferred; see Scope).
+- Multi-question support (intentionally deferred; see Scope).
+- Inline-button toggle/Submit UX for multi-select (we route through chat reply instead).
 - Inline-keyboard support on the abstract `ChannelAdapter` interface (kept Telegram-specific in v1).
 - Live Telegram smoke test (owner: user).
 

--- a/docs/ai/implementation/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/implementation/2026-06-29-feature-telegram-question-buttons.md
@@ -1,0 +1,65 @@
+---
+phase: implementation
+title: Implementation Guide
+description: What was actually built for telegram-question-buttons
+---
+
+# Implementation Guide
+
+## Files Changed
+
+- `packages/channel-connector/src/types.ts` — added `InlineKeyboardButton`, `InlineKeyboard`, `IncomingCallback`, `CallbackHandler`.
+- `packages/channel-connector/src/index.ts` — re-exported the new types.
+- `packages/channel-connector/src/adapters/TelegramAdapter.ts` — added `sendInlineKeyboard`, `editInlineKeyboard`, `answerCallback`, `onCallback`; wired `bot.on('callback_query', ...)` in `start()` to normalize callbacks into `IncomingCallback` and dispatch to the handler.
+- `packages/cli/src/services/channel/ask-user-question.ts` (new) — `AskUserQuestionService` (in-memory session store keyed by base36 question id), `parseAskUserQuestionInput`, `formatAskUserQuestionBody`, `buildKeyboard`, `escapeHtml`. Service exposes `tryHandle(toolInput, chatId)` for the runner and `handleCallback(cb)` for adapter callbacks.
+- `packages/cli/src/services/channel/channel-runner.ts` — `startOutputPolling` accepts an optional `askUserQuestionService`. When the agent-request `toolName` is `AskUserQuestion`, the service is offered the input first; on `false` (malformed payload) the runner falls back to the existing `formatPromptMessage` + `sendMessage` path. `runChannelBridge` constructs the service with `(message) => TtyWriter.send(terminalLocation, message)` and registers `telegram.onCallback`.
+
+## Test Files Changed
+
+- `packages/cli/src/__tests__/services/channel/ask-user-question.test.ts` (new) — 22 tests covering parser, escapeHtml, body formatter, keyboard builder, single-select / multi-select flow, multi-question sequencing, stale callback, chatId mismatch.
+- `packages/cli/src/__tests__/services/channel/channel-runner.test.ts` — replaced the two raw-JSON assertions with inline-keyboard assertions; added malformed-payload fallback test.
+- `packages/cli/src/__tests__/commands/channel.test.ts` — widened the `mockTelegramAdapter` shape to include the new keyboard methods.
+- `packages/channel-connector/src/__tests__/adapters/TelegramAdapter.test.ts` — added stub methods (`editMessageReplyMarkup`, `answerCbQuery`) and `_triggerCallback` helper to the mocked bot; added 6 tests for the new adapter methods.
+
+## Scope
+
+**Supported:** single-select, single-question `AskUserQuestion` payloads only.
+
+**Deliberately unsupported (fall back to plain `[Question]` text):**
+- `multiSelect: true` on any question.
+- `questions` array with length ≠ 1.
+
+Rationale: driving multi-select or multi-question through the TTY picker is fragile — it requires the bridge to sequence digit + Enter keystrokes across multiple turns, with timing assumptions about when the next picker opens. Sending the wrong key at the wrong moment puts garbage into the agent's prompt. The fallback path still works for those cases; the user can type a free-text reply.
+
+## Callback Data Format
+
+`callback_data` shape: `q:<id>:o:<idx>` (option tap). Bounded ≤64 bytes (Telegram cap). `<id>` is a base36-encoded monotonic counter; never sent to the agent.
+
+## State Model
+
+In-memory `Map<questionId, ActiveSession>` on the service instance. Each session holds `spec`, `messageId`, and `chatId`. Session is deleted on finalization or on send failure. Bridge restart drops all sessions; subsequent taps on dropped questions get a "Question expired" toast.
+
+## Final Answer Delivery
+
+When the user taps option N, the bridge writes the digit `String(optionIdx + 1)` to the agent's TTY via the new `TtyWriter.sendKey` — **not** `TtyWriter.send`, and **not** the option label.
+
+`TtyWriter.send` was unusable here because it wraps the payload in bracketed paste markers and auto-appends Enter — the picker would see a paste of "1\n", which lands in the "Other" free-text field rather than triggering the digit hotkey.
+
+`TtyWriter.sendKey` sends a raw keystroke:
+- **tmux:** `tmux send-keys -t <id> <key>` (single call, no paste buffer, no auto-Enter).
+- **iTerm2 / Terminal.app:** focus the target session/tab, then `System Events keystroke "<key>"`. Requires Accessibility permissions on macOS.
+
+The Telegram toast shown to the user displays the option's `label` (for human-readable confirmation); the agent's TTY receives only the digit keystroke.
+
+## Out-of-Scope / Deferred
+
+- Persistent sessions across bridge restarts.
+- Multi-tenant chat support (bridge is single-authorized-chat by design).
+- Multi-select / multi-question support (intentionally deferred; see Scope).
+- Inline-keyboard support on the abstract `ChannelAdapter` interface (kept Telegram-specific in v1).
+- Live Telegram smoke test (owner: user).
+
+## Verification
+
+- `npm run build` → exit 0 across 5 projects.
+- `npm test` → exit 0; 1,495 tests pass.

--- a/docs/ai/planning/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/planning/2026-06-29-feature-telegram-question-buttons.md
@@ -1,0 +1,35 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+Per `feedback_backlog_format.md`: flat checklist, no multi-status sections.
+
+## Tasks
+
+- [x] T1 — Extend `packages/channel-connector/src/types.ts` with `InlineKeyboardButton`, `InlineKeyboard`, `IncomingCallback`, `CallbackHandler`; re-export from `index.ts`.
+- [x] T2 — Add `sendInlineKeyboard`, `editInlineKeyboard`, `answerCallback`, `onCallback` to `TelegramAdapter`. Wire `bot.on('callback_query', ...)` in `start()`.
+- [x] T3 — Adapter unit tests for the four new methods using a stubbed Telegraf bot.
+- [x] T4 — Created new module `packages/cli/src/services/channel/ask-user-question.ts` with `AskUserQuestionService` (in-memory session map), `parseAskUserQuestionInput`, `buildKeyboard`, `formatAskUserQuestionBody`, `escapeHtml`.
+- [x] T5 — Registered `telegram.onCallback(handleCallback)` in `runChannelBridge`; the service is injected into `startOutputPolling`.
+- [x] T6 — Polling loop routes `AskUserQuestion` to `askQuestion.tryHandle(...)`; falls back to `formatPromptMessage` + `sendMessage` when the service is absent or the payload is malformed.
+- [x] T7 — Updated `channel-runner.test.ts:171-226` to assert keyboard shape, not raw JSON.
+- [x] T8 — Added multi-question fixture test in `ask-user-question.test.ts`.
+- [x] T9 — Full repo `npm run build` (exit 0) + `npm test` (exit 0; 1,495 tests across 5 projects).
+- [ ] T10 — Manual Telegram smoke test (live bot). Owner: user.
+- [x] T11 — Implementation doc updated.
+
+## Dependencies
+
+- T2 depends on T1.
+- T3 depends on T2.
+- T4 depends on T1.
+- T5 depends on T2, T4.
+- T6 depends on T4, T5.
+- T7, T8 depend on T6.
+- T9 depends on T7, T8.
+- T10 depends on T9.
+- T11 depends on T10.

--- a/docs/ai/requirements/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/requirements/2026-06-29-feature-telegram-question-buttons.md
@@ -17,23 +17,27 @@ Affected: any user driving a Claude Code agent remotely via the configured Teleg
 **Primary goals**
 - Render single-select, single-question `AskUserQuestion` payloads as a Telegram message with an inline keyboard, one button per option.
 - A tap on any option finalizes the answer and delivers the option's **digit key** (`String(optionIdx + 1)`) to the agent as a raw TTY keystroke — the host picker is a key-driven menu that selects+confirms on digit press.
+- Every keyboard includes a `Skip` button that sends `Esc` (`\x1b`) to dismiss the picker.
+- For **multi-select** single-question payloads (`multiSelect: true`): render the question + numbered options as a read-only formatted message with a `Skip`-only keyboard, plus a hint asking the user to reply in chat. Free-text replies pass through the existing `onMessage` → `TtyWriter.send` path.
 
 **Secondary goals**
 - Use Telegram HTML for the question body so visual hierarchy survives.
 - Keep the existing `[Tool prompt]` plain-text path unchanged for non-AskUserQuestion tools.
 
 **Non-goals (deliberately deferred)**
-- **Multi-select** payloads (`multiSelect: true`). Driving toggle + Submit through the TTY picker is fragile.
-- **Multi-question** payloads (`questions.length > 1`). Same reason — requires sequencing keystrokes with timing assumptions.
+- **Multi-question** payloads (`questions.length > 1`). Reliably sequencing keystrokes across pickers requires timing assumptions about when the next picker opens — fragile. These still fall back to the plain `[Question] <json>` text path.
 - Persisting selection state across bridge restarts.
 - Supporting multiple concurrent Telegram users — the bridge is single-user by design.
+- Driving multi-select toggles/Submit via inline buttons — multi-select uses the free-text reply path instead.
 
-Unsupported shapes fall back to the existing `[Question] <json>` plain-text path; the user can still type a free-text reply.
+Unsupported shapes (multi-question, malformed) fall back to the `[Question] <json>` plain-text path; the user can still type a free-text reply.
 
 ## User Stories & Use Cases
 
 - As a remote user driving an agent over Telegram, I tap a single button to answer a single-select question and the agent immediately proceeds, without me having to type anything.
-- As a remote user, I can still type a free-text reply for an unsupported shape (multi-select / multi-question) instead of tapping a button. Free-text replies pass through the existing `onMessage` path unchanged.
+- As a remote user faced with a multi-select question, I see the question and numbered options as a read-only message with a Skip button, and I type my answer in chat.
+- As a remote user, I can tap `Skip` on any question to send Esc and dismiss the picker.
+- As a remote user, I can still type a free-text reply instead of tapping a button. Free-text replies pass through the existing `onMessage` path unchanged.
 
 ### Edge cases
 
@@ -44,8 +48,10 @@ Unsupported shapes fall back to the existing `[Question] <json>` plain-text path
 ## Success Criteria
 
 - Single-select question round-trip from agent → Telegram → tap → agent receives the digit (e.g. `"1"`) via `TtyWriter.sendKey`. Verified by unit + integration tests.
+- Skip tap on any keyboard → agent receives Esc (`\x1b`) via `TtyWriter.sendKey`, translated to the backend-native form (tmux `Escape`, AppleScript `key code 53`).
+- Multi-select payloads render a Skip-only keyboard with a chat-reply hint; free-text replies still work. Verified by tests.
 - Existing non-AskUserQuestion `[Tool prompt]` output stays byte-identical.
-- Multi-select / multi-question payloads fall back to the plain `[Question]` text path (verified by tests).
+- Multi-question payloads fall back to the plain `[Question]` text path (verified by tests).
 - All `callback_data` payloads ≤64 bytes (Telegram cap).
 - 100% line coverage on new code in `ask-user-question.ts`, the new `TelegramAdapter` methods, and `TtyWriter.sendKey`.
 
@@ -64,6 +70,8 @@ Unsupported shapes fall back to the existing `[Question] <json>` plain-text path
 ## Questions & Open Items
 
 All material questions resolved during requirements gathering:
-- Multi-select / multi-question support → deferred; fall back to plain text.
-- Answer delivery format → digit key, not label.
+- Multi-question support → deferred; fall back to plain text.
+- Multi-select support → Skip-only keyboard + free-text reply path (no Toggle/Submit buttons).
+- Skip button → present on every keyboard; sends Esc keystroke.
+- Answer delivery format → digit key (for option taps), Esc (`\x1b`) (for Skip taps), not labels.
 - Stale callback after restart → ack with "Question expired" toast, no agent write.

--- a/docs/ai/requirements/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/requirements/2026-06-29-feature-telegram-question-buttons.md
@@ -1,0 +1,69 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+description: Clarify the problem space, gather requirements, and define success criteria
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+
+When a Claude Code session running locally asks the user a structured question via the `AskUserQuestion` tool, the channel bridge (`channel-runner.ts`) forwards the payload to Telegram. Today the payload `{ questions: [{ question, header, options: [{label, description}], multiSelect }] }` is dumped as raw JSON because `formatPromptMessage` only handles a singular `toolInput.question` field. The Telegram user must read JSON and type the answer back as free text — unfriendly and error-prone.
+
+Affected: any user driving a Claude Code agent remotely via the configured Telegram channel.
+
+## Goals & Objectives
+
+**Primary goals**
+- Render single-select, single-question `AskUserQuestion` payloads as a Telegram message with an inline keyboard, one button per option.
+- A tap on any option finalizes the answer and delivers the option's **digit key** (`String(optionIdx + 1)`) to the agent as a raw TTY keystroke — the host picker is a key-driven menu that selects+confirms on digit press.
+
+**Secondary goals**
+- Use Telegram HTML for the question body so visual hierarchy survives.
+- Keep the existing `[Tool prompt]` plain-text path unchanged for non-AskUserQuestion tools.
+
+**Non-goals (deliberately deferred)**
+- **Multi-select** payloads (`multiSelect: true`). Driving toggle + Submit through the TTY picker is fragile.
+- **Multi-question** payloads (`questions.length > 1`). Same reason — requires sequencing keystrokes with timing assumptions.
+- Persisting selection state across bridge restarts.
+- Supporting multiple concurrent Telegram users — the bridge is single-user by design.
+
+Unsupported shapes fall back to the existing `[Question] <json>` plain-text path; the user can still type a free-text reply.
+
+## User Stories & Use Cases
+
+- As a remote user driving an agent over Telegram, I tap a single button to answer a single-select question and the agent immediately proceeds, without me having to type anything.
+- As a remote user, I can still type a free-text reply for an unsupported shape (multi-select / multi-question) instead of tapping a button. Free-text replies pass through the existing `onMessage` path unchanged.
+
+### Edge cases
+
+- **Stale callback**: user taps a button on a question whose state was already finalized or never existed (e.g., bridge restarted). Acknowledge the callback so Telegram clears the spinner; do not feed anything to the agent; show a brief "Question expired" toast.
+- **`editMessageReplyMarkup` failure**: rare (e.g., message too old). Log the error, still feed back the resolved answer, do not crash the bridge.
+- **Unauthorized chat**: callbacks from any `chatId` other than `chatIdRef.value` are dropped at the runner before reaching the service.
+
+## Success Criteria
+
+- Single-select question round-trip from agent → Telegram → tap → agent receives the digit (e.g. `"1"`) via `TtyWriter.sendKey`. Verified by unit + integration tests.
+- Existing non-AskUserQuestion `[Tool prompt]` output stays byte-identical.
+- Multi-select / multi-question payloads fall back to the plain `[Question]` text path (verified by tests).
+- All `callback_data` payloads ≤64 bytes (Telegram cap).
+- 100% line coverage on new code in `ask-user-question.ts`, the new `TelegramAdapter` methods, and `TtyWriter.sendKey`.
+
+## Constraints & Assumptions
+
+**Technical**
+- Telegraf is the Telegram client; `bot.on('callback_query', ...)` delivers taps.
+- `callback_data` must be ≤64 bytes UTF-8.
+- The host `AskUserQuestion` picker reads stdin in raw mode. Digit keypresses select+confirm; pasted text via bracketed paste lands in the "Other" free-text field. The bridge therefore uses `TtyWriter.sendKey` (raw keystroke), not `TtyWriter.send` (paste + Enter).
+- macOS terminals (iTerm2 / Terminal.app) require Accessibility permissions for the System Events keystroke path. tmux uses `send-keys` directly with no extra permissions.
+- Bridge is single-user, single-agent: `chatIdRef.value` is the one authorized chat.
+
+**Assumptions**
+- A `questionId` is generated per render as a short base36 counter, never sent to the agent. Used only for routing callbacks to in-memory state.
+
+## Questions & Open Items
+
+All material questions resolved during requirements gathering:
+- Multi-select / multi-question support → deferred; fall back to plain text.
+- Answer delivery format → digit key, not label.
+- Stale callback after restart → ack with "Question expired" toast, no agent write.

--- a/docs/ai/testing/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/testing/2026-06-29-feature-telegram-question-buttons.md
@@ -10,13 +10,14 @@ description: Define testing approach, test cases, and quality assurance
 
 - 100% line coverage on new code in `ask-user-question.ts`, the new `TelegramAdapter` methods, and `TtyWriter.sendKey`.
 - All callback paths exercised (option tap, stale, chatId mismatch, malformed data, out-of-range index).
-- Fallback path exercised for every rejected shape (multi-select, multi-question, malformed).
+- Fallback path exercised for every rejected shape (multi-question, malformed).
+- Multi-select is rendered with a Skip-only keyboard + chat-reply hint.
 
 ## Unit Tests
 
 ### `parseAskUserQuestionInput` (ask-user-question.test.ts)
 - [x] Parses a single-select single-question payload.
-- [x] Rejects multi-select payloads (`multiSelect: true`) → returns null.
+- [x] Parses multi-select payloads with `multiSelect: true` carried on the spec.
 - [x] Rejects multi-question payloads (`questions.length !== 1`) → returns null.
 - [x] Returns null when `questions` is missing.
 - [x] Returns null when an option has no `label`.
@@ -28,18 +29,21 @@ description: Define testing approach, test cases, and quality assurance
 ### `formatAskUserQuestionBody`
 - [x] Includes header, question, and numbered options with descriptions.
 - [x] Omits header line when undefined.
+- [x] Adds reply-in-chat hint for multi-select.
 - [x] HTML-escapes user-controlled fields (`question`, `header`, `label`, `description`).
 
 ### `buildKeyboard`
-- [x] Renders one numbered button per option, one row each.
+- [x] Single-select: one numbered button per option plus a final Skip row.
+- [x] Multi-select: Skip-only keyboard (no numbered option rows).
 - [x] Every `callback_data` ≤64 bytes.
 
 ### `AskUserQuestionService`
 - [x] Sends digit key `String(optionIdx + 1)` when option is tapped.
+- [x] Sends Esc byte `\x1b` with "Skipped" toast when Skip is tapped.
 - [x] Removes the keyboard after the tap (calls `editInlineKeyboard(..., null)`).
 - [x] Shows toast with the chosen `label`.
 - [x] Returns `false` on malformed payload (caller falls back to plain text).
-- [x] Returns `false` on multi-select payload.
+- [x] Handles multi-select payload by rendering a Skip-only keyboard.
 - [x] Returns `false` on multi-question payload.
 - [x] Shows "Question expired" toast on unknown `questionId`.
 - [x] Ignores callback with mismatched `chatId`.
@@ -58,15 +62,19 @@ description: Define testing approach, test cases, and quality assurance
 ### `TtyWriter.sendKey` (TtyWriter.test.ts)
 - [x] tmux: invokes `tmux send-keys -t <id> <key>` directly (no paste buffer, no auto-Enter).
 - [x] tmux: passes through named keys (e.g. `Enter`).
-- [x] iTerm2: focuses the target session via AppleScript, then `tell application "System Events" to keystroke "<key>"`.
+- [x] tmux: translates the Esc byte (`\x1b`) to the named `Escape` key.
+- [x] WezTerm: invokes `wezterm cli send-text --pane-id <id> --no-paste <key>`.
+- [x] iTerm2: focuses the target session via AppleScript, then `keystroke "<key>"`.
+- [x] iTerm2: translates Esc byte to AppleScript `key code 53`.
 - [x] iTerm2: throws when session not found.
-- [x] Terminal.app: focuses the target tab via AppleScript, then `tell application "System Events" to keystroke "<key>"`.
+- [x] Terminal.app: focuses the target tab via AppleScript, then `keystroke "<key>"`.
+- [x] Terminal.app: translates Esc byte to AppleScript `key code 53`.
 - [x] Terminal.app: throws when tab not found.
 - [x] Unsupported terminal type throws.
 
 ### channel-runner integration
-- [x] Routes a single-select payload to `AskUserQuestionService.tryHandle` and the adapter receives a `sendInlineKeyboard` call with numbered option buttons.
-- [x] Falls back to plain `[Question]` text for multi-select payloads.
+- [x] Routes a single-select payload to `AskUserQuestionService.tryHandle` and the adapter receives a `sendInlineKeyboard` call with numbered option buttons + Skip row.
+- [x] Routes a multi-select payload with a Skip-only keyboard and the multi-select hint in the body.
 - [x] Falls back to plain `[Question]` text for malformed payloads.
 - [x] Non-AskUserQuestion `[Tool prompt]` formatting byte-identical to existing test.
 
@@ -85,12 +93,14 @@ Out of scope for this feature (would require a live Telegram bot + a real termin
 ## Test Reporting & Coverage
 
 - Command: `npm test` (runs vitest across all 5 workspace projects).
-- Latest run: 1,502 tests pass; exit 0.
+- Latest run: 1,525 tests pass; exit 0.
 
 ## Manual Testing
 
 - [ ] Live Telegram smoke: configure a real bot, trigger a single-select `AskUserQuestion`, tap a button, agent's picker selects and proceeds.
-- [ ] Live Telegram smoke: trigger a multi-select payload — bridge falls back to plain `[Question]` text; user can type a free-text reply.
+- [ ] Live Telegram smoke: trigger a multi-select payload — bridge renders Skip-only keyboard + reply-in-chat hint; typed free-text reaches the agent.
+- [ ] Live Telegram smoke: tap Skip on any keyboard — picker is dismissed (Esc).
+- [ ] Live Telegram smoke: trigger a multi-question payload — bridge falls back to plain `[Question]` text; user types a free-text reply.
 - [ ] Live Telegram smoke: stale callback after bridge restart shows "Question expired".
 
 ## Performance Testing

--- a/docs/ai/testing/2026-06-29-feature-telegram-question-buttons.md
+++ b/docs/ai/testing/2026-06-29-feature-telegram-question-buttons.md
@@ -1,0 +1,102 @@
+---
+phase: testing
+title: Testing Strategy
+description: Define testing approach, test cases, and quality assurance
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+
+- 100% line coverage on new code in `ask-user-question.ts`, the new `TelegramAdapter` methods, and `TtyWriter.sendKey`.
+- All callback paths exercised (option tap, stale, chatId mismatch, malformed data, out-of-range index).
+- Fallback path exercised for every rejected shape (multi-select, multi-question, malformed).
+
+## Unit Tests
+
+### `parseAskUserQuestionInput` (ask-user-question.test.ts)
+- [x] Parses a single-select single-question payload.
+- [x] Rejects multi-select payloads (`multiSelect: true`) → returns null.
+- [x] Rejects multi-question payloads (`questions.length !== 1`) → returns null.
+- [x] Returns null when `questions` is missing.
+- [x] Returns null when an option has no `label`.
+- [x] Returns null when `options` is empty.
+
+### `escapeHtml`
+- [x] Escapes `<`, `>`, `&`, `"`.
+
+### `formatAskUserQuestionBody`
+- [x] Includes header, question, and numbered options with descriptions.
+- [x] Omits header line when undefined.
+- [x] HTML-escapes user-controlled fields (`question`, `header`, `label`, `description`).
+
+### `buildKeyboard`
+- [x] Renders one numbered button per option, one row each.
+- [x] Every `callback_data` ≤64 bytes.
+
+### `AskUserQuestionService`
+- [x] Sends digit key `String(optionIdx + 1)` when option is tapped.
+- [x] Removes the keyboard after the tap (calls `editInlineKeyboard(..., null)`).
+- [x] Shows toast with the chosen `label`.
+- [x] Returns `false` on malformed payload (caller falls back to plain text).
+- [x] Returns `false` on multi-select payload.
+- [x] Returns `false` on multi-question payload.
+- [x] Shows "Question expired" toast on unknown `questionId`.
+- [x] Ignores callback with mismatched `chatId`.
+- [x] Ignores callbacks with malformed `callback_data`.
+- [x] Ignores callbacks with out-of-range option index.
+
+### `TelegramAdapter` (TelegramAdapter.test.ts)
+- [x] `sendInlineKeyboard` sends with `parse_mode: HTML` + `inline_keyboard`, returns `message_id`.
+- [x] `editInlineKeyboard` replaces the keyboard on an existing message.
+- [x] `editInlineKeyboard(..., null)` removes the keyboard (undefined `reply_markup`).
+- [x] `answerCallback` forwards id + optional text to telegraf.
+- [x] `onCallback` invokes registered handler with a normalized `IncomingCallback`.
+- [x] `onCallback` acks callbacks when no handler is registered.
+- [x] `onCallback` acks with "Error" toast when handler rejects.
+
+### `TtyWriter.sendKey` (TtyWriter.test.ts)
+- [x] tmux: invokes `tmux send-keys -t <id> <key>` directly (no paste buffer, no auto-Enter).
+- [x] tmux: passes through named keys (e.g. `Enter`).
+- [x] iTerm2: focuses the target session via AppleScript, then `tell application "System Events" to keystroke "<key>"`.
+- [x] iTerm2: throws when session not found.
+- [x] Terminal.app: focuses the target tab via AppleScript, then `tell application "System Events" to keystroke "<key>"`.
+- [x] Terminal.app: throws when tab not found.
+- [x] Unsupported terminal type throws.
+
+### channel-runner integration
+- [x] Routes a single-select payload to `AskUserQuestionService.tryHandle` and the adapter receives a `sendInlineKeyboard` call with numbered option buttons.
+- [x] Falls back to plain `[Question]` text for multi-select payloads.
+- [x] Falls back to plain `[Question]` text for malformed payloads.
+- [x] Non-AskUserQuestion `[Tool prompt]` formatting byte-identical to existing test.
+
+## Integration Tests
+
+- [x] End-to-end via `startOutputPolling` + mocked `TelegramAdapter`: write an `AskUserQuestion` agent-request to JSONL → adapter receives `sendInlineKeyboard` call.
+
+## End-to-End Tests
+
+Out of scope for this feature (would require a live Telegram bot + a real terminal with Accessibility permissions). Manual smoke test only.
+
+## Test Data
+
+- Fixtures inline in each test file. The original `singleSelectInput` shape is preserved in `channel-runner.test.ts`.
+
+## Test Reporting & Coverage
+
+- Command: `npm test` (runs vitest across all 5 workspace projects).
+- Latest run: 1,502 tests pass; exit 0.
+
+## Manual Testing
+
+- [ ] Live Telegram smoke: configure a real bot, trigger a single-select `AskUserQuestion`, tap a button, agent's picker selects and proceeds.
+- [ ] Live Telegram smoke: trigger a multi-select payload — bridge falls back to plain `[Question]` text; user can type a free-text reply.
+- [ ] Live Telegram smoke: stale callback after bridge restart shows "Question expired".
+
+## Performance Testing
+
+N/A — callback rate is human-paced.
+
+## Bug Tracking
+
+Standard repo issue tracker.

--- a/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
@@ -303,4 +303,120 @@ describe('TtyWriter', () => {
                 .rejects.toThrow('Cannot send input: unsupported terminal type');
         });
     });
+
+    describe('sendKey — tmux', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.TMUX,
+            identifier: 'main:0.1',
+            tty: '/dev/ttys030',
+        };
+
+        it('sends key via tmux send-keys directly (no paste buffer, no auto-Enter)', async () => {
+            mockExecFileSuccess();
+
+            await TtyWriter.sendKey(location, '1');
+
+            expect(mockedExecFile).toHaveBeenCalledTimes(1);
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'tmux',
+                ['send-keys', '-t', 'main:0.1', '1'],
+                expect.any(Function),
+            );
+        });
+
+        it('passes through named keys like Enter', async () => {
+            mockExecFileSuccess();
+            await TtyWriter.sendKey(location, 'Enter');
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'tmux',
+                ['send-keys', '-t', 'main:0.1', 'Enter'],
+                expect.any(Function),
+            );
+        });
+    });
+
+    describe('sendKey — WezTerm', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.WEZTERM,
+            identifier: '7',
+            tty: '/dev/ttys030',
+        };
+
+        it('uses wezterm cli send-text --no-paste to deliver a raw key', async () => {
+            mockExecFileSuccess();
+
+            await TtyWriter.sendKey(location, '1');
+
+            expect(mockedExecFile).toHaveBeenCalledTimes(1);
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'wezterm',
+                ['cli', 'send-text', '--pane-id', '7', '--no-paste', '1'],
+                expect.any(Function),
+            );
+        });
+    });
+
+    describe('sendKey — iTerm2', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.ITERM2,
+            identifier: '/dev/ttys030',
+            tty: '/dev/ttys030',
+        };
+
+        it('uses System Events keystroke after activating the iTerm2 session', async () => {
+            mockExecFileSuccess('ok');
+
+            await TtyWriter.sendKey(location, '2');
+
+            const args = (mockedExecFile.mock.calls[0] as unknown[])[1] as string[];
+            const script = args[1];
+            expect(script).toContain('tell application "iTerm"');
+            expect(script).toContain('tell application "System Events" to keystroke "2"');
+            expect(mockedExecFile).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws when session not found', async () => {
+            mockExecFileSuccess('not_found');
+            await expect(TtyWriter.sendKey(location, '1'))
+                .rejects.toThrow('iTerm2 session not found');
+        });
+    });
+
+    describe('sendKey — Terminal.app', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.TERMINAL_APP,
+            identifier: '/dev/ttys030',
+            tty: '/dev/ttys030',
+        };
+
+        it('uses System Events keystroke after selecting the Terminal.app tab', async () => {
+            mockExecFileSuccess('ok');
+
+            await TtyWriter.sendKey(location, '3');
+
+            const args = (mockedExecFile.mock.calls[0] as unknown[])[1] as string[];
+            const script = args[1];
+            expect(script).toContain('tell application "Terminal"');
+            expect(script).toContain('tell application "System Events" to keystroke "3"');
+            expect(mockedExecFile).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws when tab not found', async () => {
+            mockExecFileSuccess('not_found');
+            await expect(TtyWriter.sendKey(location, '1'))
+                .rejects.toThrow('Terminal.app tab not found');
+        });
+    });
+
+    describe('sendKey — unsupported terminal', () => {
+        it('throws for unknown terminal type', async () => {
+            const location: TerminalLocation = {
+                type: TerminalType.UNKNOWN,
+                identifier: '',
+                tty: '/dev/ttys030',
+            };
+            await expect(TtyWriter.sendKey(location, '1'))
+                .rejects.toThrow('Cannot send key: unsupported terminal type');
+        });
+    });
 });

--- a/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
@@ -333,6 +333,16 @@ describe('TtyWriter', () => {
                 expect.any(Function),
             );
         });
+
+        it('translates Esc byte (\\x1b) to the named "Escape" key', async () => {
+            mockExecFileSuccess();
+            await TtyWriter.sendKey(location, '\x1b');
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'tmux',
+                ['send-keys', '-t', 'main:0.1', 'Escape'],
+                expect.any(Function),
+            );
+        });
     });
 
     describe('sendKey — WezTerm', () => {
@@ -375,6 +385,15 @@ describe('TtyWriter', () => {
             expect(mockedExecFile).toHaveBeenCalledTimes(1);
         });
 
+        it('translates Esc byte (\\x1b) to AppleScript `key code 53`', async () => {
+            mockExecFileSuccess('ok');
+            await TtyWriter.sendKey(location, '\x1b');
+            const args = (mockedExecFile.mock.calls[0] as unknown[])[1] as string[];
+            const script = args[1];
+            expect(script).toContain('tell application "System Events" to key code 53');
+            expect(script).not.toContain('keystroke');
+        });
+
         it('throws when session not found', async () => {
             mockExecFileSuccess('not_found');
             await expect(TtyWriter.sendKey(location, '1'))
@@ -399,6 +418,15 @@ describe('TtyWriter', () => {
             expect(script).toContain('tell application "Terminal"');
             expect(script).toContain('tell application "System Events" to keystroke "3"');
             expect(mockedExecFile).toHaveBeenCalledTimes(1);
+        });
+
+        it('translates Esc byte (\\x1b) to AppleScript `key code 53`', async () => {
+            mockExecFileSuccess('ok');
+            await TtyWriter.sendKey(location, '\x1b');
+            const args = (mockedExecFile.mock.calls[0] as unknown[])[1] as string[];
+            const script = args[1];
+            expect(script).toContain('tell application "System Events" to key code 53');
+            expect(script).not.toContain('keystroke');
         });
 
         it('throws when tab not found', async () => {

--- a/packages/agent-manager/src/terminal/TtyWriter.ts
+++ b/packages/agent-manager/src/terminal/TtyWriter.ts
@@ -46,6 +46,117 @@ export class TtyWriter {
         }
     }
 
+    /**
+     * Send a single raw key (e.g. "1", "Enter", "Up") to the terminal as a
+     * keystroke — bypassing bracketed paste and without auto-appending Enter.
+     *
+     * Use this when the target TUI distinguishes between typed text and raw
+     * keypresses (e.g. an `AskUserQuestion` picker that selects on digit-key
+     * press, not on a pasted digit followed by Enter).
+     *
+     * - tmux: `tmux send-keys -t <id> <key>` — direct keystroke, no paste buffer.
+     * - WezTerm: `wezterm cli send-text --pane-id <id> --no-paste <key>`.
+     * - iTerm2 / Terminal.app: AppleScript via System Events. Requires
+     *   Accessibility permissions.
+     */
+    static async sendKey(location: TerminalLocation, key: string): Promise<void> {
+        switch (location.type) {
+            case TerminalType.TMUX:
+                return TtyWriter.sendKeyViaTmux(location.identifier, key);
+            case TerminalType.WEZTERM:
+                return TtyWriter.sendKeyViaWezterm(location.identifier, key);
+            case TerminalType.ITERM2:
+                return TtyWriter.sendKeyViaITerm2(location.tty, key);
+            case TerminalType.TERMINAL_APP:
+                return TtyWriter.sendKeyViaTerminalApp(location.tty, key);
+            default:
+                throw new Error(
+                    `Cannot send key: unsupported terminal type "${location.type}". ` +
+                    'Supported: tmux, WezTerm, iTerm2, Terminal.app.'
+                );
+        }
+    }
+
+    private static async sendKeyViaTmux(identifier: string, key: string): Promise<void> {
+        // tmux send-keys interprets named keys (Enter, Up, ...) and passes
+        // literals through. No bracketed paste, no auto-Enter.
+        await execFileAsync('tmux', ['send-keys', '-t', identifier, key]);
+    }
+
+    private static async sendKeyViaWezterm(paneId: string, key: string): Promise<void> {
+        // --no-paste delivers the key bytes literally outside bracketed-paste
+        // markers; the TUI sees a raw keystroke. Same convention as
+        // sendViaWezterm's Enter step, just without the preceding paste.
+        await execFileAsync('wezterm', [
+            'cli', 'send-text', '--pane-id', paneId, '--no-paste', key,
+        ]);
+    }
+
+    private static async sendKeyViaITerm2(tty: string, key: string): Promise<void> {
+        // Focus the target session, then press the key via System Events so the
+        // inner TUI sees a raw keystroke (not a bracketed-paste text run).
+        const escaped = escapeAppleScript(key);
+        const script = `
+tell application "iTerm"
+  set targetSession to missing value
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s is "${tty}" then
+          set targetSession to s
+          set frontmost of w to true
+          tell t to select
+          tell s to select
+          exit repeat
+        end if
+      end repeat
+      if targetSession is not missing value then exit repeat
+    end repeat
+    if targetSession is not missing value then exit repeat
+  end repeat
+  if targetSession is missing value then return "not_found"
+  activate
+end tell
+tell application "System Events" to keystroke "${escaped}"
+return "ok"`;
+
+        const { stdout } = await execFileAsync('osascript', ['-e', script]);
+        if (stdout.trim() !== 'ok') {
+            throw new Error(`iTerm2 session not found for TTY ${tty}`);
+        }
+    }
+
+    private static async sendKeyViaTerminalApp(tty: string, key: string): Promise<void> {
+        const escaped = escapeAppleScript(key);
+        const script = `
+tell application "Terminal"
+  set targetTab to missing value
+  set targetWindow to missing value
+  repeat with w in windows
+    repeat with i from 1 to count of tabs of w
+      set t to tab i of w
+      if tty of t is "${tty}" then
+        set targetTab to t
+        set targetWindow to w
+        exit repeat
+      end if
+    end repeat
+    if targetTab is not missing value then exit repeat
+  end repeat
+  if targetTab is missing value then return "not_found"
+  set selected of targetTab to true
+  set frontmost of targetWindow to true
+  activate
+end tell
+tell application "System Events" to keystroke "${escaped}"
+return "ok"`;
+
+        const { stdout } = await execFileAsync('osascript', ['-e', script]);
+        if (stdout.trim() !== 'ok') {
+            throw new Error(`Terminal.app tab not found for TTY ${tty}`);
+        }
+    }
+
     private static async sendViaWezterm(paneId: string, message: string): Promise<void> {
         // Two explicit CLI calls, mirroring the text-then-Enter convention used
         // by tmux / iTerm2 / Terminal.app so a bracketed-paste-aware TUI still

--- a/packages/agent-manager/src/terminal/TtyWriter.ts
+++ b/packages/agent-manager/src/terminal/TtyWriter.ts
@@ -12,6 +12,13 @@ const execFileAsync = promisify(execFile);
  */
 const CARRIAGE_RETURN = '\x0d';
 
+/**
+ * Escape byte (0x1b). Recognized by `sendKey` and translated to the
+ * backend-native representation (`Escape` for tmux, `key code 53` for
+ * AppleScript, the literal byte for WezTerm).
+ */
+const ESCAPE_BYTE = '\x1b';
+
 export class TtyWriter {
     /**
      * Send a message as keyboard input to a terminal session.
@@ -78,15 +85,16 @@ export class TtyWriter {
     }
 
     private static async sendKeyViaTmux(identifier: string, key: string): Promise<void> {
-        // tmux send-keys interprets named keys (Enter, Up, ...) and passes
-        // literals through. No bracketed paste, no auto-Enter.
-        await execFileAsync('tmux', ['send-keys', '-t', identifier, key]);
+        // tmux send-keys interprets named keys (Enter, Up, Escape, ...) and
+        // passes literals through. No bracketed paste, no auto-Enter.
+        const arg = key === ESCAPE_BYTE ? 'Escape' : key;
+        await execFileAsync('tmux', ['send-keys', '-t', identifier, arg]);
     }
 
     private static async sendKeyViaWezterm(paneId: string, key: string): Promise<void> {
         // --no-paste delivers the key bytes literally outside bracketed-paste
-        // markers; the TUI sees a raw keystroke. Same convention as
-        // sendViaWezterm's Enter step, just without the preceding paste.
+        // markers; the TUI sees a raw keystroke. For Esc (`\x1b`), wezterm
+        // accepts the byte directly.
         await execFileAsync('wezterm', [
             'cli', 'send-text', '--pane-id', paneId, '--no-paste', key,
         ]);
@@ -95,7 +103,7 @@ export class TtyWriter {
     private static async sendKeyViaITerm2(tty: string, key: string): Promise<void> {
         // Focus the target session, then press the key via System Events so the
         // inner TUI sees a raw keystroke (not a bracketed-paste text run).
-        const escaped = escapeAppleScript(key);
+        const action = appleScriptKeyAction(key);
         const script = `
 tell application "iTerm"
   set targetSession to missing value
@@ -117,7 +125,7 @@ tell application "iTerm"
   if targetSession is missing value then return "not_found"
   activate
 end tell
-tell application "System Events" to keystroke "${escaped}"
+tell application "System Events" to ${action}
 return "ok"`;
 
         const { stdout } = await execFileAsync('osascript', ['-e', script]);
@@ -127,7 +135,7 @@ return "ok"`;
     }
 
     private static async sendKeyViaTerminalApp(tty: string, key: string): Promise<void> {
-        const escaped = escapeAppleScript(key);
+        const action = appleScriptKeyAction(key);
         const script = `
 tell application "Terminal"
   set targetTab to missing value
@@ -148,7 +156,7 @@ tell application "Terminal"
   set frontmost of targetWindow to true
   activate
 end tell
-tell application "System Events" to keystroke "${escaped}"
+tell application "System Events" to ${action}
 return "ok"`;
 
         const { stdout } = await execFileAsync('osascript', ['-e', script]);
@@ -316,4 +324,14 @@ return "ok"`;
             throw new Error(`Terminal.app tab disappeared before Enter could be sent for TTY ${tty}`);
         }
     }
+}
+
+/**
+ * AppleScript `keystroke` only delivers typeable characters; non-typeable
+ * keys (Esc, arrows, F-keys, …) must be sent via `key code <N>`. Add more
+ * mappings here as new special keys are needed.
+ */
+function appleScriptKeyAction(key: string): string {
+    if (key === ESCAPE_BYTE) return 'key code 53';
+    return `keystroke "${escapeAppleScript(key)}"`;
 }

--- a/packages/channel-connector/src/__tests__/adapters/TelegramAdapter.test.ts
+++ b/packages/channel-connector/src/__tests__/adapters/TelegramAdapter.test.ts
@@ -14,6 +14,8 @@ vi.mock('telegraf', () => {
         }),
         telegram: {
             sendMessage: vi.fn().mockResolvedValue(undefined),
+            editMessageReplyMarkup: vi.fn().mockResolvedValue(undefined),
+            answerCbQuery: vi.fn().mockResolvedValue(undefined),
             getMe: vi.fn().mockResolvedValue({ username: 'test_bot' }),
         },
         _handlers: handlers,
@@ -29,6 +31,21 @@ vi.mock('telegraf', () => {
             };
             if (handlers['text']) {
                 await handlers['text'](ctx);
+            }
+            return ctx;
+        },
+        _triggerCallback: async (chatId: number, userId: number, data: string, messageId = 555) => {
+            const ctx = {
+                callbackQuery: {
+                    id: 'cbq-test',
+                    data,
+                    message: { message_id: messageId, chat: { id: chatId } },
+                    from: { id: userId },
+                },
+                answerCbQuery: vi.fn().mockResolvedValue(undefined),
+            };
+            if (handlers['callback_query']) {
+                await handlers['callback_query'](ctx);
             }
             return ctx;
         },
@@ -370,6 +387,88 @@ describe('TelegramAdapter', () => {
 
             // Only the HTML attempt should have happened — no fallback retry
             expect(bot.telegram.sendMessage).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('sendInlineKeyboard', () => {
+        it('sends with parse_mode HTML and inline_keyboard payload, returns message_id', async () => {
+            const bot = getMockBot();
+            (bot.telegram.sendMessage as any).mockResolvedValueOnce({ message_id: 42 });
+
+            const id = await adapter.sendInlineKeyboard('12345', '<b>hi</b>', [
+                [{ text: 'A', callbackData: 'q:1:o:0' }],
+                [{ text: 'B', callbackData: 'q:1:o:1' }],
+            ]);
+
+            expect(id).toBe(42);
+            expect(bot.telegram.sendMessage).toHaveBeenCalledWith('12345', '<b>hi</b>', {
+                parse_mode: 'HTML',
+                reply_markup: {
+                    inline_keyboard: [
+                        [{ text: 'A', callback_data: 'q:1:o:0' }],
+                        [{ text: 'B', callback_data: 'q:1:o:1' }],
+                    ],
+                },
+            });
+        });
+    });
+
+    describe('editInlineKeyboard', () => {
+        it('replaces the keyboard on an existing message', async () => {
+            const bot = getMockBot();
+            await adapter.editInlineKeyboard('12345', 99, [[{ text: '✓ A', callbackData: 'q:1:o:0' }]]);
+            expect(bot.telegram.editMessageReplyMarkup).toHaveBeenCalledWith('12345', 99, undefined, {
+                inline_keyboard: [[{ text: '✓ A', callback_data: 'q:1:o:0' }]],
+            });
+        });
+
+        it('passes undefined reply_markup to remove the keyboard', async () => {
+            const bot = getMockBot();
+            await adapter.editInlineKeyboard('12345', 99, null);
+            expect(bot.telegram.editMessageReplyMarkup).toHaveBeenCalledWith('12345', 99, undefined, undefined);
+        });
+    });
+
+    describe('answerCallback', () => {
+        it('forwards id and optional text to telegraf', async () => {
+            const bot = getMockBot();
+            await adapter.answerCallback('cbq-1', 'thanks');
+            expect(bot.telegram.answerCbQuery).toHaveBeenCalledWith('cbq-1', 'thanks');
+        });
+    });
+
+    describe('onCallback', () => {
+        it('invokes the registered handler with a normalized IncomingCallback', async () => {
+            const handler = vi.fn().mockResolvedValue(undefined);
+            adapter.onCallback(handler);
+            await adapter.start();
+
+            const bot = getMockBot();
+            await (bot as any)._triggerCallback(12345, 67890, 'q:abc:o:1', 777);
+
+            expect(handler).toHaveBeenCalledOnce();
+            const cb = handler.mock.calls[0][0];
+            expect(cb.channelType).toBe('telegram');
+            expect(cb.chatId).toBe('12345');
+            expect(cb.userId).toBe('67890');
+            expect(cb.messageId).toBe(777);
+            expect(cb.callbackData).toBe('q:abc:o:1');
+            expect(cb.callbackQueryId).toBe('cbq-test');
+        });
+
+        it('answers callbacks when no handler is registered', async () => {
+            await adapter.start();
+            const bot = getMockBot();
+            const ctx = await (bot as any)._triggerCallback(12345, 67890, 'q:x:o:0');
+            expect(ctx.answerCbQuery).toHaveBeenCalled();
+        });
+
+        it('answers with error when handler rejects', async () => {
+            adapter.onCallback(vi.fn().mockRejectedValue(new Error('boom')));
+            await adapter.start();
+            const bot = getMockBot();
+            const ctx = await (bot as any)._triggerCallback(12345, 67890, 'q:x:o:0');
+            expect(ctx.answerCbQuery).toHaveBeenCalledWith('Error');
         });
     });
 

--- a/packages/channel-connector/src/adapters/TelegramAdapter.ts
+++ b/packages/channel-connector/src/adapters/TelegramAdapter.ts
@@ -2,7 +2,7 @@ import { Telegraf } from 'telegraf';
 import { Marked, type Token, type Tokens } from 'marked';
 import type { ChannelAdapter } from './ChannelAdapter.js';
 import { markdownToTelegramHtml } from '../utils/telegramHtml.js';
-import type { IncomingMessage } from '../types.js';
+import type { IncomingMessage, InlineKeyboard, IncomingCallback, CallbackHandler } from '../types.js';
 
 export const TELEGRAM_CHANNEL_TYPE = 'telegram';
 export const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
@@ -26,6 +26,7 @@ export class TelegramAdapter implements ChannelAdapter {
 
     private bot: Telegraf;
     private messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null;
+    private callbackHandler: CallbackHandler | null = null;
     private running = false;
 
     constructor(options: TelegramAdapterOptions) {
@@ -49,6 +50,42 @@ export class TelegramAdapter implements ChannelAdapter {
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';
                 await ctx.reply(`Error processing message: ${errorMessage}`);
+            }
+        });
+
+        this.bot.on('callback_query', async (ctx) => {
+            if (!this.callbackHandler) {
+                try { await ctx.answerCbQuery(); } catch { /* ignore */ }
+                return;
+            }
+
+            const query = ctx.callbackQuery as {
+                id: string;
+                data?: string;
+                message?: { message_id: number; chat: { id: number | string } };
+                from: { id: number | string };
+            };
+
+            const data = typeof query.data === 'string' ? query.data : '';
+            if (!query.message) {
+                try { await ctx.answerCbQuery(); } catch { /* ignore */ }
+                return;
+            }
+
+            const cb: IncomingCallback = {
+                channelType: TELEGRAM_CHANNEL_TYPE,
+                chatId: String(query.message.chat.id),
+                userId: String(query.from.id),
+                messageId: query.message.message_id,
+                callbackData: data,
+                callbackQueryId: query.id,
+                timestamp: new Date(),
+            };
+
+            try {
+                await this.callbackHandler(cb);
+            } catch {
+                try { await ctx.answerCbQuery('Error'); } catch { /* ignore */ }
             }
         });
 
@@ -98,9 +135,48 @@ export class TelegramAdapter implements ChannelAdapter {
         this.messageHandler = handler;
     }
 
+    onCallback(handler: CallbackHandler): void {
+        this.callbackHandler = handler;
+    }
+
+    /**
+     * Send a message with an inline keyboard. `html` is sent verbatim with
+     * parse_mode=HTML — callers must pre-escape any user-controlled fields.
+     * Returns the Telegram message_id of the sent message.
+     */
+    async sendInlineKeyboard(chatId: string, html: string, keyboard: InlineKeyboard): Promise<number> {
+        const result = await this.bot.telegram.sendMessage(chatId, html, {
+            parse_mode: TELEGRAM_PARSE_MODE,
+            reply_markup: { inline_keyboard: toTelegrafKeyboard(keyboard) },
+        }) as { message_id: number };
+        return result.message_id;
+    }
+
+    /**
+     * Replace the inline keyboard on an existing message. Pass `null` to remove
+     * the keyboard entirely.
+     */
+    async editInlineKeyboard(chatId: string, messageId: number, keyboard: InlineKeyboard | null): Promise<void> {
+        await this.bot.telegram.editMessageReplyMarkup(chatId, messageId, undefined, keyboard
+            ? { inline_keyboard: toTelegrafKeyboard(keyboard) }
+            : undefined);
+    }
+
+    /**
+     * Acknowledge a callback_query. Without this Telegram leaves a spinner on
+     * the tapped button. Pass `text` to show a transient toast.
+     */
+    async answerCallback(callbackQueryId: string, text?: string): Promise<void> {
+        await this.bot.telegram.answerCbQuery(callbackQueryId, text);
+    }
+
     async isHealthy(): Promise<boolean> {
         return this.running;
     }
+}
+
+function toTelegrafKeyboard(keyboard: InlineKeyboard): { text: string; callback_data: string }[][] {
+    return keyboard.map((row) => row.map((btn) => ({ text: btn.text, callback_data: btn.callbackData })));
 }
 
 function isParseEntitiesError(error: unknown): boolean {

--- a/packages/channel-connector/src/index.ts
+++ b/packages/channel-connector/src/index.ts
@@ -12,4 +12,8 @@ export type {
     ChannelEntry,
     ChannelType,
     TelegramConfig,
+    InlineKeyboardButton,
+    InlineKeyboard,
+    IncomingCallback,
+    CallbackHandler,
 } from './types.js';

--- a/packages/channel-connector/src/types.ts
+++ b/packages/channel-connector/src/types.ts
@@ -47,3 +47,34 @@ export interface TelegramConfig {
     botUsername: string;
     authorizedChatId?: number;
 }
+
+/**
+ * A single button in a Telegram-style inline keyboard.
+ */
+export interface InlineKeyboardButton {
+    text: string;
+    callbackData: string;
+}
+
+/**
+ * An inline keyboard layout: rows of buttons.
+ */
+export type InlineKeyboard = InlineKeyboardButton[][];
+
+/**
+ * An inline-keyboard tap delivered as a callback_query.
+ */
+export interface IncomingCallback {
+    channelType: string;
+    chatId: string;
+    userId: string;
+    messageId: number;
+    callbackData: string;
+    callbackQueryId: string;
+    timestamp: Date;
+}
+
+/**
+ * Handler for inline-keyboard taps.
+ */
+export type CallbackHandler = (callback: IncomingCallback) => Promise<void>;

--- a/packages/cli/src/__tests__/commands/channel.test.ts
+++ b/packages/cli/src/__tests__/commands/channel.test.ts
@@ -40,7 +40,11 @@ const mockTerminalFocusManager = {
 };
 const mockTelegramAdapter = {
     onMessage: vi.fn(),
+    onCallback: vi.fn(),
     sendMessage: vi.fn<() => Promise<void>>(),
+    sendInlineKeyboard: vi.fn<() => Promise<number>>(),
+    editInlineKeyboard: vi.fn<() => Promise<void>>(),
+    answerCallback: vi.fn<() => Promise<void>>(),
 };
 const mockChannelService = {
     resolveConnectChannelName: vi.fn((name?: string) => name ?? 'telegram'),

--- a/packages/cli/src/__tests__/services/channel/ask-user-question.test.ts
+++ b/packages/cli/src/__tests__/services/channel/ask-user-question.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    AskUserQuestionService,
+    buildKeyboard,
+    escapeHtml,
+    formatAskUserQuestionBody,
+    parseAskUserQuestionInput,
+    type KeyboardChannel,
+    type QuestionSpec,
+} from '../../../services/channel/ask-user-question.js';
+import type { IncomingCallback } from '@ai-devkit/channel-connector';
+
+const baseCallback = (data: string): IncomingCallback => ({
+    channelType: 'telegram',
+    chatId: 'chat-1',
+    userId: 'user-1',
+    messageId: 1001,
+    callbackData: data,
+    callbackQueryId: 'cbq-1',
+    timestamp: new Date(0),
+});
+
+function makeChannel(): KeyboardChannel & {
+    sendInlineKeyboard: ReturnType<typeof vi.fn>;
+    editInlineKeyboard: ReturnType<typeof vi.fn>;
+    answerCallback: ReturnType<typeof vi.fn>;
+} {
+    let nextMessageId = 1000;
+    return {
+        sendInlineKeyboard: vi.fn().mockImplementation(async () => ++nextMessageId),
+        editInlineKeyboard: vi.fn().mockResolvedValue(undefined),
+        answerCallback: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+describe('parseAskUserQuestionInput', () => {
+    it('parses a single-select single-question payload', () => {
+        const parsed = parseAskUserQuestionInput({
+            questions: [{
+                question: 'Pick one',
+                header: 'Next action',
+                multiSelect: false,
+                options: [
+                    { label: 'A', description: 'first' },
+                    { label: 'B' },
+                ],
+            }],
+        });
+        expect(parsed).toEqual({
+            question: 'Pick one',
+            header: 'Next action',
+            options: [
+                { label: 'A', description: 'first' },
+                { label: 'B', description: undefined },
+            ],
+        });
+    });
+
+    it('rejects multi-select payloads (fallback)', () => {
+        expect(parseAskUserQuestionInput({
+            questions: [{
+                question: 'q', multiSelect: true, options: [{ label: 'A' }],
+            }],
+        })).toBeNull();
+    });
+
+    it('rejects multi-question payloads (fallback)', () => {
+        expect(parseAskUserQuestionInput({
+            questions: [
+                { question: 'q1', options: [{ label: 'A' }] },
+                { question: 'q2', options: [{ label: 'B' }] },
+            ],
+        })).toBeNull();
+    });
+
+    it('returns null when `questions` is missing', () => {
+        expect(parseAskUserQuestionInput({ question: 'x' })).toBeNull();
+    });
+
+    it('returns null when an option has no label', () => {
+        expect(parseAskUserQuestionInput({
+            questions: [{ question: 'q', options: [{}] }],
+        })).toBeNull();
+    });
+
+    it('returns null when options is empty', () => {
+        expect(parseAskUserQuestionInput({
+            questions: [{ question: 'q', options: [] }],
+        })).toBeNull();
+    });
+});
+
+describe('escapeHtml', () => {
+    it('escapes <, >, &, "', () => {
+        expect(escapeHtml('a < b & c > "d"')).toBe('a &lt; b &amp; c &gt; &quot;d&quot;');
+    });
+});
+
+describe('formatAskUserQuestionBody', () => {
+    const spec: QuestionSpec = {
+        question: 'Pick',
+        header: 'Choose',
+        options: [
+            { label: 'Alpha', description: 'first' },
+            { label: 'Beta' },
+        ],
+    };
+
+    it('includes header, question, and numbered options with descriptions', () => {
+        const out = formatAskUserQuestionBody(spec);
+        expect(out).toContain('<b>Choose</b>');
+        expect(out).toContain('Pick');
+        expect(out).toContain('<b>1.</b> <b>Alpha</b> — <i>first</i>');
+        expect(out).toContain('<b>2.</b> <b>Beta</b>');
+    });
+
+    it('omits header line when header is undefined', () => {
+        const out = formatAskUserQuestionBody({ ...spec, header: undefined });
+        expect(out).not.toContain('<b>Choose</b>');
+        expect(out.split('\n')[0]).toBe('Pick');
+    });
+
+    it('html-escapes user-controlled fields', () => {
+        const out = formatAskUserQuestionBody({
+            question: 'Pick <one>',
+            header: '<script>',
+            options: [{ label: 'A & B', description: '<i>' }],
+        });
+        expect(out).toContain('Pick &lt;one&gt;');
+        expect(out).toContain('&lt;script&gt;');
+        expect(out).toContain('A &amp; B');
+        expect(out).toContain('&lt;i&gt;');
+    });
+});
+
+describe('buildKeyboard', () => {
+    const spec: QuestionSpec = {
+        question: 'q',
+        options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }],
+    };
+
+    it('renders one numbered button per option, one row each', () => {
+        const kb = buildKeyboard('abc', spec);
+        expect(kb).toHaveLength(4);
+        expect(kb[0][0]).toEqual({ text: '1. A', callbackData: 'q:abc:o:0' });
+        expect(kb[3][0]).toEqual({ text: '4. D', callbackData: 'q:abc:o:3' });
+    });
+
+    it('keeps every callback_data ≤ 64 bytes', () => {
+        const kb = buildKeyboard('zzzzzzzz', spec);
+        for (const row of kb) for (const btn of row) {
+            expect(Buffer.byteLength(btn.callbackData, 'utf8')).toBeLessThanOrEqual(64);
+        }
+    });
+});
+
+describe('AskUserQuestionService', () => {
+    let channel: ReturnType<typeof makeChannel>;
+    let sendToAgent: ReturnType<typeof vi.fn>;
+    let svc: AskUserQuestionService;
+
+    beforeEach(() => {
+        channel = makeChannel();
+        sendToAgent = vi.fn().mockResolvedValue(undefined);
+        svc = new AskUserQuestionService(channel, sendToAgent);
+    });
+
+    it('sends digit key (optionIdx + 1) when option is tapped', async () => {
+        const handled = await svc.tryHandle({
+            questions: [{
+                question: 'Pick',
+                multiSelect: false,
+                options: [{ label: 'Alpha' }, { label: 'Beta' }, { label: 'Gamma' }],
+            }],
+        }, 'chat-1');
+        expect(handled).toBe(true);
+        const kb = channel.sendInlineKeyboard.mock.calls[0][2] as Array<Array<{ callbackData: string }>>;
+
+        await svc.handleCallback(baseCallback(kb[1][0].callbackData));
+
+        expect(sendToAgent).toHaveBeenCalledWith('2');
+    });
+
+    it('removes the keyboard after the tap', async () => {
+        await svc.tryHandle({
+            questions: [{ question: 'q', multiSelect: false, options: [{ label: 'A' }] }],
+        }, 'chat-1');
+        const kb = channel.sendInlineKeyboard.mock.calls[0][2] as Array<Array<{ callbackData: string }>>;
+        const sentMessageId = await channel.sendInlineKeyboard.mock.results[0].value;
+
+        await svc.handleCallback(baseCallback(kb[0][0].callbackData));
+
+        expect(channel.editInlineKeyboard).toHaveBeenCalledWith('chat-1', sentMessageId, null);
+    });
+
+    it('shows toast with the chosen label', async () => {
+        await svc.tryHandle({
+            questions: [{ question: 'q', multiSelect: false, options: [{ label: 'Alpha' }] }],
+        }, 'chat-1');
+        const kb = channel.sendInlineKeyboard.mock.calls[0][2] as Array<Array<{ callbackData: string }>>;
+        await svc.handleCallback(baseCallback(kb[0][0].callbackData));
+        expect(channel.answerCallback).toHaveBeenCalledWith('cbq-1', 'Alpha');
+    });
+
+    it('returns false on malformed payload (caller falls back)', async () => {
+        const handled = await svc.tryHandle({ question: 'plain' }, 'chat-1');
+        expect(handled).toBe(false);
+        expect(channel.sendInlineKeyboard).not.toHaveBeenCalled();
+    });
+
+    it('returns false on multi-select payload (caller falls back)', async () => {
+        const handled = await svc.tryHandle({
+            questions: [{ question: 'q', multiSelect: true, options: [{ label: 'A' }] }],
+        }, 'chat-1');
+        expect(handled).toBe(false);
+        expect(channel.sendInlineKeyboard).not.toHaveBeenCalled();
+    });
+
+    it('returns false on multi-question payload (caller falls back)', async () => {
+        const handled = await svc.tryHandle({
+            questions: [
+                { question: 'q1', options: [{ label: 'A' }] },
+                { question: 'q2', options: [{ label: 'B' }] },
+            ],
+        }, 'chat-1');
+        expect(handled).toBe(false);
+        expect(channel.sendInlineKeyboard).not.toHaveBeenCalled();
+    });
+
+    it('shows "Question expired" toast on unknown questionId', async () => {
+        await svc.handleCallback(baseCallback('q:zz:o:0'));
+        expect(channel.answerCallback).toHaveBeenCalledWith('cbq-1', 'Question expired');
+        expect(sendToAgent).not.toHaveBeenCalled();
+    });
+
+    it('ignores callback with mismatched chatId', async () => {
+        await svc.tryHandle({
+            questions: [{ question: 'q', multiSelect: false, options: [{ label: 'A' }] }],
+        }, 'chat-1');
+        const data = (channel.sendInlineKeyboard.mock.calls[0][2] as Array<Array<{ callbackData: string }>>)[0][0].callbackData;
+        await svc.handleCallback({ ...baseCallback(data), chatId: 'someone-else' });
+        expect(sendToAgent).not.toHaveBeenCalled();
+    });
+
+    it('ignores callbacks with malformed data', async () => {
+        await svc.handleCallback(baseCallback('garbage'));
+        expect(channel.answerCallback).toHaveBeenCalledWith('cbq-1', undefined);
+        expect(sendToAgent).not.toHaveBeenCalled();
+    });
+
+    it('ignores callbacks with out-of-range option index', async () => {
+        await svc.tryHandle({
+            questions: [{ question: 'q', multiSelect: false, options: [{ label: 'A' }] }],
+        }, 'chat-1');
+        await svc.handleCallback(baseCallback('q:1:o:5'));
+        expect(sendToAgent).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/src/__tests__/services/channel/ask-user-question.test.ts
+++ b/packages/cli/src/__tests__/services/channel/ask-user-question.test.ts
@@ -49,6 +49,7 @@ describe('parseAskUserQuestionInput', () => {
         expect(parsed).toEqual({
             question: 'Pick one',
             header: 'Next action',
+            multiSelect: false,
             options: [
                 { label: 'A', description: 'first' },
                 { label: 'B', description: undefined },
@@ -56,12 +57,16 @@ describe('parseAskUserQuestionInput', () => {
         });
     });
 
-    it('rejects multi-select payloads (fallback)', () => {
-        expect(parseAskUserQuestionInput({
+    it('parses a multi-select single-question payload with multiSelect=true', () => {
+        const parsed = parseAskUserQuestionInput({
             questions: [{
-                question: 'q', multiSelect: true, options: [{ label: 'A' }],
+                question: 'Pick many',
+                multiSelect: true,
+                options: [{ label: 'A' }, { label: 'B' }],
             }],
-        })).toBeNull();
+        });
+        expect(parsed?.multiSelect).toBe(true);
+        expect(parsed?.options).toHaveLength(2);
     });
 
     it('rejects multi-question payloads (fallback)', () => {
@@ -100,6 +105,7 @@ describe('formatAskUserQuestionBody', () => {
     const spec: QuestionSpec = {
         question: 'Pick',
         header: 'Choose',
+        multiSelect: false,
         options: [
             { label: 'Alpha', description: 'first' },
             { label: 'Beta' },
@@ -112,6 +118,7 @@ describe('formatAskUserQuestionBody', () => {
         expect(out).toContain('Pick');
         expect(out).toContain('<b>1.</b> <b>Alpha</b> — <i>first</i>');
         expect(out).toContain('<b>2.</b> <b>Beta</b>');
+        expect(out).not.toContain('Multi-select');
     });
 
     it('omits header line when header is undefined', () => {
@@ -120,10 +127,16 @@ describe('formatAskUserQuestionBody', () => {
         expect(out.split('\n')[0]).toBe('Pick');
     });
 
+    it('adds reply-in-chat hint for multi-select', () => {
+        const out = formatAskUserQuestionBody({ ...spec, multiSelect: true });
+        expect(out).toContain('Multi-select — tap Skip, and answer in chat.');
+    });
+
     it('html-escapes user-controlled fields', () => {
         const out = formatAskUserQuestionBody({
             question: 'Pick <one>',
             header: '<script>',
+            multiSelect: false,
             options: [{ label: 'A & B', description: '<i>' }],
         });
         expect(out).toContain('Pick &lt;one&gt;');
@@ -136,14 +149,22 @@ describe('formatAskUserQuestionBody', () => {
 describe('buildKeyboard', () => {
     const spec: QuestionSpec = {
         question: 'q',
+        multiSelect: false,
         options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }],
     };
 
-    it('renders one numbered button per option, one row each', () => {
+    it('renders one numbered button per option plus a Skip row (single-select)', () => {
         const kb = buildKeyboard('abc', spec);
-        expect(kb).toHaveLength(4);
+        expect(kb).toHaveLength(5);
         expect(kb[0][0]).toEqual({ text: '1. A', callbackData: 'q:abc:o:0' });
         expect(kb[3][0]).toEqual({ text: '4. D', callbackData: 'q:abc:o:3' });
+        expect(kb[4][0]).toEqual({ text: 'Skip', callbackData: 'q:abc:skip' });
+    });
+
+    it('renders only the Skip row for multi-select', () => {
+        const kb = buildKeyboard('abc', { ...spec, multiSelect: true });
+        expect(kb).toHaveLength(1);
+        expect(kb[0][0]).toEqual({ text: 'Skip', callbackData: 'q:abc:skip' });
     });
 
     it('keeps every callback_data ≤ 64 bytes', () => {
@@ -208,12 +229,16 @@ describe('AskUserQuestionService', () => {
         expect(channel.sendInlineKeyboard).not.toHaveBeenCalled();
     });
 
-    it('returns false on multi-select payload (caller falls back)', async () => {
+    it('handles multi-select payload by rendering a Skip-only keyboard', async () => {
         const handled = await svc.tryHandle({
-            questions: [{ question: 'q', multiSelect: true, options: [{ label: 'A' }] }],
+            questions: [{ question: 'Pick many', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] }],
         }, 'chat-1');
-        expect(handled).toBe(false);
-        expect(channel.sendInlineKeyboard).not.toHaveBeenCalled();
+        expect(handled).toBe(true);
+        expect(channel.sendInlineKeyboard).toHaveBeenCalledOnce();
+        const [, html, kb] = channel.sendInlineKeyboard.mock.calls[0];
+        expect(html).toContain('Multi-select');
+        expect(kb).toHaveLength(1);
+        expect((kb as Array<Array<{ text: string }>>)[0][0].text).toBe('Skip');
     });
 
     it('returns false on multi-question payload (caller falls back)', async () => {
@@ -246,6 +271,25 @@ describe('AskUserQuestionService', () => {
         await svc.handleCallback(baseCallback('garbage'));
         expect(channel.answerCallback).toHaveBeenCalledWith('cbq-1', undefined);
         expect(sendToAgent).not.toHaveBeenCalled();
+    });
+
+    it('sends Esc byte (\\x1b) and "Skipped" toast when Skip is tapped', async () => {
+        await svc.tryHandle({
+            questions: [{
+                question: 'Pick',
+                multiSelect: false,
+                options: [{ label: 'Alpha' }, { label: 'Beta' }],
+            }],
+        }, 'chat-1');
+        const kb = channel.sendInlineKeyboard.mock.calls[0][2] as Array<Array<{ text: string; callbackData: string }>>;
+        const skipData = kb[kb.length - 1][0].callbackData;
+        expect(skipData).toBe('q:1:skip');
+
+        await svc.handleCallback(baseCallback(skipData));
+
+        expect(sendToAgent).toHaveBeenCalledWith('\x1b');
+        expect(channel.answerCallback).toHaveBeenCalledWith('cbq-1', 'Skipped');
+        expect(channel.editInlineKeyboard).toHaveBeenCalledWith('chat-1', expect.any(Number), null);
     });
 
     it('ignores callbacks with out-of-range option index', async () => {

--- a/packages/cli/src/__tests__/services/channel/channel-runner.test.ts
+++ b/packages/cli/src/__tests__/services/channel/channel-runner.test.ts
@@ -202,11 +202,14 @@ describe('startOutputPolling — agent requests', () => {
         expect(htmlArg).toContain('What would you like to do next?');
         expect(htmlArg).toContain('Continue the bug fix');
         const kb = kbArg as Array<Array<{ text: string; callbackData: string }>>;
-        expect(kb).toHaveLength(2);
+        // 2 option rows + 1 Skip row
+        expect(kb).toHaveLength(3);
         expect(kb[0][0].callbackData).toMatch(/^q:[a-z0-9]+:o:0$/);
+        expect(kb[2][0].text).toBe('Skip');
+        expect(kb[2][0].callbackData).toMatch(/^q:[a-z0-9]+:skip$/);
     });
 
-    it('falls back to plain [Question] text for multi-select payloads (deliberately unsupported)', async () => {
+    it('routes AskUserQuestion multi-select payload with Skip-only keyboard', async () => {
         const multiSelectInput = {
             questions: [{
                 question: 'Which programming languages do you work with most?',
@@ -216,9 +219,9 @@ describe('startOutputPolling — agent requests', () => {
         };
         const telegram = {
             ...makeTelegram(),
-            sendInlineKeyboard: vi.fn(),
-            editInlineKeyboard: vi.fn(),
-            answerCallback: vi.fn(),
+            sendInlineKeyboard: vi.fn().mockResolvedValue(8),
+            editInlineKeyboard: vi.fn().mockResolvedValue(undefined),
+            answerCallback: vi.fn().mockResolvedValue(undefined),
         };
         const askQuestion = new AskUserQuestionService(telegram as never, vi.fn().mockResolvedValue(undefined));
         const interval = startOutputPolling(telegram as never, makeAdapter() as never, makeAgent(), chatIdRef, {
@@ -229,10 +232,14 @@ describe('startOutputPolling — agent requests', () => {
         await vi.advanceTimersByTimeAsync(2100);
         clearInterval(interval);
 
-        expect(telegram.sendInlineKeyboard).not.toHaveBeenCalled();
-        expect(telegram.sendMessage).toHaveBeenCalledOnce();
-        const [, message] = (telegram.sendMessage as Mock).mock.calls[0];
-        expect(message).toContain('[Question]');
+        expect(telegram.sendMessage).not.toHaveBeenCalled();
+        expect(telegram.sendInlineKeyboard).toHaveBeenCalledOnce();
+        const [, html, kb] = telegram.sendInlineKeyboard.mock.calls[0];
+        expect(html).toContain('Multi-select');
+        const keyboard = kb as Array<Array<{ text: string; callbackData: string }>>;
+        expect(keyboard).toHaveLength(1);
+        expect(keyboard[0][0].text).toBe('Skip');
+        expect(keyboard[0][0].callbackData).toMatch(/^q:[a-z0-9]+:skip$/);
     });
 
     it('falls back to plain [Question] text when AskUserQuestion payload is malformed', async () => {

--- a/packages/cli/src/__tests__/services/channel/channel-runner.test.ts
+++ b/packages/cli/src/__tests__/services/channel/channel-runner.test.ts
@@ -5,6 +5,7 @@ import { vi, type Mock } from 'vitest';
 import type { AgentInfo, AgentRequest } from '@ai-devkit/agent-manager';
 import { AgentStatus, writeAgentRequest } from '@ai-devkit/agent-manager';
 import { startOutputPolling } from '../../../services/channel/channel-runner.js';
+import { AskUserQuestionService } from '../../../services/channel/ask-user-question.js';
 
 function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
     return {
@@ -167,8 +168,7 @@ describe('startOutputPolling — agent requests', () => {
         expect(calls[1][1]).toContain('[Tool prompt]');
     });
 
-    // Exact fixtures observed from live Telegram test — lock raw output (formatting is a future PR)
-    it('forwards AskUserQuestion single-select questions-array payload as raw [Question] JSON', async () => {
+    it('routes AskUserQuestion single-select payload to inline-keyboard service', async () => {
         const singleSelectInput = {
             questions: [{
                 question: 'What would you like to do next?',
@@ -176,53 +176,89 @@ describe('startOutputPolling — agent requests', () => {
                 options: [
                     { label: 'Continue the bug fix', description: 'Pick up where we left off on fixing the bug' },
                     { label: 'Start something new', description: 'Begin a fresh task or feature' },
-                    { label: 'Review code', description: 'Look over existing code for issues or improvements' },
-                    { label: 'Chat / explore ideas', description: 'Discuss approaches or brainstorm solutions' },
                 ],
                 multiSelect: false,
             }],
         };
-        const telegram = makeTelegram();
-        const interval = startOutputPolling(telegram as never, makeAdapter() as never, makeAgent(), chatIdRef, { homeDir });
+        const telegram = {
+            ...makeTelegram(),
+            sendInlineKeyboard: vi.fn().mockResolvedValue(42),
+            editInlineKeyboard: vi.fn().mockResolvedValue(undefined),
+            answerCallback: vi.fn().mockResolvedValue(undefined),
+        };
+        const askQuestion = new AskUserQuestionService(telegram as never, vi.fn().mockResolvedValue(undefined));
+        const interval = startOutputPolling(telegram as never, makeAdapter() as never, makeAgent(), chatIdRef, {
+            homeDir,
+            askUserQuestionService: askQuestion,
+        });
         writeAgentRequest(homeDir, makeRequest({ toolName: 'AskUserQuestion', toolInput: singleSelectInput }));
         await vi.advanceTimersByTimeAsync(2100);
         clearInterval(interval);
 
-        expect(telegram.sendMessage).toHaveBeenCalledOnce();
-        const [, message] = (telegram.sendMessage as Mock).mock.calls[0];
-        // Raw output: no direct question field → JSON.stringify(toolInput)
-        expect(message).toMatch(/^\[Question\]/);
-        expect(message).toContain('"questions"');
-        expect(message).toContain('What would you like to do next?');
-        expect(message).toContain('Continue the bug fix');
+        expect(telegram.sendInlineKeyboard).toHaveBeenCalledOnce();
+        expect(telegram.sendMessage).not.toHaveBeenCalled();
+        const [chatArg, htmlArg, kbArg] = telegram.sendInlineKeyboard.mock.calls[0];
+        expect(chatArg).toBe('chat-123');
+        expect(htmlArg).toContain('What would you like to do next?');
+        expect(htmlArg).toContain('Continue the bug fix');
+        const kb = kbArg as Array<Array<{ text: string; callbackData: string }>>;
+        expect(kb).toHaveLength(2);
+        expect(kb[0][0].callbackData).toMatch(/^q:[a-z0-9]+:o:0$/);
     });
 
-    it('forwards AskUserQuestion multi-select questions-array payload as raw [Question] JSON', async () => {
+    it('falls back to plain [Question] text for multi-select payloads (deliberately unsupported)', async () => {
         const multiSelectInput = {
             questions: [{
                 question: 'Which programming languages do you work with most?',
-                header: 'Languages',
-                options: [
-                    { label: 'TypeScript', description: 'Typed JavaScript for frontend or backend' },
-                    { label: 'Python', description: 'Scripting, data, or backend services' },
-                    { label: 'Go', description: 'High-performance backend services' },
-                    { label: 'Rust', description: 'Systems programming' },
-                ],
+                options: [{ label: 'TypeScript' }, { label: 'Python' }],
                 multiSelect: true,
             }],
         };
-        const telegram = makeTelegram();
-        const interval = startOutputPolling(telegram as never, makeAdapter() as never, makeAgent(), chatIdRef, { homeDir });
+        const telegram = {
+            ...makeTelegram(),
+            sendInlineKeyboard: vi.fn(),
+            editInlineKeyboard: vi.fn(),
+            answerCallback: vi.fn(),
+        };
+        const askQuestion = new AskUserQuestionService(telegram as never, vi.fn().mockResolvedValue(undefined));
+        const interval = startOutputPolling(telegram as never, makeAdapter() as never, makeAgent(), chatIdRef, {
+            homeDir,
+            askUserQuestionService: askQuestion,
+        });
         writeAgentRequest(homeDir, makeRequest({ toolName: 'AskUserQuestion', toolInput: multiSelectInput }));
         await vi.advanceTimersByTimeAsync(2100);
         clearInterval(interval);
 
+        expect(telegram.sendInlineKeyboard).not.toHaveBeenCalled();
         expect(telegram.sendMessage).toHaveBeenCalledOnce();
         const [, message] = (telegram.sendMessage as Mock).mock.calls[0];
-        expect(message).toMatch(/^\[Question\]/);
-        expect(message).toContain('"questions"');
-        expect(message).toContain('Which programming languages do you work with most?');
-        expect(message).toContain('TypeScript');
+        expect(message).toContain('[Question]');
+    });
+
+    it('falls back to plain [Question] text when AskUserQuestion payload is malformed', async () => {
+        const telegram = {
+            ...makeTelegram(),
+            sendInlineKeyboard: vi.fn(),
+            editInlineKeyboard: vi.fn(),
+            answerCallback: vi.fn(),
+        };
+        const askQuestion = new AskUserQuestionService(telegram as never, vi.fn().mockResolvedValue(undefined));
+        const interval = startOutputPolling(telegram as never, makeAdapter() as never, makeAgent(), chatIdRef, {
+            homeDir,
+            askUserQuestionService: askQuestion,
+        });
+        writeAgentRequest(homeDir, makeRequest({
+            toolName: 'AskUserQuestion',
+            toolInput: { question: 'How should I handle this?' },
+        }));
+        await vi.advanceTimersByTimeAsync(2100);
+        clearInterval(interval);
+
+        expect(telegram.sendInlineKeyboard).not.toHaveBeenCalled();
+        expect(telegram.sendMessage).toHaveBeenCalledOnce();
+        const [, message] = (telegram.sendMessage as Mock).mock.calls[0];
+        expect(message).toContain('[Question]');
+        expect(message).toContain('How should I handle this?');
     });
 
     it('formats AskUserQuestion with direct question field as [Question] text', async () => {

--- a/packages/cli/src/services/channel/ask-user-question.ts
+++ b/packages/cli/src/services/channel/ask-user-question.ts
@@ -1,0 +1,214 @@
+import type {
+    IncomingCallback,
+    InlineKeyboard,
+} from '@ai-devkit/channel-connector';
+import { createLogger } from '../../util/debug.js';
+import { getErrorMessage } from '../../util/text.js';
+
+const debug = createLogger('askuserquestion');
+
+export interface QuestionOption {
+    label: string;
+    description?: string;
+}
+
+export interface QuestionSpec {
+    question: string;
+    header?: string;
+    options: QuestionOption[];
+}
+
+interface ActiveSession {
+    questionId: string;
+    chatId: string;
+    spec: QuestionSpec;
+    messageId: number | null;
+}
+
+/**
+ * Subset of TelegramAdapter that this module depends on. Keeps the module
+ * easy to unit-test without spinning up a real adapter.
+ */
+export interface KeyboardChannel {
+    sendInlineKeyboard(chatId: string, html: string, keyboard: InlineKeyboard): Promise<number>;
+    editInlineKeyboard(chatId: string, messageId: number, keyboard: InlineKeyboard | null): Promise<void>;
+    answerCallback(callbackQueryId: string, text?: string): Promise<void>;
+}
+
+export type SendToAgent = (message: string) => Promise<void>;
+
+/**
+ * Parse a raw `AskUserQuestion` tool input into a normalized question spec.
+ *
+ * Returns `null` (caller falls back to plain text) when the payload is not a
+ * supported shape. We deliberately reject multi-select and multi-question
+ * payloads — driving those through the TTY picker reliably is too fragile
+ * (see feedback_askuserquestion_scope memory).
+ */
+export function parseAskUserQuestionInput(input: Record<string, unknown>): QuestionSpec | null {
+    const raw = input.questions;
+    if (!Array.isArray(raw) || raw.length !== 1) return null;
+    const q = raw[0];
+    if (!q || typeof q !== 'object') return null;
+    const qObj = q as Record<string, unknown>;
+    if (typeof qObj.question !== 'string') return null;
+    if (qObj.multiSelect === true) return null;
+    if (!Array.isArray(qObj.options) || qObj.options.length === 0) return null;
+    const options: QuestionOption[] = [];
+    for (const opt of qObj.options) {
+        if (!opt || typeof opt !== 'object') return null;
+        const optObj = opt as Record<string, unknown>;
+        if (typeof optObj.label !== 'string') return null;
+        options.push({
+            label: optObj.label,
+            description: typeof optObj.description === 'string' ? optObj.description : undefined,
+        });
+    }
+    return {
+        question: qObj.question,
+        header: typeof qObj.header === 'string' ? qObj.header : undefined,
+        options,
+    };
+}
+
+export function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+export function formatAskUserQuestionBody(spec: QuestionSpec): string {
+    const lines: string[] = [];
+    if (spec.header) {
+        lines.push(`<b>${escapeHtml(spec.header)}</b>`);
+    }
+    lines.push(escapeHtml(spec.question));
+    lines.push('');
+    spec.options.forEach((opt, idx) => {
+        const desc = opt.description ? ` — <i>${escapeHtml(opt.description)}</i>` : '';
+        lines.push(`<b>${idx + 1}.</b> <b>${escapeHtml(opt.label)}</b>${desc}`);
+    });
+    return lines.join('\n');
+}
+
+export function buildKeyboard(questionId: string, spec: QuestionSpec): InlineKeyboard {
+    return spec.options.map((opt, idx) => {
+        const key = idx + 1;
+        return [{
+            text: `${key}. ${opt.label}`,
+            callbackData: `q:${questionId}:o:${idx}`,
+        }];
+    });
+}
+
+export class AskUserQuestionService {
+    private sessions = new Map<string, ActiveSession>();
+    private nextId = 1;
+
+    constructor(
+        private readonly telegram: KeyboardChannel,
+        private readonly sendToAgent: SendToAgent,
+    ) { }
+
+    /**
+     * Try to render the given tool input as an inline-keyboard question.
+     * Returns `true` if handled, `false` if the caller should fall back to
+     * plain-text formatting (e.g. multi-select / multi-question payloads).
+     */
+    async tryHandle(toolInput: Record<string, unknown>, chatId: string): Promise<boolean> {
+        const spec = parseAskUserQuestionInput(toolInput);
+        if (!spec) return false;
+
+        const questionId = (this.nextId++).toString(36);
+        const session: ActiveSession = { questionId, chatId, spec, messageId: null };
+        this.sessions.set(questionId, session);
+        await this.render(session);
+        return true;
+    }
+
+    /**
+     * Handle an inline-keyboard tap. Resolves the option, writes its digit key
+     * (`optionIdx + 1`) to the agent's TTY, and clears the keyboard from the
+     * Telegram message.
+     */
+    async handleCallback(cb: IncomingCallback): Promise<void> {
+        const parsed = parseCallbackData(cb.callbackData);
+        if (!parsed) {
+            await this.safeAnswerCallback(cb.callbackQueryId);
+            return;
+        }
+
+        const session = this.sessions.get(parsed.questionId);
+        if (!session) {
+            await this.safeAnswerCallback(cb.callbackQueryId, 'Question expired');
+            return;
+        }
+
+        if (session.chatId !== cb.chatId) {
+            await this.safeAnswerCallback(cb.callbackQueryId);
+            return;
+        }
+
+        const spec = session.spec;
+        if (parsed.optionIdx >= spec.options.length) {
+            await this.safeAnswerCallback(cb.callbackQueryId);
+            return;
+        }
+
+        const option = spec.options[parsed.optionIdx];
+        const key = String(parsed.optionIdx + 1);
+        await this.safeAnswerCallback(cb.callbackQueryId, option.label);
+        this.sessions.delete(session.questionId);
+
+        if (session.messageId !== null) {
+            try {
+                await this.telegram.editInlineKeyboard(session.chatId, session.messageId, null);
+            } catch (error) {
+                debug(`finalize editInlineKeyboard failed: ${getErrorMessage(error)}`);
+            }
+        }
+
+        try {
+            await this.sendToAgent(key);
+        } catch (error) {
+            debug(`sendToAgent failed: ${getErrorMessage(error)}`);
+        }
+    }
+
+    private async render(session: ActiveSession): Promise<void> {
+        try {
+            session.messageId = await this.telegram.sendInlineKeyboard(
+                session.chatId,
+                formatAskUserQuestionBody(session.spec),
+                buildKeyboard(session.questionId, session.spec),
+            );
+        } catch (error) {
+            debug(`sendInlineKeyboard failed: ${getErrorMessage(error)}`);
+            this.sessions.delete(session.questionId);
+        }
+    }
+
+    private async safeAnswerCallback(callbackQueryId: string, text?: string): Promise<void> {
+        try {
+            await this.telegram.answerCallback(callbackQueryId, text);
+        } catch (error) {
+            debug(`answerCallback failed: ${getErrorMessage(error)}`);
+        }
+    }
+}
+
+interface ParsedCallback {
+    questionId: string;
+    optionIdx: number;
+}
+
+function parseCallbackData(data: string): ParsedCallback | null {
+    const parts = data.split(':');
+    if (parts.length !== 4 || parts[0] !== 'q' || parts[2] !== 'o') return null;
+    const optionIdx = Number.parseInt(parts[3], 10);
+    if (!Number.isFinite(optionIdx)) return null;
+    return { questionId: parts[1], optionIdx };
+}
+

--- a/packages/cli/src/services/channel/ask-user-question.ts
+++ b/packages/cli/src/services/channel/ask-user-question.ts
@@ -16,6 +16,7 @@ export interface QuestionSpec {
     question: string;
     header?: string;
     options: QuestionOption[];
+    multiSelect: boolean;
 }
 
 interface ActiveSession {
@@ -41,9 +42,10 @@ export type SendToAgent = (message: string) => Promise<void>;
  * Parse a raw `AskUserQuestion` tool input into a normalized question spec.
  *
  * Returns `null` (caller falls back to plain text) when the payload is not a
- * supported shape. We deliberately reject multi-select and multi-question
- * payloads — driving those through the TTY picker reliably is too fragile
- * (see feedback_askuserquestion_scope memory).
+ * supported shape. Multi-question payloads (`questions.length !== 1`) are
+ * rejected because reliably sequencing keystrokes across pickers is fragile;
+ * multi-select is supported as a Skip-or-free-text-reply flow (no numbered
+ * option buttons).
  */
 export function parseAskUserQuestionInput(input: Record<string, unknown>): QuestionSpec | null {
     const raw = input.questions;
@@ -52,7 +54,6 @@ export function parseAskUserQuestionInput(input: Record<string, unknown>): Quest
     if (!q || typeof q !== 'object') return null;
     const qObj = q as Record<string, unknown>;
     if (typeof qObj.question !== 'string') return null;
-    if (qObj.multiSelect === true) return null;
     if (!Array.isArray(qObj.options) || qObj.options.length === 0) return null;
     const options: QuestionOption[] = [];
     for (const opt of qObj.options) {
@@ -68,6 +69,7 @@ export function parseAskUserQuestionInput(input: Record<string, unknown>): Quest
         question: qObj.question,
         header: typeof qObj.header === 'string' ? qObj.header : undefined,
         options,
+        multiSelect: qObj.multiSelect === true,
     };
 }
 
@@ -90,17 +92,28 @@ export function formatAskUserQuestionBody(spec: QuestionSpec): string {
         const desc = opt.description ? ` — <i>${escapeHtml(opt.description)}</i>` : '';
         lines.push(`<b>${idx + 1}.</b> <b>${escapeHtml(opt.label)}</b>${desc}`);
     });
+    if (spec.multiSelect) {
+        lines.push('');
+        lines.push('<i>Multi-select — tap Skip, and answer in chat.</i>');
+    }
     return lines.join('\n');
 }
 
+/** Esc byte — what the `Skip` button delivers to the picker. */
+const SKIP_KEY = '\x1b';
+
 export function buildKeyboard(questionId: string, spec: QuestionSpec): InlineKeyboard {
-    return spec.options.map((opt, idx) => {
-        const key = idx + 1;
-        return [{
-            text: `${key}. ${opt.label}`,
-            callbackData: `q:${questionId}:o:${idx}`,
-        }];
-    });
+    const rows: InlineKeyboard = spec.multiSelect
+        ? []
+        : spec.options.map((opt, idx) => {
+            const key = idx + 1;
+            return [{
+                text: `${key}. ${opt.label}`,
+                callbackData: `q:${questionId}:o:${idx}`,
+            }];
+        });
+    rows.push([{ text: 'Skip', callbackData: `q:${questionId}:skip` }]);
+    return rows;
 }
 
 export class AskUserQuestionService {
@@ -129,9 +142,9 @@ export class AskUserQuestionService {
     }
 
     /**
-     * Handle an inline-keyboard tap. Resolves the option, writes its digit key
-     * (`optionIdx + 1`) to the agent's TTY, and clears the keyboard from the
-     * Telegram message.
+     * Handle an inline-keyboard tap. Resolves the option (digit key) or Skip
+     * (Esc), writes the result to the agent's TTY, and clears the keyboard
+     * from the Telegram message.
      */
     async handleCallback(cb: IncomingCallback): Promise<void> {
         const parsed = parseCallbackData(cb.callbackData);
@@ -152,14 +165,22 @@ export class AskUserQuestionService {
         }
 
         const spec = session.spec;
-        if (parsed.optionIdx >= spec.options.length) {
-            await this.safeAnswerCallback(cb.callbackQueryId);
-            return;
+        let key: string;
+        let toast: string;
+
+        if (parsed.kind === 'skip') {
+            key = SKIP_KEY;
+            toast = 'Skipped';
+        } else {
+            if (parsed.optionIdx >= spec.options.length) {
+                await this.safeAnswerCallback(cb.callbackQueryId);
+                return;
+            }
+            key = String(parsed.optionIdx + 1);
+            toast = spec.options[parsed.optionIdx].label;
         }
 
-        const option = spec.options[parsed.optionIdx];
-        const key = String(parsed.optionIdx + 1);
-        await this.safeAnswerCallback(cb.callbackQueryId, option.label);
+        await this.safeAnswerCallback(cb.callbackQueryId, toast);
         this.sessions.delete(session.questionId);
 
         if (session.messageId !== null) {
@@ -199,16 +220,22 @@ export class AskUserQuestionService {
     }
 }
 
-interface ParsedCallback {
-    questionId: string;
-    optionIdx: number;
-}
+type ParsedCallback =
+    | { kind: 'option'; questionId: string; optionIdx: number }
+    | { kind: 'skip'; questionId: string };
 
 function parseCallbackData(data: string): ParsedCallback | null {
     const parts = data.split(':');
-    if (parts.length !== 4 || parts[0] !== 'q' || parts[2] !== 'o') return null;
-    const optionIdx = Number.parseInt(parts[3], 10);
-    if (!Number.isFinite(optionIdx)) return null;
-    return { questionId: parts[1], optionIdx };
+    if (parts[0] !== 'q' || parts.length < 3) return null;
+    const questionId = parts[1];
+    if (parts.length === 4 && parts[2] === 'o') {
+        const optionIdx = Number.parseInt(parts[3], 10);
+        if (!Number.isFinite(optionIdx)) return null;
+        return { kind: 'option', questionId, optionIdx };
+    }
+    if (parts.length === 3 && parts[2] === 'skip') {
+        return { kind: 'skip', questionId };
+    }
+    return null;
 }
 

--- a/packages/cli/src/services/channel/channel-runner.ts
+++ b/packages/cli/src/services/channel/channel-runner.ts
@@ -26,6 +26,7 @@ import { getErrorMessage } from '../../util/text.js';
 import { createLogger } from '../../util/debug.js';
 import { select } from '@inquirer/prompts';
 import { ChannelService } from './channel.service.js';
+import { AskUserQuestionService } from './ask-user-question.js';
 
 const debug = createLogger('channel');
 const AGENT_POLL_INTERVAL_MS = 2000;
@@ -123,6 +124,7 @@ function formatPromptMessage(toolName: string, toolInput: Record<string, unknown
 
 export interface OutputPollingOptions {
     homeDir?: string;
+    askUserQuestionService?: AskUserQuestionService;
 }
 
 export function startOutputPolling(
@@ -132,6 +134,7 @@ export function startOutputPolling(
     chatIdRef: { value: string | null },
     options: OutputPollingOptions = {},
 ): NodeJS.Timeout {
+    const askQuestion = options.askUserQuestionService;
     const home = options.homeDir ?? homedir();
     let lastAgentRequestTimestamp: string | undefined;
     let lastMessageCount = 0;
@@ -222,8 +225,14 @@ export function startOutputPolling(
                 debug(`New agent request: ${agentRequest.toolName} at ${agentRequest.timestamp}`);
                 lastAgentRequestTimestamp = agentRequest.timestamp;
                 try {
-                    await telegram.sendMessage(chatIdRef.value, formatPromptMessage(agentRequest.toolName, agentRequest.toolInput));
-                    debug(`Sent agent request notification to Telegram`);
+                    let handled = false;
+                    if (askQuestion && agentRequest.toolName === 'AskUserQuestion') {
+                        handled = await askQuestion.tryHandle(agentRequest.toolInput, chatIdRef.value);
+                    }
+                    if (!handled) {
+                        await telegram.sendMessage(chatIdRef.value, formatPromptMessage(agentRequest.toolName, agentRequest.toolInput));
+                    }
+                    debug(`Sent agent request notification to Telegram (handled=${handled})`);
                 } catch (error: unknown) {
                     debug(`sendMessage (agent request) failed: ${getErrorMessage(error)}`);
                 }
@@ -321,8 +330,24 @@ export async function runChannelBridge(input: RunChannelBridgeInput): Promise<vo
             },
         });
     });
+    const askUserQuestionService = new AskUserQuestionService(
+        telegram,
+        // AskUserQuestion picker reacts to raw digit keystrokes (1-N), not to
+        // pasted text. Use sendKey to bypass bracketed paste / auto-Enter.
+        (key) => TtyWriter.sendKey(terminalLocation, key),
+    );
+    telegram.onCallback(async (cb) => {
+        if (cb.chatId !== chatIdRef.value) {
+            debug(`callback rejected: chatId=${cb.chatId} not authorized`);
+            return;
+        }
+        await askUserQuestionService.handleCallback(cb);
+    });
+
     debug(`Starting output polling (interval: ${AGENT_POLL_INTERVAL_MS}ms)`);
-    const pollInterval = startOutputPolling(telegram, agentAdapter, agent, chatIdRef);
+    const pollInterval = startOutputPolling(telegram, agentAdapter, agent, chatIdRef, {
+        askUserQuestionService,
+    });
 
     const manager = new ChannelManager();
     manager.registerAdapter(telegram);


### PR DESCRIPTION
## Summary
- Replace raw-JSON forwarding of `AskUserQuestion` tool requests with a Telegram inline keyboard that resolves to a single-digit keystroke on the agent's TTY.
- Scope deliberately narrowed to **single-select, single-question** payloads. 
- New `TtyWriter.sendKey` delivers the answer as a raw keystroke (bypassing bracketed paste + auto-Enter) so the picker captures it as a hotkey.