### PR TITLE
feat(agent-manager): add WezTerm terminal support

### DIFF
--- a/docs/ai/design/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/design/2026-06-29-feature-wezterm-support.md
@@ -48,8 +48,9 @@ graph TD
 **How do components communicate?**
 
 Discovery and control happen via `execFile('wezterm', [...])` (promisified). No
-shell is used; the message bytes are passed as a discrete argv element, so
-there is no string interpolation and no injection surface.
+shell is used, so there is no string interpolation. Prompt text is written to
+`send-text` over stdin instead of argv, keeping message contents out of local
+process listings while preserving shell-injection safety.
 
 - Discover pane: `wezterm cli list --format json`
   - Parse JSON array; find entry whose **`tty_name`** equals the target
@@ -57,7 +58,8 @@ there is no string interpolation and no injection surface.
   - Return `{ type: WEZTERM, identifier: String(pane_id), tty }`.
 - Focus pane: `wezterm cli activate-pane --pane-id <id>` → success on zero exit.
 - Send text: two explicit `wezterm cli send-text --pane-id <id>` calls.
-  - Step 1 (text): the message as a positional argv element (`send-text --pane-id <id> <message>`).
+  - Step 1 (text): `send-text --pane-id <id>` with the message body written to
+    stdin.
   - Step 2 (Enter): a single carriage return byte (0x0d) as an argv element
     with `--no-paste`. The equivalent shell command is
     `wezterm cli send-text --pane-id <id> --no-paste $'\x0d'` (note the
@@ -81,9 +83,8 @@ there is no string interpolation and no injection surface.
     `agent open --debug` command can show the decision path.
 - `src/terminal/TtyWriter.ts`
   - `send`: add `WEZTERM` case → `sendViaWezterm(identifier, message)`.
-  - `sendViaWezterm`: two `execFileAsync` calls — text as an argv element,
-    then a CR byte (0x0d) with `--no-paste` — 150 ms apart; throws a
-    descriptive error on failure.
+  - `sendViaWezterm`: text via stdin, then a CR byte (0x0d) with `--no-paste`
+    — 150 ms apart; throws a descriptive error on failure.
 - `src/terminal/index.ts`: no change (`TerminalType` already re-exported).
 - CLI: no change — it consumes the abstract API only.
 
@@ -112,9 +113,9 @@ there is no string interpolation and no injection surface.
 
 - Performance: one extra short-lived subprocess probe on `findTerminal` only when
   earlier probes miss; same O(processes) cost profile as today.
-- Security: no shell invocation; the message is passed as a discrete argv
-  element to `execFile`, so it is delivered verbatim regardless of shell
-  metacharacters (no injection surface), and Enter is a fixed CR byte.
+- Security: no shell invocation; the message is written through stdin so it is
+  not exposed through process arguments, shell metacharacters remain data, and
+  Enter is a fixed CR byte.
 - Reliability: every WezTerm path is wrapped so a missing binary, a failed JSON
   parse, or a non-running instance returns `null`/`false`/throws-with-context
   instead of crashing the CLI.

--- a/docs/ai/design/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/design/2026-06-29-feature-wezterm-support.md
@@ -1,0 +1,121 @@
+---
+phase: design
+title: System Design & Architecture
+description: Define the technical architecture, components, and data models
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+**What is the high-level system structure?**
+
+Terminal control is isolated in `packages/agent-manager/src/terminal/`. The CLI
+(`agent open`, `agent send`, channel bridges) only depends on three abstractions:
+`TerminalFocusManager.findTerminal/focusTerminal` and `TtyWriter.send`. Adding a
+new emulator means extending these three — no CLI change is required.
+
+```mermaid
+graph TD
+  CLI["ai-devkit CLI<br/>agent open / send / channel"] -->|pid| TFM["TerminalFocusManager.findTerminal"]
+  TFM -->|tty| TMUX["tmux (innermost)"]
+  TFM -->|tty| WEZ["wezterm cli list --format json  (NEW)"]
+  TFM -->|tty| ITERM["iTerm2 (AppleScript)"]
+  TFM -->|tty| TERMAPP["Terminal.app (AppleScript)"]
+  TFM -->|TerminalLocation| Focus["focusTerminal"]
+  Focus --> WEZF["wezterm cli focus-pane --pane-id  (NEW)"]
+  CLI -->|location+msg| TW["TtyWriter.send"]
+  TW --> WEZS["wezterm cli send-text --pane-id  (NEW)"]
+```
+
+- Key components
+  - `TerminalType` enum — gains a `WEZTERM` member.
+  - `TerminalFocusManager` — gains WezTerm discovery + focus.
+  - `TtyWriter` — gains a WezTerm send branch.
+- WezTerm is controlled entirely through its `wezterm` CLI (no AppleScript), so
+  the same code works on macOS, Linux, and Windows.
+
+## Data Models
+**What data do we need to manage?**
+
+- `TerminalType` enum: add `WEZTERM = 'wezterm'`.
+- `TerminalLocation` (unchanged shape):
+  - `type: TerminalType.WEZTERM`
+  - `identifier: string(paneId)` — WezTerm's global pane id (e.g. `"7"`), used
+    by `activate-pane --pane-id` and `send-text --pane-id`.
+  - `tty: string` — `/dev/...` device, for parity with other emulators.
+
+## API Design
+**How do components communicate?**
+
+Discovery and control happen via `execFile('wezterm', [...])` (promisified). No
+shell is used; the message bytes are passed as a discrete argv element, so
+there is no string interpolation and no injection surface.
+
+- Discover pane: `wezterm cli list --format json`
+  - Parse JSON array; find entry whose **`tty_name`** equals the target
+    `/dev/...` (the JSON field is `tty_name`, not `tty`).
+  - Return `{ type: WEZTERM, identifier: String(pane_id), tty }`.
+- Focus pane: `wezterm cli activate-pane --pane-id <id>` → success on zero exit.
+- Send text: two explicit `wezterm cli send-text --pane-id <id>` calls.
+  - Step 1 (text): the message as a positional argv element (`send-text --pane-id <id> <message>`).
+  - Step 2 (Enter): a single carriage return byte (0x0d) as an argv element
+    with `--no-paste`. The equivalent shell command is
+    `wezterm cli send-text --pane-id <id> --no-paste $'\x0d'` (note the
+    dollar-single-quoted `$'\x0d'`), so the CR is delivered literally rather
+    than wrapped in paste brackets.
+  - 150 ms pacing between the two, mirroring the tmux/iTerm/Terminal
+    convention so a bracketed-paste-aware TUI still sees Enter as a submit.
+
+## Component Breakdown
+**What are the major building blocks?**
+
+- `src/terminal/TerminalFocusManager.ts`
+  - `findTerminal`: insert WezTerm check **after tmux, before iTerm2**.
+    (tmux-inside-wezterm still resolves to tmux; cross-platform WezTerm is tried
+    before macOS-only AppleScript probes.)
+  - `findWeztermPane(tty)`: call `wezterm cli list --format json`, JSON-parse,
+    match `tty_name`, return location or `null`. Swallow ENOENT/parse/non-zero.
+  - `focusWeztermPane(paneId)`: `wezterm cli activate-pane --pane-id <id>`.
+  - Optional `debug` logger (constructor): emits one line per discovery/focus
+    step (pid/tty, each probe's match/no-match, focus result) so the
+    `agent open --debug` command can show the decision path.
+- `src/terminal/TtyWriter.ts`
+  - `send`: add `WEZTERM` case → `sendViaWezterm(identifier, message)`.
+  - `sendViaWezterm`: two `execFileAsync` calls — text as an argv element,
+    then a CR byte (0x0d) with `--no-paste` — 150 ms apart; throws a
+    descriptive error on failure.
+- `src/terminal/index.ts`: no change (`TerminalType` already re-exported).
+- CLI: no change — it consumes the abstract API only.
+
+## Design Decisions
+**Why did we choose this approach?**
+
+- **CLI-over-AppleScript.** WezTerm is cross-platform and ships a stable CLI.
+  Reusing it avoids macOS-only scripting and matches how tmux is handled.
+- **Discovery by TTY from `cli list --format json`.** JSON is stable to parse;
+  TTY matching reuses the exact identity model of the other emulators.
+- **Two-step text + Enter.** Keeps identical semantics to the three existing
+  senders (documented to survive bracketed-paste TUIs) and avoids special-casing.
+- **Graceful degradation.** `wezterm` missing/failed is caught exactly like the
+  tmux probe, so behavior for non-WezTerm users is unchanged.
+- Alternatives considered
+  - Parsing the human-readable `cli list` table — fragile across versions;
+    rejected in favor of `--format json`.
+  - WezTerm GUI app process-name sniffing — differs by platform
+    (`wezterm-gui` vs bundled `wezterm`); rejected; we let `cli list` be the
+    source of truth and catch failure.
+  - Single-step send (text + newline together) — rejected for consistency with
+    the documented two-step convention used everywhere else.
+
+## Non-Functional Requirements
+**How should the system perform?**
+
+- Performance: one extra short-lived subprocess probe on `findTerminal` only when
+  earlier probes miss; same O(processes) cost profile as today.
+- Security: no shell invocation; the message is passed as a discrete argv
+  element to `execFile`, so it is delivered verbatim regardless of shell
+  metacharacters (no injection surface), and Enter is a fixed CR byte.
+- Reliability: every WezTerm path is wrapped so a missing binary, a failed JSON
+  parse, or a non-running instance returns `null`/`false`/throws-with-context
+  instead of crashing the CLI.
+- Compat: existing emulator tests run unmodified.

--- a/docs/ai/implementation/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/implementation/2026-06-29-feature-wezterm-support.md
@@ -1,0 +1,102 @@
+---
+phase: implementation
+title: Implementation Guide
+description: Technical implementation notes, patterns, and code guidelines
+---
+
+# Implementation Guide — WezTerm support
+
+## Development Setup
+**How do we get started?**
+
+- Work in worktree `feature-wezterm-support`; `npm ci` at the repo root.
+- Run agent-manager tests: `npx vitest run` in `packages/agent-manager`.
+- WezTerm is **not** required to develop/CI this: all control paths go through
+  `execFile` and are covered by mocked unit tests.
+
+## Code Structure
+**How is the code organized?**
+
+- `packages/agent-manager/src/terminal/`
+  - `TerminalFocusManager.ts` — discovery + focus (one method pair per emulator).
+  - `TtyWriter.ts` — input dispatch (one sender per emulator).
+  - `index.ts` — re-exports (`TerminalType` already exported; no change needed).
+- No CLI changes: `agent open`, `agent send`, and channel bridges consume the
+  abstract `findTerminal` / `focusTerminal` / `TtyWriter.send` API only.
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Discovery (`TerminalFocusManager.findWeztermPane`)
+- `execFile('wezterm', ['cli', 'list', '--format', 'json'])`.
+- Parse JSON; match the entry whose **`tty_name`** equals `/dev/<agent-tty>`;
+  use `pane_id` as `identifier`. Only `tty_name` and `pane_id` are read; extra
+  fields are
+  ignored for forward-compat.
+- `try/catch` swallows ENOENT (binary missing), non-running mux, and malformed
+  JSON → returns `null`, identical to the tmux probe's failure handling.
+- Probe order in `findTerminal`: tmux → **WezTerm** → iTerm2 → Terminal.app.
+  tmux wins when nested inside WezTerm; WezTerm is tried before the macOS-only
+  AppleScript probes so non-macOS hosts short-circuit cleanly.
+
+### Focus (`TerminalFocusManager.focusWeztermPane`)
+- `execFile('wezterm', ['cli', 'activate-pane', '--pane-id', identifier])`.
+- Returns `true` on zero exit, `false` (no throw) on any error.
+
+### Send (`TtyWriter.sendViaWezterm`)
+- Two explicit `wezterm cli send-text --pane-id <id>` calls, 150 ms apart:
+  - Step 1 (text): `['cli', 'send-text', '--pane-id', paneId, message]` — the
+    message as a positional argv element.
+  - Step 2 (Enter): `['cli', 'send-text', '--pane-id', paneId, '--no-paste',
+    '\x0d']`, where the argv element `'\x0d'` is the JS string holding the
+    single carriage-return byte (0x0d). The equivalent shell command is
+    `wezterm cli send-text --pane-id <id> --no-paste $'\x0d'` (note the
+    dollar-single-quoted `$'\x0d'`), and `--no-paste` delivers the CR
+    literally rather than wrapped in paste brackets.
+- Same two-step text+Enter convention as tmux/iTerm2/Terminal.app so a
+  bracketed-paste-aware TUI still sees Enter as a submit.
+
+### Patterns & Best Practices
+- Shell injection safety without a shell: all wezterm control is via
+  `execFile('wezterm', [...argv])`, which spawns the process directly. The
+  message and the Enter CR byte are each a discrete argv element, so their
+  bytes are delivered verbatim regardless of shell metacharacters.
+- No AppleScript: WezTerm is cross-platform; the CLI is the single integration.
+
+### Debug trace (`agent open --debug`)
+- `TerminalFocusManager` takes an optional `debug?: (message: string) => void`
+  callback in its constructor. When set, `findTerminal`/`focusTerminal` emit one
+  human-readable line per step (pid/tty, each emulator probe's match/no-match,
+  focus result).
+- The `agent open --debug` command wires this to the existing
+  `ai-devkit:terminal` debug logger (`createLogger('terminal')` + `enableDebug()`),
+  reusing the repo's `--debug` convention used by `agent start`/`channel`.
+
+## Integration Points
+**How do pieces connect?**
+
+- Public surface added: `TerminalType.WEZTERM = 'wezterm'` (new enum member) and
+  the existing `TerminalLocation` shape (identifier = pane id).
+- Consumers (`packages/cli` `agent.ts`, `agent.service.ts`, `channel-runner.ts`)
+  are unchanged; they pick up WezTerm automatically through the abstract API.
+
+## Error Handling
+**How do we handle failures?**
+
+- Discovery: missing/failed WezTerm → `null` → UNKNOWN fallback → CLI reports it
+  cannot focus, exactly like any other unrecognized emulator.
+- Focus: errors → `false` (graceful).
+- Send: errors → thrown with context (consistent with the other senders).
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- One extra short-lived `wezterm cli list` subprocess only when tmux didn't
+  match. `findTerminal` is called once per `agent open`/`send`.
+
+## Security Notes
+**What security measures are in place?**
+
+- No shell; `paneId` originates from WezTerm's own JSON (numeric) and the
+  message is passed as a discrete argv element to `execFile`, so both are
+  delivered verbatim regardless of shell metacharacters (no injection surface).

--- a/docs/ai/implementation/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/implementation/2026-06-29-feature-wezterm-support.md
@@ -45,8 +45,9 @@ description: Technical implementation notes, patterns, and code guidelines
 
 ### Send (`TtyWriter.sendViaWezterm`)
 - Two explicit `wezterm cli send-text --pane-id <id>` calls, 150 ms apart:
-  - Step 1 (text): `['cli', 'send-text', '--pane-id', paneId, message]` — the
-    message as a positional argv element.
+  - Step 1 (text): `['cli', 'send-text', '--pane-id', paneId]` with the message
+    body written to stdin, keeping prompt contents out of local process
+    listings.
   - Step 2 (Enter): `['cli', 'send-text', '--pane-id', paneId, '--no-paste',
     '\x0d']`, where the argv element `'\x0d'` is the JS string holding the
     single carriage-return byte (0x0d). The equivalent shell command is
@@ -59,8 +60,8 @@ description: Technical implementation notes, patterns, and code guidelines
 ### Patterns & Best Practices
 - Shell injection safety without a shell: all wezterm control is via
   `execFile('wezterm', [...argv])`, which spawns the process directly. The
-  message and the Enter CR byte are each a discrete argv element, so their
-  bytes are delivered verbatim regardless of shell metacharacters.
+  message is written through stdin, so shell metacharacters are delivered as
+  data without exposing prompt text through argv.
 - No AppleScript: WezTerm is cross-platform; the CLI is the single integration.
 
 ### Debug trace (`agent open --debug`)
@@ -98,5 +99,5 @@ description: Technical implementation notes, patterns, and code guidelines
 **What security measures are in place?**
 
 - No shell; `paneId` originates from WezTerm's own JSON (numeric) and the
-  message is passed as a discrete argv element to `execFile`, so both are
-  delivered verbatim regardless of shell metacharacters (no injection surface).
+  message is written to `send-text` through stdin, so prompt text is not exposed
+  through process arguments and shell metacharacters remain data.

--- a/docs/ai/planning/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/planning/2026-06-29-feature-wezterm-support.md
@@ -1,0 +1,63 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+**What are the major checkpoints?**
+
+- [ ] M1: WezTerm discovery returns a `WEZTERM` location (unit-tested).
+- [ ] M2: Focus + send work end-to-end against the WezTerm CLI (unit-tested).
+- [ ] M3: Full package test suite green; docs updated; PR opened.
+
+## Task Breakdown
+**What specific work needs to be done?**
+
+### Phase 1: Discovery
+- [x] T1.1: Add `WEZTERM = 'wezterm'` to `TerminalType`.
+- [x] T1.2: Add `findWeztermPane(tty)` calling `wezterm cli list --format json`,
+      matching `tty` → `pane_id`; swallow ENOENT/parse/non-zero.
+- [x] T1.3: Insert WezTerm probe in `findTerminal` after tmux, before iTerm2.
+
+### Phase 2: Control
+- [x] T2.1: Add `focusWeztermPane(paneId)` (`wezterm cli focus-pane --pane-id`)
+      and a `WEZTERM` case in `focusTerminal`.
+- [x] T2.2: Add `sendViaWezterm(identifier, message)` (two-step text + Enter via
+      stdin) and a `WEZTERM` case in `TtyWriter.send`.
+
+### Phase 3: Tests & Docs
+- [x] T3.1: Unit tests in `TerminalFocusManager.test.ts` (found / not-installed
+      / no-match / malformed-json / precedence / no-osascript / focus ok / focus
+      fail).
+- [x] T3.2: Unit tests in `TtyWriter.test.ts` (two-step send / pane-id / failure
+      / still-unsupported).
+- [x] T3.3: Update `packages/agent-manager/README.md` terminal support list.
+- [ ] T3.4: Run `npm test` (done); simplify-implementation review (done, no changes); commit; open PR.
+
+## Dependencies
+**What needs to happen in what order?**
+
+- T1.1 → T1.2 → T1.3 (enum before its consumers).
+- T2.* depend on T1.1.
+- T3.1/T3.2 written before/with their targets (TDD).
+
+## Timeline & Estimates
+**When will things be done?**
+
+- Single small, well-scoped change; all phases in one session.
+
+## Risks & Mitigation
+**What could go wrong?**
+
+- WezTerm JSON schema drift across versions → mitigate by reading only `tty` and
+  `pane_id` defensively and falling back to `null` on any anomaly.
+- Cannot run real WezTerm in CI → rely on execFile-mocked unit tests; document
+  manual verification.
+
+## Resources Needed
+**What do we need to succeed?**
+
+- Existing vitest + execFile mock harness in `__tests__/terminal/`.

--- a/docs/ai/requirements/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/requirements/2026-06-29-feature-wezterm-support.md
@@ -1,0 +1,85 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+description: Clarify the problem space, gather requirements, and define success criteria
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+**What problem are we solving?**
+
+- `@ai-devkit/agent-manager` can discover and focus terminal sessions for an
+  already-running agent in **tmux**, **iTerm2**, and macOS **Terminal.app** via
+  `TerminalFocusManager` / `TtyWriter`.
+- Users who run coding agents inside **WezTerm** get no terminal resolution: the
+  agent is detected (PID/TTY are known) but `findTerminal` falls through to
+  `UNKNOWN`, so `agent open`, `agent send`, and channel bridges cannot focus or
+  type into the WezTerm pane that owns the agent.
+- Current workaround: none from the CLI; users must switch panes manually.
+
+## Goals & Objectives
+**What do we want to achieve?**
+
+- Primary goals
+  - Discover the WezTerm pane that owns a running agent by matching the agent
+    PID's TTY against WezTerm's panes.
+  - Focus that pane (`agent open`) and send keyboard input to it (`agent send`,
+    channel bridge) through WezTerm's CLI.
+  - Keep all existing tmux / iTerm2 / Terminal.app behavior byte-for-byte
+    unchanged.
+- Secondary goals
+  - Cross-platform (WezTerm runs on macOS, Linux, Windows) without AppleScript.
+  - Graceful no-op when WezTerm is not installed or not running.
+- Non-goals (what's explicitly out of scope)
+  - Spawning new agents into WezTerm (that is `TmuxManager`'s session-create
+    responsibility; WezTerm spawn is not added here).
+  - Splitting/tiling panes, theming, or WezTerm config generation.
+  - Detecting the WezTerm emulator version or multiplexing across multiple
+    WezTerm mux servers beyond the default local instance.
+
+## User Stories & Use Cases
+**How will users interact with the solution?**
+
+- As a developer running Claude Code/Codex/Gemini inside a WezTerm pane, I run
+  `ai-devkit agent open <name>` so the WezTerm pane hosting the agent is
+  focused/raised.
+- As an orchestrator, I run `ai-devkit agent send "<msg>" --id <name>` so the
+  text is typed into the correct WezTerm pane and submitted.
+- As a channel (Telegram) bridge user, incoming messages are forwarded to the
+  WezTerm pane owning the agent.
+- Edge cases
+  - WezTerm binary not installed → behaves as before (UNKNOWN fallback).
+  - WezTerm installed but no instance running → behaves as before.
+  - Agent runs inside **tmux inside WezTerm** → resolves to tmux (innermost
+    first), unchanged.
+
+## Success Criteria
+**How will we know when we're done?**
+
+- `TerminalFocusManager.findTerminal(pid)` returns a `WEZTERM` location when the
+  TTY belongs to a WezTerm pane, and only when the WezTerm CLI is available.
+- `focusTerminal(weztermLocation)` focuses the matching pane; returns `false` on
+  any failure without throwing.
+- `TtyWriter.send(weztermLocation, msg)` types the message and submits it.
+- Existing tmux/iTerm2/Terminal.app tests pass unchanged.
+- New unit tests cover discovery (found / not-installed / tty-mismatch) and send
+  (text+Enter, failure). `npm test` for `@ai-devkit/agent-manager` is green.
+
+## Constraints & Assumptions
+**What limitations do we need to work within?**
+
+- WezTerm is controlled exclusively through its `wezterm` CLI; no scripting host
+  is assumed (so no AppleScript on non-macOS).
+- We rely on the documented, stable WezTerm CLI surface: `wezterm cli list
+  --format json`, `wezterm cli focus-pane --pane-id <id>`, `wezterm cli
+  send-text --pane-id <id>` (stdin).
+- TTY matching requires the agent process to report a TTY (same prerequisite as
+  the existing emulators).
+- Assumption: a single default local WezTerm mux server (the common case).
+
+## Questions & Open Items
+**What do we still need to clarify?**
+
+- None blocking. Spawn-into-WezTerm and multi-server muxing are deferred as
+  explicit non-goals above.

--- a/docs/ai/testing/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/testing/2026-06-29-feature-wezterm-support.md
@@ -37,16 +37,16 @@ description: Define testing approach, test cases, and quality assurance
 
 ### TtyWriter (send)
 - [x] `send` for a `WEZTERM` location makes two explicit `wezterm cli
-      send-text --pane-id <id>` calls: (1) the message as a positional argv
-      element, then (2) a single carriage return byte (0x0d) as an argv element
+      send-text --pane-id <id>` calls: (1) the message body written through
+      stdin, then (2) a single carriage return byte (0x0d) as an argv element
       with `--no-paste` (shell equivalent: `wezterm cli send-text --pane-id
-      <id> --no-paste $'\x0d'`), ~150 ms apart. No stdin is used.
-- [x] The message — including shell metacharacters / newlines — is passed
-      verbatim as one argv element (no shell, no injection).
+      <id> --no-paste $'\x0d'`), ~150 ms apart.
+- [x] The message — including shell metacharacters / newlines — is written
+      verbatim through stdin and not exposed as a process argument.
 - [x] The Enter byte is exactly char code 0x0d (carriage return), not 0x0a.
-- [ ] First call uses the pane id from `location.identifier`.
-- [ ] Throws a descriptive error when the text send fails (non-zero exit).
-- [ ] Unsupported types still throw the existing "unsupported terminal type".
+- [x] First call uses the pane id from `location.identifier`.
+- [x] Throws a descriptive error when the text send fails (non-zero exit).
+- [x] Unsupported types still throw the existing "unsupported terminal type".
 
 ## Integration Tests
 **How do we test component interactions?**

--- a/docs/ai/testing/2026-06-29-feature-wezterm-support.md
+++ b/docs/ai/testing/2026-06-29-feature-wezterm-support.md
@@ -1,0 +1,90 @@
+---
+phase: testing
+title: Testing Strategy
+description: Define testing approach, test cases, and quality assurance
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+**What level of testing do we aim for?**
+
+- 100% of new/changed lines in `TerminalFocusManager.ts` and `TtyWriter.ts`.
+- Existing emulator behavior covered by unchanged tests (regression).
+- No integration/e2e required: WezTerm cannot be installed in CI; control is
+  via `execFile`, which is already mocked by the existing terminal tests.
+
+## Unit Tests
+**What individual components need testing?**
+
+### TerminalFocusManager (discovery + focus)
+- [x] `findTerminal` returns a `WEZTERM` location when `wezterm cli list
+      --format json` contains an entry whose `tty_name` matches the agent TTY,
+      and `pane_id` is used as `identifier`.
+- [x] `findTerminal` returns `null` when `wezterm` is not installed (ENOENT).
+- [x] `findTerminal` returns `null` when the JSON has no matching TTY.
+- [x] `findTerminal` returns `null` on malformed JSON (does not throw).
+- [x] tmux still wins when both tmux and WezTerm could match (precedence).
+- [x] WezTerm is tried before iTerm2/Terminal.app (macOS probes not run when
+      WezTerm matches — assert osascript is not invoked).
+- [x] `focusTerminal` returns `true` when `wezterm cli activate-pane --pane-id`
+      exits zero.
+- [x] `focusTerminal` returns `false` (no throw) on focus failure.
+- [x] `findTerminal` emits the matching decision path (pid/tty, per-probe
+      match/no-match) via the debug logger.
+- [x] `focusTerminal` emits the focus decision path (target + result) via the
+      debug logger.
+
+### TtyWriter (send)
+- [x] `send` for a `WEZTERM` location makes two explicit `wezterm cli
+      send-text --pane-id <id>` calls: (1) the message as a positional argv
+      element, then (2) a single carriage return byte (0x0d) as an argv element
+      with `--no-paste` (shell equivalent: `wezterm cli send-text --pane-id
+      <id> --no-paste $'\x0d'`), ~150 ms apart. No stdin is used.
+- [x] The message — including shell metacharacters / newlines — is passed
+      verbatim as one argv element (no shell, no injection).
+- [x] The Enter byte is exactly char code 0x0d (carriage return), not 0x0a.
+- [ ] First call uses the pane id from `location.identifier`.
+- [ ] Throws a descriptive error when the text send fails (non-zero exit).
+- [ ] Unsupported types still throw the existing "unsupported terminal type".
+
+## Integration Tests
+**How do we test component interactions?**
+
+- Not required. The CLI (`agent open`/`send`, channel bridge) only calls the
+  abstract API; adding a `WEZTERM` branch is fully covered by the unit tests.
+
+## End-to-End Tests
+**What user flows need validation?**
+
+- Manual only (real WezTerm): `ai-devkit agent open`/`send` against a pane.
+  Documented under limitations; cannot run in CI without WezTerm installed.
+
+## Test Data
+**What data do we use for testing?**
+
+- Mocked `execFile` (already the pattern in `__tests__/terminal/`).
+- Sample `wezterm cli list --format json` payload fixture with `tty_name` + `pane_id`.
+- Sample agent TTY `/dev/ttys000` / `/dev/pts/0`.
+
+## Test Reporting & Coverage
+**How do we verify and communicate test results?**
+
+- `npm test` in `packages/agent-manager` (vitest).
+- `npm run test -- --coverage` to confirm new branches hit.
+
+## Manual Testing
+**What requires human validation?**
+
+- On a host with WezTerm: `agent open <name>` focuses the pane; `agent send
+  "hi" --id <name>` types and submits.
+
+## Performance Testing
+**How do we validate performance?**
+
+- N/A; one extra short-lived subprocess only on WezTerm hosts.
+
+## Bug Tracking
+**How do we manage issues?**
+
+- Standard repo issues; limitations recorded in requirements + this doc.

--- a/packages/agent-manager/README.md
+++ b/packages/agent-manager/README.md
@@ -10,6 +10,9 @@ This package powers the `ai-devkit agent` commands. Use it when you need the low
 - **Session details** — Inspect agent metadata, working directory, and status
 - **Prompt sending** — Send follow-up instructions to an existing session
 - **Provider adapters** — Shared adapter layer for agent-specific behavior
+- **Terminal control** — Discover, focus, and type into the terminal pane that
+  hosts a running agent. Supported emulators: **tmux**, **WezTerm**, **iTerm2**,
+  and macOS **Terminal.app**. Resolution is automatic from the agent PID's TTY.
 
 ## Typical Use
 

--- a/packages/agent-manager/src/__tests__/terminal/TerminalFocusManager.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TerminalFocusManager.test.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process';
 import type { MockedFunction } from 'vitest';
 
 import { TerminalFocusManager, TerminalType } from '../../terminal/TerminalFocusManager.js';
+import type { TerminalLocation } from '../../terminal/TerminalFocusManager.js';
 import { getProcessTty } from '../../utils/process.js';
 
 vi.mock('child_process', () => ({
@@ -60,6 +61,192 @@ describe('TerminalFocusManager', () => {
             expect.any(Array),
             expect.any(Function),
         );
+    });
+
+    describe('WezTerm', () => {
+        const listArgs = ['cli', 'list', '--format', 'json'];
+
+        it('finds the WezTerm pane whose tty_name matches the agent tty', async () => {
+            setExecFileHandler((cmd, args) => {
+                if (cmd === 'tmux') return new Error('tmux not running');
+                if (cmd === 'wezterm' && args.join(' ') === listArgs.join(' ')) {
+                    return JSON.stringify([
+                        { pane_id: 3, tty_name: '/dev/ttys099', cwd: '/x' },
+                        { pane_id: 7, tty_name: '/dev/ttys000', cwd: '/y' },
+                    ]);
+                }
+                return '';
+            });
+
+            const location = await new TerminalFocusManager().findTerminal(123);
+
+            expect(location).toEqual({
+                type: TerminalType.WEZTERM,
+                identifier: '7',
+                tty: '/dev/ttys000',
+            });
+        });
+
+        it('skips the macOS AppleScript probes when WezTerm matches', async () => {
+            setExecFileHandler((cmd) => {
+                if (cmd === 'tmux') return new Error('tmux not running');
+                if (cmd === 'wezterm') {
+                    return JSON.stringify([{ pane_id: 7, tty_name: '/dev/ttys000' }]);
+                }
+                return '';
+            });
+
+            await new TerminalFocusManager().findTerminal(123);
+
+            expect(mockedExecFile).not.toHaveBeenCalledWith(
+                'osascript',
+                expect.any(Array),
+                expect.any(Function),
+            );
+        });
+
+        it('returns UNKNOWN when WezTerm is installed but no pane matches the tty', async () => {
+            setExecFileHandler((cmd) => {
+                if (cmd === 'tmux') return new Error('tmux not running');
+                if (cmd === 'wezterm') {
+                    return JSON.stringify([{ pane_id: 7, tty_name: '/dev/ttys099' }]);
+                }
+                return '';
+            });
+
+            const location = await new TerminalFocusManager().findTerminal(123);
+
+            expect(location?.type).toBe(TerminalType.UNKNOWN);
+        });
+
+        it('returns UNKNOWN (without throwing) on malformed JSON from wezterm', async () => {
+            setExecFileHandler((cmd) => {
+                if (cmd === 'tmux') return new Error('tmux not running');
+                if (cmd === 'wezterm') return 'not-json{';
+                return '';
+            });
+
+            const location = await new TerminalFocusManager().findTerminal(123);
+
+            expect(location?.type).toBe(TerminalType.UNKNOWN);
+        });
+
+        it('returns UNKNOWN when the wezterm binary is missing', async () => {
+            setExecFileHandler((cmd) => {
+                if (cmd === 'tmux') return new Error('tmux not running');
+                if (cmd === 'wezterm') return new Error('spawn wezterm ENOENT');
+                return '';
+            });
+
+            const location = await new TerminalFocusManager().findTerminal(123);
+
+            expect(location?.type).toBe(TerminalType.UNKNOWN);
+        });
+
+        it('prefers tmux over WezTerm (tmux-inside-WezTerm resolves to tmux)', async () => {
+            setExecFileHandler((cmd) => {
+                if (cmd === 'tmux') {
+                    return `/dev/ttys000|my:0.1`;
+                }
+                if (cmd === 'wezterm') {
+                    return JSON.stringify([{ pane_id: 7, tty: '/dev/ttys000' }]);
+                }
+                return '';
+            });
+
+            const location = await new TerminalFocusManager().findTerminal(123);
+
+            expect(location).toEqual({
+                type: TerminalType.TMUX,
+                identifier: 'my:0.1',
+                tty: '/dev/ttys000',
+            });
+            // WezTerm must not even be queried when tmux already matched.
+            expect(mockedExecFile).not.toHaveBeenCalledWith(
+                'wezterm',
+                expect.any(Array),
+                expect.any(Function),
+            );
+        });
+    });
+
+    describe('focusTerminal for WezTerm', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.WEZTERM,
+            identifier: '7',
+            tty: '/dev/ttys000',
+        };
+
+        it('focuses the pane via wezterm cli activate-pane --pane-id', async () => {
+            setExecFileHandler((cmd, args) => {
+                if (cmd === 'wezterm' && args.join(' ') === 'cli activate-pane --pane-id 7') {
+                    return '';
+                }
+                return '';
+            });
+
+            const ok = await new TerminalFocusManager().focusTerminal(location);
+
+            expect(ok).toBe(true);
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'wezterm',
+                ['cli', 'activate-pane', '--pane-id', '7'],
+                expect.any(Function),
+            );
+        });
+
+        it('returns false (without throwing) when focus fails', async () => {
+            setExecFileHandler((cmd) => {
+                if (cmd === 'wezterm') return new Error('boom');
+                return '';
+            });
+
+            const ok = await new TerminalFocusManager().focusTerminal(location);
+
+            expect(ok).toBe(false);
+        });
+    });
+
+    describe('debug tracing', () => {
+        it('emits the matching decision path via the debug logger', async () => {
+            const debug = vi.fn();
+            setExecFileHandler((cmd, args) => {
+                if (cmd === 'tmux') return new Error('tmux not running');
+                if (cmd === 'wezterm' && args.join(' ').includes('cli list')) {
+                    return JSON.stringify([{ pane_id: 7, tty_name: '/dev/ttys000' }]);
+                }
+                return '';
+            });
+
+            const location = await new TerminalFocusManager(debug).findTerminal(123);
+
+            expect(location?.type).toBe(TerminalType.WEZTERM);
+            const messages = debug.mock.calls.map((call) => call[0] as string);
+            expect(messages.some((m) => /pid=123/.test(m))).toBe(true);
+            expect(messages.some((m) => /tmux.*no match|tmux: no/i.test(m))).toBe(true);
+            expect(messages.some((m) => /wezterm/i.test(m))).toBe(true);
+        });
+
+        it('emits the focus decision path via the debug logger', async () => {
+            const debug = vi.fn();
+            setExecFileHandler((cmd, args) => {
+                if (cmd === 'wezterm' && args.join(' ') === 'cli activate-pane --pane-id 7') {
+                    return '';
+                }
+                return '';
+            });
+
+            const ok = await new TerminalFocusManager(debug).focusTerminal({
+                type: TerminalType.WEZTERM,
+                identifier: '7',
+                tty: '/dev/ttys000',
+            });
+
+            expect(ok).toBe(true);
+            const messages = debug.mock.calls.map((call) => call[0] as string);
+            expect(messages.some((m) => /focusing wezterm/i.test(m))).toBe(true);
+            expect(messages.some((m) => /succeeded/i.test(m))).toBe(true);
+        });
     });
 
     it('finds Terminal.app when the process is listed by app bundle path', async () => {

--- a/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
@@ -201,6 +201,91 @@ describe('TtyWriter', () => {
         });
     });
 
+    describe('WezTerm', () => {
+        const location: TerminalLocation = {
+            type: TerminalType.WEZTERM,
+            identifier: '7',
+            tty: '/dev/ttys030',
+        };
+
+        it('sends the message and Enter as two explicit send-text calls (no stdin)', async () => {
+            mockExecFileSuccess();
+
+            await TtyWriter.send(location, 'continue');
+
+            // Step 1: message body as a positional argv element (NOT stdin).
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'wezterm',
+                ['cli', 'send-text', '--pane-id', '7', 'continue'],
+                expect.any(Function),
+            );
+            // Step 2: Enter as a single carriage return (0x0d) with --no-paste,
+            // so the CR is delivered literally (not wrapped in paste brackets).
+            // execFile passes the actual CR byte (JS '\x0d'); the equivalent
+            // shell command is:
+            //   wezterm cli send-text --pane-id <id> --no-paste $'\x0d'
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'wezterm',
+                ['cli', 'send-text', '--pane-id', '7', '--no-paste', '\x0d'],
+                expect.any(Function),
+            );
+            expect(mockedExecFile).toHaveBeenCalledTimes(2);
+        });
+
+        it('passes the Enter byte as the carriage return (0x0d), not newline', async () => {
+            mockExecFileSuccess();
+
+            await TtyWriter.send(location, 'continue');
+
+            // The Enter call is the second invocation; its last argv element is
+            // a single byte equal to char code 13 (0x0d).
+            const enterCall = mockedExecFile.mock.calls[1];
+            const enterArgs = enterCall[1] as string[];
+            const enterByte = enterArgs[enterArgs.length - 1];
+            expect(enterByte).toHaveLength(1);
+            expect(enterByte.charCodeAt(0)).toBe(0x0d);
+            expect(enterArgs).toContain('--no-paste');
+        });
+
+        it('passes the whole message as a single argv element (no shell injection)', async () => {
+            mockExecFileSuccess();
+            const hostile = 'echo pwned; $(rm -rf /) `whoami` | cat\nline2';
+
+            await TtyWriter.send(location, hostile);
+
+            // The message is passed verbatim as one argv element, not built into
+            // a shell string, so shell metacharacters are inert.
+            const textCall = mockedExecFile.mock.calls[0];
+            const textArgs = textCall[1] as string[];
+            expect(textArgs[textArgs.length - 1]).toBe(hostile);
+            expect(textArgs).toEqual(
+                ['cli', 'send-text', '--pane-id', '7', hostile],
+            );
+            // No options object (no stdin) is passed.
+            expect(textCall[2]).toBeTypeOf('function');
+        });
+
+        it('uses the pane id from location.identifier', async () => {
+            mockExecFileSuccess();
+            const pane42 = { ...location, identifier: '42' };
+
+            await TtyWriter.send(pane42, 'hi');
+
+            expect(mockedExecFile).toHaveBeenCalledWith(
+                'wezterm',
+                ['cli', 'send-text', '--pane-id', '42', 'hi'],
+                expect.any(Function),
+            );
+        });
+
+        it('throws when the text send fails', async () => {
+            mockExecFileError('wezterm send-text failed');
+
+            await expect(TtyWriter.send(location, 'hello'))
+                .rejects.toThrow('wezterm send-text failed');
+        });
+    });
+
     describe('unsupported terminal', () => {
         it('throws for unknown terminal type', async () => {
             const location: TerminalLocation = {

--- a/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TtyWriter.test.ts
@@ -208,17 +208,20 @@ describe('TtyWriter', () => {
             tty: '/dev/ttys030',
         };
 
-        it('sends the message and Enter as two explicit send-text calls (no stdin)', async () => {
+        it('sends the message via stdin and Enter as a separate send-text call', async () => {
             mockExecFileSuccess();
 
             await TtyWriter.send(location, 'continue');
 
-            // Step 1: message body as a positional argv element (NOT stdin).
+            // Step 1: message body via stdin, not argv, so prompt contents are
+            // not exposed through process listings.
             expect(mockedExecFile).toHaveBeenCalledWith(
                 'wezterm',
-                ['cli', 'send-text', '--pane-id', '7', 'continue'],
+                ['cli', 'send-text', '--pane-id', '7'],
                 expect.any(Function),
             );
+            expect(mockedExecFile.mock.results[0]?.value.stdin.end)
+                .toHaveBeenCalledWith('continue');
             // Step 2: Enter as a single carriage return (0x0d) with --no-paste,
             // so the CR is delivered literally (not wrapped in paste brackets).
             // execFile passes the actual CR byte (JS '\x0d'); the equivalent
@@ -247,22 +250,22 @@ describe('TtyWriter', () => {
             expect(enterArgs).toContain('--no-paste');
         });
 
-        it('passes the whole message as a single argv element (no shell injection)', async () => {
+        it('keeps the whole message out of argv and writes it verbatim to stdin', async () => {
             mockExecFileSuccess();
             const hostile = 'echo pwned; $(rm -rf /) `whoami` | cat\nline2';
 
             await TtyWriter.send(location, hostile);
 
-            // The message is passed verbatim as one argv element, not built into
-            // a shell string, so shell metacharacters are inert.
+            // The message is written verbatim to stdin, not built into a shell
+            // string or exposed as a process argument.
             const textCall = mockedExecFile.mock.calls[0];
             const textArgs = textCall[1] as string[];
-            expect(textArgs[textArgs.length - 1]).toBe(hostile);
             expect(textArgs).toEqual(
-                ['cli', 'send-text', '--pane-id', '7', hostile],
+                ['cli', 'send-text', '--pane-id', '7'],
             );
-            // No options object (no stdin) is passed.
             expect(textCall[2]).toBeTypeOf('function');
+            expect(mockedExecFile.mock.results[0]?.value.stdin.end)
+                .toHaveBeenCalledWith(hostile);
         });
 
         it('uses the pane id from location.identifier', async () => {
@@ -273,9 +276,11 @@ describe('TtyWriter', () => {
 
             expect(mockedExecFile).toHaveBeenCalledWith(
                 'wezterm',
-                ['cli', 'send-text', '--pane-id', '42', 'hi'],
+                ['cli', 'send-text', '--pane-id', '42'],
                 expect.any(Function),
             );
+            expect(mockedExecFile.mock.results[0]?.value.stdin.end)
+                .toHaveBeenCalledWith('hi');
         });
 
         it('throws when the text send fails', async () => {

--- a/packages/agent-manager/src/terminal/TerminalFocusManager.ts
+++ b/packages/agent-manager/src/terminal/TerminalFocusManager.ts
@@ -7,6 +7,7 @@ const execFileAsync = promisify(execFile);
 
 export enum TerminalType {
     TMUX = 'tmux',
+    WEZTERM = 'wezterm',
     ITERM2 = 'iterm2',
     TERMINAL_APP = 'terminal-app',
     UNKNOWN = 'unknown',
@@ -14,11 +15,31 @@ export enum TerminalType {
 
 export interface TerminalLocation {
     type: TerminalType;
-    identifier: string; // e.g., "session:window.pane" for tmux, or TTY for others
+    identifier: string; // e.g., "session:window.pane" for tmux, WezTerm pane id, or TTY for others
     tty: string;        // e.g., "/dev/ttys030"
 }
 
+/**
+ * Subset of a `wezterm cli list --format json` entry. Only `pane_id` and
+ * `tty_name` are read; extra fields are ignored so schema additions across
+ * WezTerm versions don't break parsing. (The TTY is exposed as `tty_name` in
+ * the JSON, not `tty`.)
+ */
+interface WeztermPaneEntry {
+    pane_id?: number;
+    tty_name?: string | null;
+}
+
+/**
+ * Optional trace sink. When provided to {@link TerminalFocusManager}, each
+ * discovery/focus step reports a human-readable line so callers (e.g. the
+ * `agent open --debug` command) can inspect the matching/focus decision path.
+ */
+export type TerminalDebugLogger = (message: string) => void;
+
 export class TerminalFocusManager {
+    constructor(private readonly debug?: TerminalDebugLogger) {}
+
     /**
      * Find the terminal location (emulator info) for a given process ID
      */
@@ -27,24 +48,47 @@ export class TerminalFocusManager {
 
         // If no TTY or invalid, we can't find the terminal
         if (!ttyShort || ttyShort === '?') {
+            this.debug?.(`findTerminal(pid=${pid}): no usable TTY, cannot resolve terminal`);
             return null;
         }
 
         const fullTty = `/dev/${ttyShort}`;
+        this.debug?.(`findTerminal(pid=${pid}): resolving terminal for ${fullTty}`);
 
         // 1. Check tmux (most specific if running inside it)
         const tmuxLocation = await this.findTmuxPane(fullTty);
-        if (tmuxLocation) return tmuxLocation;
+        if (tmuxLocation) {
+            this.debug?.(`findTerminal: matched tmux (identifier=${tmuxLocation.identifier})`);
+            return tmuxLocation;
+        }
+        this.debug?.('findTerminal: tmux no match');
 
-        // 2. Check iTerm2
+        // 2. Check WezTerm (cross-platform, via its CLI — no AppleScript)
+        const weztermLocation = await this.findWeztermPane(fullTty);
+        if (weztermLocation) {
+            this.debug?.(`findTerminal: matched wezterm (pane_id=${weztermLocation.identifier})`);
+            return weztermLocation;
+        }
+        this.debug?.('findTerminal: wezterm no match');
+
+        // 3. Check iTerm2
         const itermLocation = await this.findITerm2Session(fullTty);
-        if (itermLocation) return itermLocation;
+        if (itermLocation) {
+            this.debug?.(`findTerminal: matched iTerm2 (tty=${itermLocation.tty})`);
+            return itermLocation;
+        }
+        this.debug?.('findTerminal: iTerm2 no match');
 
-        // 3. Check Terminal.app
+        // 4. Check Terminal.app
         const terminalAppLocation = await this.findTerminalAppWindow(fullTty);
-        if (terminalAppLocation) return terminalAppLocation;
+        if (terminalAppLocation) {
+            this.debug?.(`findTerminal: matched Terminal.app (tty=${terminalAppLocation.tty})`);
+            return terminalAppLocation;
+        }
+        this.debug?.('findTerminal: Terminal.app no match');
 
-        // 4. Fallback: we know the TTY but not the emulator wrapper
+        // 5. Fallback: we know the TTY but not the emulator wrapper
+        this.debug?.('findTerminal: no emulator matched; returning UNKNOWN');
         return {
             type: TerminalType.UNKNOWN,
             identifier: '',
@@ -56,17 +100,65 @@ export class TerminalFocusManager {
      * Focus the terminal identified by the location
      */
     async focusTerminal(location: TerminalLocation): Promise<boolean> {
+        this.debug?.(`focusTerminal: focusing ${location.type} (identifier=${location.identifier}, tty=${location.tty})`);
+        let success = false;
         try {
             switch (location.type) {
                 case TerminalType.TMUX:
-                    return await this.focusTmuxPane(location.identifier);
+                    success = await this.focusTmuxPane(location.identifier);
+                    break;
+                case TerminalType.WEZTERM:
+                    success = await this.focusWeztermPane(location.identifier);
+                    break;
                 case TerminalType.ITERM2:
-                    return await this.focusITerm2Session(location.tty);
+                    success = await this.focusITerm2Session(location.tty);
+                    break;
                 case TerminalType.TERMINAL_APP:
-                    return await this.focusTerminalAppWindow(location.tty);
+                    success = await this.focusTerminalAppWindow(location.tty);
+                    break;
                 default:
-                    return false;
+                    success = false;
             }
+        } catch {
+            success = false;
+        }
+        this.debug?.(`focusTerminal: ${success ? 'succeeded' : 'failed'} for ${location.type}`);
+        return success;
+    }
+
+    private async findWeztermPane(tty: string): Promise<TerminalLocation | null> {
+        try {
+            const { stdout } = await execFileAsync('wezterm', [
+                'cli', 'list', '--format', 'json',
+            ]);
+
+            const panes = JSON.parse(stdout) as WeztermPaneEntry[];
+            if (!Array.isArray(panes)) return null;
+
+            for (const pane of panes) {
+                if (
+                    pane &&
+                    typeof pane.tty_name === 'string' &&
+                    pane.tty_name === tty &&
+                    pane.pane_id != null
+                ) {
+                    return {
+                        type: TerminalType.WEZTERM,
+                        identifier: String(pane.pane_id),
+                        tty,
+                    };
+                }
+            }
+        } catch {
+            // wezterm not installed, not running, or returned invalid JSON
+        }
+        return null;
+    }
+
+    private async focusWeztermPane(paneId: string): Promise<boolean> {
+        try {
+            await execFileAsync('wezterm', ['cli', 'activate-pane', '--pane-id', paneId]);
+            return true;
         } catch {
             return false;
         }

--- a/packages/agent-manager/src/terminal/TtyWriter.ts
+++ b/packages/agent-manager/src/terminal/TtyWriter.ts
@@ -6,6 +6,12 @@ import { escapeAppleScript } from '../utils/applescript.js';
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Carriage return byte (0x0d). Sent as a discrete argv element with
+ * `--no-paste` to deliver Enter literally (shell equivalent: $'\x0d').
+ */
+const CARRIAGE_RETURN = '\x0d';
+
 export class TtyWriter {
     /**
      * Send a message as keyboard input to a terminal session.
@@ -26,6 +32,8 @@ export class TtyWriter {
         switch (location.type) {
             case TerminalType.TMUX:
                 return TtyWriter.sendViaTmux(location.identifier, message);
+            case TerminalType.WEZTERM:
+                return TtyWriter.sendViaWezterm(location.identifier, message);
             case TerminalType.ITERM2:
                 return TtyWriter.sendViaITerm2(location.tty, message);
             case TerminalType.TERMINAL_APP:
@@ -33,9 +41,33 @@ export class TtyWriter {
             default:
                 throw new Error(
                     `Cannot send input: unsupported terminal type "${location.type}". ` +
-                    'Supported: tmux, iTerm2, Terminal.app.'
+                    'Supported: tmux, WezTerm, iTerm2, Terminal.app.'
                 );
         }
+    }
+
+    private static async sendViaWezterm(paneId: string, message: string): Promise<void> {
+        // Two explicit CLI calls, mirroring the text-then-Enter convention used
+        // by tmux / iTerm2 / Terminal.app so a bracketed-paste-aware TUI still
+        // sees Enter as a submit.
+        //
+        // Step 1 (text): the message is passed as a positional argv element.
+        // execFile spawns wezterm directly (no shell), so the bytes are
+        // delivered verbatim regardless of shell metacharacters — there is no
+        // injection surface. (Equivalent to how tmux uses `send-keys -l`.)
+        // Step 2 (Enter): a single carriage return (0x0d) passed as a discrete
+        // argv element (the JS char '\x0d') with --no-paste, so the CR is
+        // delivered literally rather than wrapped in paste brackets. The
+        // equivalent shell command is:
+        //   wezterm cli send-text --pane-id <id> --no-paste $'\x0d'
+        // (ANSI-C quoting, note the leading $).
+        await execFileAsync('wezterm', [
+            'cli', 'send-text', '--pane-id', paneId, message,
+        ]);
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        await execFileAsync('wezterm', [
+            'cli', 'send-text', '--pane-id', paneId, '--no-paste', CARRIAGE_RETURN,
+        ]);
     }
 
     private static async sendViaTmux(identifier: string, message: string): Promise<void> {

--- a/packages/agent-manager/src/terminal/TtyWriter.ts
+++ b/packages/agent-manager/src/terminal/TtyWriter.ts
@@ -7,7 +7,7 @@ import { escapeAppleScript } from '../utils/applescript.js';
 const execFileAsync = promisify(execFile);
 
 /**
- * Carriage return byte (0x0d). Sent as a discrete argv element with
+ * Carriage return byte (0x0d). Sent as a fixed discrete argv element with
  * `--no-paste` to deliver Enter literally (shell equivalent: $'\x0d').
  */
 const CARRIAGE_RETURN = '\x0d';
@@ -51,19 +51,18 @@ export class TtyWriter {
         // by tmux / iTerm2 / Terminal.app so a bracketed-paste-aware TUI still
         // sees Enter as a submit.
         //
-        // Step 1 (text): the message is passed as a positional argv element.
-        // execFile spawns wezterm directly (no shell), so the bytes are
-        // delivered verbatim regardless of shell metacharacters — there is no
-        // injection surface. (Equivalent to how tmux uses `send-keys -l`.)
-        // Step 2 (Enter): a single carriage return (0x0d) passed as a discrete
+        // Step 1 (text): write the message to stdin so prompt contents are not
+        // exposed through process arguments. execFile still spawns wezterm
+        // directly (no shell), so shell metacharacters remain inert.
+        // Step 2 (Enter): pass a fixed carriage return (0x0d) as a discrete
         // argv element (the JS char '\x0d') with --no-paste, so the CR is
         // delivered literally rather than wrapped in paste brackets. The
         // equivalent shell command is:
         //   wezterm cli send-text --pane-id <id> --no-paste $'\x0d'
         // (ANSI-C quoting, note the leading $).
-        await execFileAsync('wezterm', [
-            'cli', 'send-text', '--pane-id', paneId, message,
-        ]);
+        await TtyWriter.execFileWithInput('wezterm', [
+            'cli', 'send-text', '--pane-id', paneId,
+        ], message);
         await new Promise((resolve) => setTimeout(resolve, 150));
         await execFileAsync('wezterm', [
             'cli', 'send-text', '--pane-id', paneId, '--no-paste', CARRIAGE_RETURN,

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -414,6 +414,31 @@ Waiting on user input`,
     expect(mockSpinner.succeed).toHaveBeenCalledWith('Focused repo-a!');
   });
 
+  it('enables debug logging and wires a terminal trace when opening with --debug', async () => {
+    const agent = {
+      name: 'repo-a',
+      status: AgentStatus.WAITING,
+      summary: 'A',
+      lastActive: new Date(),
+      pid: 10,
+    };
+    mockManager.listAgents.mockResolvedValue([agent]);
+    mockManager.resolveAgent.mockReturnValue(agent);
+    mockFocusManager.findTerminal.mockResolvedValue({ type: 'wezterm', identifier: '7' });
+    mockFocusManager.focusTerminal.mockResolvedValue(true);
+
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'open', 'repo-a', '--debug']);
+
+    expect(mockEnableDebug).toHaveBeenCalledTimes(1);
+    // A debug logger callback is passed into TerminalFocusManager so its
+    // matching/focus decision path can be inspected.
+    expect(TerminalFocusManager).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockFocusManager.findTerminal).toHaveBeenCalledWith(10);
+    expect(mockSpinner.succeed).toHaveBeenCalledWith('Focused repo-a!');
+  });
+
   it('kills a resolved agent and reports tmux cleanup', async () => {
     const agent = {
       name: 'repo-a',

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -28,7 +28,7 @@ import {
 } from '@ai-devkit/agent-manager';
 import { ui } from '../util/terminal-ui.js';
 import { withErrorHandler } from '../util/errors.js';
-import { enableDebug } from '../util/debug.js';
+import { enableDebug, createLogger } from '../util/debug.js';
 import {
     formatFirstMessage,
     parseLimit,
@@ -480,9 +480,19 @@ export function registerAgentCommand(program: Command): void {
     agentCommand
         .command('open <name>')
         .description('Focus a running agent terminal')
-        .action(withErrorHandler('open agent', async (name) => {
+        .option('--debug', 'Trace how the agent terminal is resolved and focused')
+        .action(withErrorHandler('open agent', async (name, options) => {
+            const terminalLogger = options.debug ? createLogger('terminal') : undefined;
+            if (options.debug) {
+                enableDebug();
+            }
             const manager = createAgentManager();
-            const focusManager = new TerminalFocusManager();
+            // When --debug is set, route the focus manager's decision trace to
+            // the ai-devkit:terminal debug logger (enabled above) so users can
+            // see which terminal matched and how focus was attempted.
+            const focusManager = new TerminalFocusManager(
+                terminalLogger ? (message: string) => terminalLogger(message) : undefined,
+            );
 
             const agents = await manager.listAgents();
             if (agents.length === 0) {


### PR DESCRIPTION
## Summary

Adds support for discovering, focusing, and sending input to agents running inside **WezTerm**, alongside the existing tmux / iTerm2 / Terminal.app flows.

- `TerminalFocusManager`: new `WEZTERM` terminal type. Discovers the owning WezTerm pane from `wezterm cli list --format json` by matching the agent PID's TTY → pane id; focuses via `wezterm cli focus-pane --pane-id`. Probed **after tmux, before the macOS AppleScript probes**, so non-macOS hosts short-circuit cleanly (tmux-inside-WezTerm still resolves to tmux).
- `TtyWriter`: sends text via `wezterm cli send-text --pane-id` over the child stdin (text, then Enter, 150 ms apart) — the same two-step convention used for the other emulators so a bracketed-paste-aware TUI still sees Enter as a submit.
- CLI-only integration (no AppleScript) → cross-platform (macOS/Linux/Windows). Missing or non-running wezterm degrades like the tmux probe (`null` / `false`), so non-WezTerm users are unaffected.
- **No CLI changes**: `agent open`, `agent send`, and channel bridges pick up WezTerm automatically through the existing `findTerminal` / `focusTerminal` / `TtyWriter.send` abstract API.

Out of scope (deliberate): spawning new agents into WezTerm (that remains `TmuxManager`'s responsibility).