### PR TITLE
feat(agent-manager): add Grok Build CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ One `.ai-devkit.json` configures all of them. Add a new agent to your team witho
 | [Claude Code](https://www.anthropic.com/claude-code) | yes | yes |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | yes | yes |
 | [Codex CLI](https://github.com/openai/codex) | yes | yes |
-| [Grok Build CLI](https://x.ai/cli) | yes | — |
+| [Grok Build CLI](https://x.ai/cli) | yes | yes |
 | [Junie](https://www.jetbrains.com/junie/) | yes | — |
 | [Cline](https://cline.bot/) | yes | — |
 | [Devin](https://devin.ai/) | yes | — |

--- a/docs/ai/design/feature-grok-cli-adapter.md
+++ b/docs/ai/design/feature-grok-cli-adapter.md
@@ -1,0 +1,90 @@
+---
+phase: design
+title: "Grok Build CLI Adapter in @ai-devkit/agent-manager - Design"
+feature: grok-cli-adapter
+description: Architecture and implementation design for the Grok Build CLI detection adapter, launch map entry, and CLI wiring
+---
+
+# Design: Grok Build CLI Adapter for @ai-devkit/agent-manager
+
+## Architecture Overview
+
+```mermaid
+graph TD
+  User[User: ai-devkit agent list/start/open/sessions] --> Cmd[packages/cli/src/commands/agent.ts]
+  Chan[ai-devkit channel runner] --> Runner[services/channel/channel-runner.ts]
+  Cmd --> Manager[AgentManager.detectAgents/listSessions]
+  Runner --> Manager
+
+  subgraph Pkg[@ai-devkit/agent-manager]
+    Manager --> Claude[ClaudeCodeAdapter]
+    Manager --> Codex[CodexAdapter]
+    Manager --> Gemini[GeminiCliAdapter]
+    Manager --> Grok[GrokCliAdapter]
+    Grok --> Proc[process utils: ps scan, matchArgv0 'grok']
+    Grok --> Active[~/.grok/active_sessions.json: pid to cwd]
+    Grok --> Parse[inline chat_history.jsonl parsing]
+    Grok --> Types[AgentAdapter/AgentInfo/AgentStatus]
+  end
+
+  Start[ai-devkit agent start grok] --> AGENTS[utils/agents.ts AGENTS.grok_cli]
+  AGENTS --> Tmux[tmux send-keys 'grok']
+```
+
+Responsibilities:
+- `GrokCliAdapter`: discover running `grok` processes, resolve each to its cwd via `~/.grok/active_sessions.json`, read its session transcript from `chat_history.jsonl`, emit `AgentInfo`, and enumerate historical sessions — with parsing kept inline (as in the other recent adapters).
+- `AGENTS.grok_cli`: launch command + `ps` matcher (consumed by `agent start`, the console start-pane, and `agent.service`).
+- CLI/channel: register the adapter, label the type, validate `--type`.
+
+## Data Models
+
+Reuse `AgentAdapter`, `AgentInfo`, `AgentStatus`, `AgentType`, `SessionSummary`. `AgentType` gains `'grok_cli'`.
+
+Grok on-disk shapes (verified against `grok 0.2.77`):
+- Layout: `~/.grok/sessions/<encodeURIComponent(cwd)>/<session-id>/` (long paths → slug+hash + a `.cwd` file). `GROK_HOME` overrides `~/.grok`.
+- `active_sessions.json` (at the `~/.grok` root): an array of `{ pid, cwd, opened_at }`, one per running session. This is the authoritative pid → cwd map for a live process; Grok adds an entry on start and removes it on exit.
+- `chat_history.jsonl` (per session dir): the transcript, one `{ type: 'system' | 'user' | 'assistant', content }` record per line, where `content` is a string or an array of `{ type: 'text', text }` blocks. Grok wraps the real user prompt in `<user_query>...</user_query>`; other user records are context injections (`<user_info>`, `<system-reminder>`, ...) and are ignored as prompts. The file's mtime is the last-activity time.
+
+Normalized into `AgentInfo`: `name` ← `generateAgentName(projectPath, pid)`; `projectPath` ← cwd from `active_sessions.json` (else the process cwd); `sessionId` ← the session directory name; `summary` ← the last `<user_query>` in `chat_history.jsonl`; `status` ← time-threshold + last-transcript-role heuristic; `sessionFilePath` ← the session dir's `chat_history.jsonl` (so the console's `fs.stat().mtime` cache invalidation tracks conversation growth).
+
+## API Design
+
+### Package
+- Add `'grok_cli'` to `AgentType` (`adapters/AgentAdapter.ts`).
+- New `adapters/GrokCliAdapter.ts` (self-contained); export from `adapters/index.ts` and `index.ts`.
+- `utils/agents.ts`: `StartableAgentType` += `'grok_cli'`; `AGENTS.grok_cli = { command: 'grok', matches: matchArgv0('grok') }`.
+
+### CLI
+- `commands/agent.ts`: import + `registerAdapter(new GrokCliAdapter())`; `TYPE_LABELS.grok_cli = 'Grok CLI'`; extend `--type`/sessions help.
+- `services/channel/channel-runner.ts`: import + `registerAdapter(new GrokCliAdapter())`.
+- `util/sessions.ts`: add `'grok_cli'` to `VALID_AGENT_TYPES`.
+
+## Component Breakdown
+
+1. `packages/agent-manager/src/adapters/GrokCliAdapter.ts` (new, self-contained)
+   - `canHandle`: `argv[0]` basename `grok`/`grok.exe`.
+   - `detectAgents`: `enrichProcesses(listAgentProcesses('grok'))`; for each live process resolve its cwd from `readActiveSessions()` (pid → cwd, falling back to the process cwd), pick the most recently active session dir under `<sessionsDir>/<enc(cwd)>/` via `latestSessionDir`, and read it; live processes with no session dir → process-only RUNNING agents.
+   - inline parsing: `readActiveSessions`, `latestSessionDir`, `readSession`, `parseChatHistory` (extracts `<user_query>` prompts + assistant turns), `determineStatus`, `getConversation`, `decodeGroupCwd`.
+   - `getConversation`/`listSessions`: `listSessions` walks `<sessionsDir>/*/*/` dirs containing `chat_history.jsonl`, strict `cwd` filter against the decoded group cwd.
+
+2. `packages/agent-manager/src/__tests__/adapters/GrokCliAdapter.test.ts` (new)
+   - Fixtures from the real captured format: `canHandle`, no-process → `[]`, active_sessions.json cwd resolution (authoritative over process cwd), process-cwd fallback, most-recent-session selection, process-only fallback, missing-transcript dir, conversation extraction (`<user_query>` prompts, context-injection skip, verbose system), status mapping, `listSessions` + cwd filter.
+
+3. Exports, launch map, CLI registration, labels, validation — per API Design. README matrix Remote-control row.
+
+## Design Decisions
+
+- Detect Grok via `matchArgv0('grok')` — Grok is a native binary at `~/.grok/bin/grok` (`argv[0]` is the binary), unlike Gemini's Node script.
+- Resolve a live process's cwd from `~/.grok/active_sessions.json` (the pid → cwd registry Grok maintains), not from `--resume <id>` or CWD + birth-time heuristics; the lsof-derived process cwd is only a fallback when the pid is not registered.
+- Keep parsing **inline** in the adapter (no separate parser util) — matches Gemini/Codex/Copilot/Pi and the maintainer's "đừng custom quá nhiều" guidance; only the original Claude adapter externalizes its parser.
+- Treat each session **directory** as the unit; the directory name is the sessionId; the cwd comes from `active_sessions.json` (live) or the decoded group dir / `.cwd` file (historical).
+- Parse `chat_history.jsonl` (the transcript) for conversation and summary, not `summary.json`/`updates.jsonl`; take the prompt inside `<user_query>...</user_query>` and skip context-injection user records.
+- `sessionFilePath` points at `chat_history.jsonl` so live-tail cache invalidation works; `getConversation` accepts either the file path or the session dir.
+- Keep parsing resilient — a missing/malformed `chat_history.jsonl` skips the session; adapter-level failures return empty results so other adapters still render.
+
+## Non-Functional Requirements
+
+- Performance: detection session reads are scoped to the encoded-cwd group dirs of live processes; `listSessions` walks `~/.grok/sessions` once.
+- Reliability: Grok adapter failures are isolated so Claude/Codex/Gemini entries still render.
+- Maintainability: detection flow and helper names mirror the existing adapters.
+- Security: reads only local files under `~/.grok` and local `ps`/`lsof` output already permitted by existing adapters.

--- a/docs/ai/implementation/feature-grok-cli-adapter.md
+++ b/docs/ai/implementation/feature-grok-cli-adapter.md
@@ -1,0 +1,73 @@
+---
+phase: implementation
+title: "Grok Build CLI Adapter in @ai-devkit/agent-manager - Implementation"
+feature: grok-cli-adapter
+description: Implementation notes for the Grok CLI detection adapter, launch map entry, and CLI wiring
+---
+
+# Implementation Guide: Grok Build CLI Adapter in @ai-devkit/agent-manager
+
+## Development Setup
+
+- Branch: `feat/grok-cli-support`
+- Install dependencies with `npm install` (a fresh install leaves sibling `dist/` stale, so build before running `cli` tests).
+- Build + lint + test:
+  - `npx nx run agent-manager:build`
+  - `npx nx run agent-manager:test`
+  - `npx nx run cli:test`
+  - `npx nx run-many -t build test lint`
+- For end-to-end verification: `grok` installed via `https://x.ai/cli/install.sh` (verified against `grok 0.2.77`), plus `tmux` for the managed-start path.
+
+## Code Structure
+
+- Adapter + agent type + launch map:
+  - `packages/agent-manager/src/adapters/GrokCliAdapter.ts` (self-contained; parsing inline)
+  - `packages/agent-manager/src/adapters/AgentAdapter.ts` (`AgentType` += `'grok_cli'`)
+  - `packages/agent-manager/src/utils/agents.ts` (`AGENTS.grok_cli`, `StartableAgentType`)
+- Package exports: `packages/agent-manager/src/adapters/index.ts`, `packages/agent-manager/src/index.ts`
+- CLI wiring:
+  - `packages/cli/src/commands/agent.ts` (register adapter, `TYPE_LABELS`, `--type` help)
+  - `packages/cli/src/services/channel/channel-runner.ts` (register adapter)
+  - `packages/cli/src/util/sessions.ts` (`VALID_AGENT_TYPES`)
+- Tests: `packages/agent-manager/src/__tests__/adapters/GrokCliAdapter.test.ts`, `__tests__/utils/agents.test.ts`, plus asserted-array updates in `cli` (`StartAgentPane`, `sessions`, `agent`, `channel`).
+- Docs: `README.md` (Remote-control matrix row).
+
+## Implementation Notes
+
+### Core Features
+- Adapter contract: `type = 'grok_cli'`, plus `canHandle`, `detectAgents`, `getConversation`, `listSessions`.
+- Process detection: `listAgentProcesses('grok')` matches the native binary's `argv[0]` basename `grok`/`grok.exe`; `AGENTS` matcher is `matchArgv0('grok')` (not Gemini's `matchAnyToken`).
+- Session location: `~/.grok/sessions/<encodeURIComponent(cwd)>/<session-id>/` (override base via `GROK_HOME`). A live process is resolved to its cwd via `~/.grok/active_sessions.json` (`{ pid, cwd, opened_at }[]`); the process cwd is only a fallback. Per cwd the most recently active session dir (newest `chat_history.jsonl` mtime) is used.
+- Inline parsing: `chat_history.jsonl` → one `{ type, content }` record per line; user prompts are the text inside `<user_query>...</user_query>` (other user records are context injections and skipped); assistant turns are the `type:'assistant'` text; verbose adds `type:'system'`. `sessionId` is the dir name; `lastActive` is the file mtime.
+- `AgentInfo.sessionFilePath` / `SessionSummary.sessionFilePath` point at `chat_history.jsonl` so the console's `fs.stat().mtime` cache invalidation tracks conversation growth; `getConversation` accepts the file path or the session directory.
+
+### Patterns & Best Practices
+- Resolve cwd from `active_sessions.json` (cwd encoded in the session path), but keep parsing **inline** like the other recent adapters (Gemini/Codex/Copilot/Pi) — "đừng custom quá nhiều".
+- Fail soft: a missing/malformed `chat_history.jsonl` skips the session; adapter-level failures return empty so other adapters still render.
+
+## Integration Points
+
+- `AgentManager` parallel aggregation across Claude + Codex + Gemini + Grok.
+- `agent start` / console start-pane / `agent.service` launch are data-driven from `AGENTS`, so the `grok_cli` entry wires them automatically.
+- CLI list/json/sessions output mapping unchanged.
+
+## Error Handling
+
+- Missing `~/.grok/sessions` → empty result, no throw.
+- Missing/malformed `chat_history.jsonl` → session skipped.
+- A live `grok` process with no matched session → surfaced as a process-only RUNNING agent.
+- Long-path session group dirs → original path read from the `.cwd` file; `active_sessions.json` cwd is authoritative for live processes.
+
+## Out of Scope (follow-up PRs)
+
+- The Grok **setup environment** (`env.ts`/`types.ts`, `.grok/skills`) — separate PR, mirroring how Pi's environment landed after its adapter PR.
+- Console label maps (`agentTypeLabel.ts`); web docs; README-zh; channel-connector hook forwarding.
+
+## Implementation Status
+
+- Completed: adapter (inline parsing), agent type, launch map, package exports, CLI registration (both sites), labels, validation, README matrix row, docs.
+- Commands verified:
+  - `npx nx run-many -t build test lint` ✅
+  - `npx nx run agent-manager:test` ✅ · `npx nx run cli:test` ✅
+  - Parser logic validated against a real on-disk `grok 0.2.77` session.
+  - End-to-end via the built CLI: `agent start --type grok_cli` (tmux) → `agent list` shows the running agent; `agent sessions --type grok_cli` lists the real on-disk session.

--- a/docs/ai/planning/feature-grok-cli-adapter.md
+++ b/docs/ai/planning/feature-grok-cli-adapter.md
@@ -1,0 +1,69 @@
+---
+phase: planning
+title: "Grok Build CLI Adapter in @ai-devkit/agent-manager - Planning"
+feature: grok-cli-adapter
+description: Task plan for adding the Grok CLI detection adapter, launch map entry, and CLI wiring, following the existing adapter patterns
+---
+
+# Planning: Grok Build CLI Adapter in @ai-devkit/agent-manager
+
+> Execution: TDD, mirror `ClaudeCodeAdapter`'s detection flow but keep parsing inline like the recent adapters (maintainer guidance "đừng custom quá nhiều"). Rebuild dependency packages (`npm run build`) before running `cli` tests — they import sibling `dist/`. The husky pre-commit hook runs the full `nx run-many -t lint test`.
+
+## Milestones
+
+- [x] Milestone 1: Research Grok CLI distribution + session schema (captured from real `grok 0.2.77`)
+- [x] Milestone 2: Self-contained adapter + launch map + unit tests
+- [x] Milestone 3: CLI/channel wiring + asserted-test updates + README matrix row
+- [x] Milestone 4: Real-Grok end-to-end verification
+
+## Global Constraints
+
+- Agent type string: `grok_cli`. Launch command `grok`; matcher `matchArgv0('grok')` (native binary).
+- Session base `~/.grok/sessions/` (override `GROK_HOME`); per-session dir `<encodeURIComponent(cwd)>/<session-id>/`.
+- Conversation source: `chat_history.jsonl` (the transcript). Live cwd from `active_sessions.json`.
+- Parsing kept inline in the adapter (no separate parser util).
+- Vitest tests; isolate adapter errors so other adapters still render.
+
+## Task Breakdown
+
+### Phase 1: Research & Foundation
+- [x] Confirm Grok is a native binary at `~/.grok/bin/grok`; `argv[0]` basename `grok`.
+- [x] Capture real session layout `~/.grok/sessions/%2F.../<uuidv7>/` with `chat_history.jsonl`, and `~/.grok/active_sessions.json`.
+- [x] Confirm schemas (`active_sessions.json` `{ pid, cwd, opened_at }[]`; `chat_history.jsonl` `{ type, content }` records with `<user_query>` prompts) and cwd encoding (`encodeURIComponent`).
+
+### Phase 2: Adapter (agent-manager)
+- [x] Add `'grok_cli'` to `AgentType` (`adapters/AgentAdapter.ts`).
+- [x] Implement self-contained `GrokCliAdapter` (`canHandle`, `detectAgents` via `active_sessions.json`, inline `chat_history.jsonl` parsing, `getConversation`, `listSessions`) + unit tests.
+- [x] Add `AGENTS.grok_cli` + `StartableAgentType` (`utils/agents.ts`) + `agents.test.ts`.
+- [x] Export `GrokCliAdapter` from `adapters/index.ts` and `index.ts`.
+
+### Phase 3: CLI / channel
+- [x] Register adapter in `commands/agent.ts` (+ `TYPE_LABELS`, `--type` help) and `services/channel/channel-runner.ts`.
+- [x] Add `'grok_cli'` to `VALID_AGENT_TYPES` (`util/sessions.ts`).
+- [x] Update asserted tests (`StartAgentPane`, `sessions`, `agent`, `channel`).
+- [x] Add Grok to the README matrix under Remote control (`— | yes`).
+
+### Phase 4: Verification
+- [x] End-to-end: `agent start --type grok_cli` (tmux) → `agent list` shows the running agent; `agent sessions --type grok_cli` lists the real on-disk session. Inline parsing validated against the real session dir.
+
+## Dependencies
+
+- `@ai-devkit/agent-manager` adapter contract + shared utils (`process`, `session`, `matching`).
+- CLI agent command + channel-runner registration sites.
+- A Grok CLI install for end-to-end verification (installed: `grok 0.2.77`); `tmux` for the start path.
+
+## Risks & Mitigation
+
+- Risk: Grok session schema evolves. Mitigation: defensive parsing, fixtures for partial/malformed inputs, prefer `active_sessions.json` cwd for live processes.
+- Risk: assistant transcript shape unverified (no subscribed session). Mitigation: `type:'assistant'` records mirror the verified user records (an array of `{type:'text', text}` blocks); validate when a subscribed session is available.
+- Risk: adding an `AgentType`/`StartableAgentType` member breaks exact-array test assertions. Mitigation: update them explicitly.
+- Risk: cli tests import stale sibling `dist`. Mitigation: `npm run build` before cli tests.
+
+## Out of Scope (follow-up PRs)
+
+- Grok **setup environment** (`env.ts`/`types.ts`, `.grok/skills`) — separate PR (as Pi's environment followed its adapter).
+- Console label maps (`agentTypeLabel.ts`), web docs, README-zh, channel-connector hook forwarding.
+
+## Progress Summary
+
+Schemas verified against a real `grok 0.2.77` session. The self-contained `GrokCliAdapter` ships in `@ai-devkit/agent-manager`, is exported and launch-mapped (`AGENTS.grok_cli`), and is registered in the CLI agent command and channel runner. Grok is listed under Remote control in the README matrix. End-to-end verified via the built CLI (start in tmux → list; sessions list against the real on-disk session).

--- a/docs/ai/requirements/feature-grok-cli-adapter.md
+++ b/docs/ai/requirements/feature-grok-cli-adapter.md
@@ -31,7 +31,7 @@ Who is affected:
 ### Secondary Goals
 - Reuse shared process/session utilities (`listAgentProcesses`, `enrichProcesses`, `generateAgentName`).
 - Mirror `ClaudeCodeAdapter`'s detection flow; keep session parsing **inline** in the adapter as the other recent adapters do (Gemini/Codex/Copilot/Pi) — "đừng custom quá nhiều".
-- Cover detection, session-directory discovery, ACP conversation extraction, status mapping, and `listSessions` with unit tests built from fixtures matching the real on-disk format.
+- Cover detection, session-directory discovery, `chat_history.jsonl` conversation extraction, status mapping, and `listSessions` with unit tests built from fixtures matching the real on-disk format.
 
 ### Non-Goals
 - The **Grok setup environment** (`ai-devkit init` writing `.grok/skills` etc.) — a separate follow-up, mirroring how Pi's environment landed after its adapter PR.
@@ -71,5 +71,5 @@ Who is affected:
 
 - Resolved (2026-06-30): Issue #107 targets xAI's **official** Grok Build CLI (`x.ai/cli`), not the community `superagent-ai/grok-cli` (SQLite `~/.grok/grok.db`). All schemas were captured from a real `grok 0.2.77` session.
 - Resolved (2026-06-30): cwd encoding is `encodeURIComponent`; a live process's cwd is read from `active_sessions.json`, so encoding is only used to locate the session dir for that cwd.
-- Resolved (2026-06-30): conversation source is `updates.jsonl` (ACP), not `chat_history.jsonl` (raw model messages incl. system prompt).
-- Open: real **assistant** `agent_message_chunk` content was not captured (the test account had no Grok credits → 403). The shape is the ACP standard (mirrors the verified `user_message_chunk`); validate during end-to-end verification once a credited session exists.
+- Resolved (2026-07-01): conversation source is `chat_history.jsonl` (the transcript Grok persists per session), not `summary.json`/`updates.jsonl`. An earlier draft read `updates.jsonl` (ACP); corrected after confirming `chat_history.jsonl` is the authoritative record. The real user prompt is taken from `<user_query>...</user_query>` and context-injection user records are skipped, so the system prompt is not surfaced.
+- Open: real **assistant** content was not captured (the test account had no Grok credits → paywall before a reply). Assistant turns are `{ type: "assistant", content }` records in `chat_history.jsonl`, mirroring the verified user records; validate during end-to-end verification once a credited session exists.

--- a/docs/ai/requirements/feature-grok-cli-adapter.md
+++ b/docs/ai/requirements/feature-grok-cli-adapter.md
@@ -1,0 +1,75 @@
+---
+phase: requirements
+title: "Grok Build CLI Adapter in @ai-devkit/agent-manager - Requirements"
+feature: grok-cli-adapter
+description: Add a Grok Build CLI adapter to the shared agent-manager package so Grok sessions are detected, listed, inspected, and launchable alongside Claude, Codex, and Gemini
+---
+
+# Requirements: Add Grok Build CLI Adapter to @ai-devkit/agent-manager
+
+Tracking issue: [#107 Support Grok Build CLI](https://github.com/codeaholicguy/ai-devkit/issues/107) (links https://x.ai/cli).
+
+## Problem Statement
+
+`@ai-devkit/agent-manager` ships adapters for Claude, Codex, Gemini, Copilot, opencode, and Pi, and the `AGENTS` launch map lets the CLI/console start each one. **Grok Build CLI** — xAI's official terminal agent (command `grok`, installed via `https://x.ai/cli/install.sh`) — is not detected or launchable, so it never appears in `ai-devkit agent list`/`console` and cannot be started with `ai-devkit agent start`.
+
+Who is affected:
+- Grok users who expect `ai-devkit agent list`/`sessions` to surface Grok sessions next to Claude/Codex/Gemini, and `agent start grok` to launch one.
+- Maintainers who want the README support matrix to reflect real capability.
+- Contributors who need a reference for a **native-binary** agent whose sessions are stored as **per-session directories** (distinct from Claude's single-file-per-session and Gemini's opaque-hash layout).
+
+## Goals & Objectives
+
+### Primary Goals
+- Implement a package-level `GrokCliAdapter` under `packages/agent-manager` implementing the full `AgentAdapter` contract (`canHandle`, `detectAgents`, `getConversation`, `listSessions`).
+- Add `'grok_cli'` to `AgentType` and export `GrokCliAdapter` from package entry points.
+- Add a `grok_cli` entry to the `AGENTS` launch map so `agent start`, the console start-pane, and tmux launch work.
+- Register `GrokCliAdapter` in the CLI agent command and channel runner, and add it to `TYPE_LABELS`, the `--type` help, and `VALID_AGENT_TYPES`.
+- Add Grok to the README "Works across coding agents" matrix under **Remote control**.
+- Preserve existing Claude/Codex/Gemini behavior and output contracts.
+
+### Secondary Goals
+- Reuse shared process/session utilities (`listAgentProcesses`, `enrichProcesses`, `generateAgentName`).
+- Mirror `ClaudeCodeAdapter`'s detection flow; keep session parsing **inline** in the adapter as the other recent adapters do (Gemini/Codex/Copilot/Pi) — "đừng custom quá nhiều".
+- Cover detection, session-directory discovery, ACP conversation extraction, status mapping, and `listSessions` with unit tests built from fixtures matching the real on-disk format.
+
+### Non-Goals
+- The **Grok setup environment** (`ai-devkit init` writing `.grok/skills` etc.) — a separate follow-up, mirroring how Pi's environment landed after its adapter PR.
+- Wiring Grok lifecycle **hooks** into the channel-connector PreToolUse forwarder.
+- Console label maps (`agentTypeLabel.ts`) — copilot/pi aren't listed there either; out of scope.
+- Hosted/remote Grok sessions (local CLI sessions only).
+
+## User Stories & Use Cases
+
+1. As a Grok user, I want active Grok sessions to appear in `ai-devkit agent list`/`console` so I can inspect them alongside Claude/Codex/Gemini.
+2. As a CLI user, I want `ai-devkit agent start grok` to launch Grok in a managed tmux session.
+3. As a CLI user, I want `ai-devkit agent sessions --type grok_cli` to list historical Grok sessions and `agent open`/`send` to work.
+4. As a maintainer, I want Grok detection in `@ai-devkit/agent-manager` to follow the existing adapter structure to avoid drift.
+
+## Success Criteria
+
+- `packages/agent-manager/src/adapters/GrokCliAdapter.ts` exists, implements `AgentAdapter` with `type: 'grok_cli'`, and is self-contained (parsing inline).
+- `GrokCliAdapter` is exported from `adapters/index.ts` and `index.ts`; `AGENTS.grok_cli` launches `grok`.
+- `GrokCliAdapter` is registered in `commands/agent.ts` and `services/channel/channel-runner.ts`; `grok_cli` appears in `TYPE_LABELS`, `--type` help, and `VALID_AGENT_TYPES`.
+- Unit tests cover happy path, empty path, malformed data, process filtering, `active_sessions.json` cwd resolution, most-recent-session selection, `chat_history.jsonl` conversation extraction, status mapping, and `listSessions` cwd filter; `nx run agent-manager:test` and `nx run cli:test` pass.
+- README matrix lists Grok under **Remote control** (`— | yes`).
+- A real running Grok session appears in `ai-devkit agent list` during end-to-end verification.
+
+## Constraints & Assumptions
+
+### Technical Constraints
+- Follow the existing Nx TypeScript structure and Vitest conventions; keep the `AgentAdapter` contract and JSON/table output schema unchanged.
+- Isolate adapter errors so a Grok failure never breaks list/open for other adapters.
+
+### Assumptions (verified against grok 0.2.77 on macOS-aarch64)
+- Grok is a **native binary** at `~/.grok/bin/grok`; process `argv[0]` basename is `grok` → matcher is `matchArgv0('grok')` (unlike Gemini's Node-script `matchAnyToken`).
+- Sessions live under `~/.grok/sessions/<encodeURIComponent(cwd)>/<session-id>/` (long paths → slug+hash + a `.cwd` file). `GROK_HOME` overrides the `~/.grok` base. `<session-id>` is a UUIDv7 and is used directly as the adapter's sessionId (the session directory name).
+- `active_sessions.json` shape (at the `~/.grok` root): an array of `{ pid, cwd, opened_at }`, one entry per running session; Grok adds it on start and removes it on exit. This is the authoritative pid → cwd map for a live process.
+- `chat_history.jsonl` shape (per session dir): newline-delimited `{ type: "system" | "user" | "assistant", content }` records, where `content` is a string or an array of `{ type: "text", text }` blocks. The real user prompt is wrapped in `<user_query>...</user_query>`; other user records are context injections and are ignored as prompts.
+
+## Questions & Open Items
+
+- Resolved (2026-06-30): Issue #107 targets xAI's **official** Grok Build CLI (`x.ai/cli`), not the community `superagent-ai/grok-cli` (SQLite `~/.grok/grok.db`). All schemas were captured from a real `grok 0.2.77` session.
+- Resolved (2026-06-30): cwd encoding is `encodeURIComponent`; a live process's cwd is read from `active_sessions.json`, so encoding is only used to locate the session dir for that cwd.
+- Resolved (2026-06-30): conversation source is `updates.jsonl` (ACP), not `chat_history.jsonl` (raw model messages incl. system prompt).
+- Open: real **assistant** `agent_message_chunk` content was not captured (the test account had no Grok credits → 403). The shape is the ACP standard (mirrors the verified `user_message_chunk`); validate during end-to-end verification once a credited session exists.

--- a/docs/ai/testing/feature-grok-cli-adapter.md
+++ b/docs/ai/testing/feature-grok-cli-adapter.md
@@ -1,0 +1,65 @@
+---
+phase: testing
+title: "Grok Build CLI Adapter in @ai-devkit/agent-manager - Testing"
+feature: grok-cli-adapter
+description: Test strategy and coverage for the Grok CLI adapter, launch map, and CLI wiring
+---
+
+# Testing Strategy: Grok Build CLI Adapter in @ai-devkit/agent-manager
+
+## Test Coverage Goals
+
+- Unit coverage: all new paths in `GrokCliAdapter` (detection + inline parsing).
+- Integration scope: adapter registration (`agent` command + channel runner), launch map, labels, and `--type` validation.
+- End-to-end scope: real `ai-devkit agent start/list/sessions` against a live `grok` install.
+
+## Unit Tests
+
+### `GrokCliAdapter` (`GrokCliAdapter.test.ts`)
+- [x] Exposes `grok_cli` type
+- [x] `canHandle` true for `grok` (plain + full path + args); false for non-grok / arg-only matches
+- [x] `detectAgents` returns `[]` with no processes
+- [x] Resolves cwd via `active_sessions.json` (authoritative over the process cwd)
+- [x] Falls back to the process cwd when the pid is not in `active_sessions.json`
+- [x] Picks the most recently active session dir when a cwd has several
+- [x] Process-only RUNNING fallback when no session matches
+- [x] Session dir without `chat_history.jsonl` → no match (process-only)
+- [x] `getConversation` maps user (`<user_query>`) + assistant records; skips context-injection user records
+- [x] `getConversation` skips malformed lines
+- [x] `getConversation` excludes system records unless verbose
+- [x] Status: WAITING on trailing assistant message; RUNNING on trailing user message; IDLE past threshold
+- [x] Agent summary is the last `<user_query>` prompt
+- [x] `listSessions` returns `[]` when sessions dir absent; returns summaries with cwd decoded from the group dir; applies cwd filter; skips non-session entries (e.g. `prompt_history.jsonl`)
+
+### Launch map (`agents.test.ts`)
+- [x] `AGENTS.grok_cli.command === 'grok'`; `matchArgv0('grok')` matches the binary, rejects arg-only paths
+
+## Integration Tests (cli)
+
+- [x] `agent` command registers `GrokCliAdapter` (registerAdapter called 7×)
+- [x] `channel` runner registers `GrokCliAdapter` (registerAdapter called 6×)
+- [x] `STARTABLE_AGENT_TYPES` includes `grok_cli` in pane order
+- [x] `--type grok_cli` is accepted; invalid `--type` error lists `grok_cli`
+
+## End-to-End Tests
+
+- [x] `listSessions()` against the real `~/.grok` lists the on-disk session `019f16c3-…` with `cwd`, `firstUserMessage:"hello"`, and the `chat_history.jsonl` `sessionFilePath`.
+- [x] `getConversation()` against the real `chat_history.jsonl` returns `[{role:"user",content:"hello"}]`.
+- [x] `detectAgents()` with a live `grok` process + `active_sessions.json` resolves the cwd, picks the `019f16c3-…` session, and surfaces `{type:"grok_cli", projectPath:<repo>, summary:"hello"}`.
+- [x] Regression: full `agent-manager` (453) and `cli` (844) suites pass.
+
+## Test Data
+
+- Synthetic fixtures matching the captured real format: `active_sessions.json` (`{ pid, cwd, opened_at }[]`) and `chat_history.jsonl` (`{ type, content }` records with `<user_query>` prompts, context injections, and assistant turns). Temp `HOME`/session dirs via `fs.mkdtempSync`; `process.js`/`matching.js` mocked.
+
+## Test Reporting & Coverage
+
+- Commands:
+  - `npx nx run agent-manager:lint` ✅ · `npx nx run agent-manager:build` ✅
+  - `npx nx run agent-manager:test` ✅ · `npx nx run cli:test` ✅
+  - `npx nx run-many -t build test lint` ✅
+
+## Open Items
+
+- The `active_sessions.json` schema (`{ pid, cwd, opened_at }`) was confirmed from the Grok binary, but a live entry could not be captured because the test account has no Grok subscription — the session stops at the paywall before registering. The end-to-end `detectAgents` check therefore injects a real-shape entry for the live `grok` pid; re-confirm against a subscribed session when available.
+- Real **assistant** transcript content was not captured for the same reason (403 at the paywall). The `type:'assistant'` records mirror the verified user records (an array of `{type:'text', text}` blocks); re-confirm against a subscribed session.

--- a/packages/agent-manager/src/__tests__/adapters/GrokCliAdapter.test.ts
+++ b/packages/agent-manager/src/__tests__/adapters/GrokCliAdapter.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for GrokCliAdapter
+ *
+ * The adapter resolves a live process to its cwd via ~/.grok/active_sessions.json
+ * and reads session details from chat_history.jsonl (not summary.json/updates.jsonl).
+ */
+
+import type { MockedFunction } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { GrokCliAdapter } from '../../adapters/GrokCliAdapter.js';
+import type { ProcessInfo } from '../../adapters/AgentAdapter.js';
+import { AgentStatus } from '../../adapters/AgentAdapter.js';
+import { listAgentProcesses, enrichProcesses } from '../../utils/process.js';
+import { generateAgentName } from '../../utils/matching.js';
+
+vi.mock('../../utils/process.js', async (importOriginal) => {
+    const actual = (await importOriginal()) as typeof import('../../utils/process.js');
+    return {
+        ...actual,
+        listAgentProcesses: vi.fn(),
+        enrichProcesses: vi.fn(),
+    };
+});
+
+vi.mock('../../utils/matching.js', async (importOriginal) => {
+    const actual = (await importOriginal()) as typeof import('../../utils/matching.js');
+    return {
+        ...actual,
+        generateAgentName: vi.fn(),
+    };
+});
+
+const mockedListAgentProcesses = listAgentProcesses as MockedFunction<typeof listAgentProcesses>;
+const mockedEnrichProcesses = enrichProcesses as MockedFunction<typeof enrichProcesses>;
+const mockedGenerateAgentName = generateAgentName as MockedFunction<typeof generateAgentName>;
+
+const SESSION_ID = '019f16c3-5d5d-7dc3-85d1-bc629416ca2d';
+
+/** A user transcript record: the real prompt wrapped in <user_query> like Grok writes it. */
+const userRecord = (text: string) => ({
+    type: 'user',
+    content: [{ type: 'text', text: `<user_query>\n${text}\n</user_query>` }],
+});
+/** A user context-injection record (no <user_query>) — should be ignored as a prompt. */
+const contextRecord = (text: string) => ({ type: 'user', content: [{ type: 'text', text }] });
+const assistantRecord = (text: string) => ({ type: 'assistant', content: [{ type: 'text', text }] });
+const systemRecord = (text: string) => ({ type: 'system', content: text });
+
+describe('GrokCliAdapter', () => {
+    let adapter: GrokCliAdapter;
+    let tmpHome: string;
+    let cwd: string;
+
+    beforeEach(() => {
+        tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-adapter-test-'));
+        process.env.HOME = tmpHome;
+        delete process.env.GROK_HOME;
+        cwd = '/Users/dev/my-project';
+
+        adapter = new GrokCliAdapter();
+
+        mockedListAgentProcesses.mockReset();
+        mockedEnrichProcesses.mockReset();
+        mockedGenerateAgentName.mockReset();
+
+        mockedEnrichProcesses.mockImplementation((procs) => procs);
+        mockedGenerateAgentName.mockImplementation((c: string, pid: number) => `${path.basename(c) || 'unknown'}-${pid}`);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    /** Write a session dir under ~/.grok/sessions/<enc(cwd)>/<id>/chat_history.jsonl. */
+    function writeSession(opts: {
+        sessionCwd?: string;
+        id?: string;
+        records?: object[];
+        chat?: boolean;
+        mtime?: Date;
+    }): string {
+        const sessionCwd = opts.sessionCwd ?? cwd;
+        const id = opts.id ?? SESSION_ID;
+        const sessionDir = path.join(tmpHome, '.grok', 'sessions', encodeURIComponent(sessionCwd), id);
+        fs.mkdirSync(sessionDir, { recursive: true });
+
+        if (opts.chat !== false) {
+            const records = opts.records ?? [userRecord('fix the bug')];
+            const chatPath = path.join(sessionDir, 'chat_history.jsonl');
+            fs.writeFileSync(chatPath, records.map((r) => JSON.stringify(r)).join('\n'));
+            if (opts.mtime) fs.utimesSync(chatPath, opts.mtime, opts.mtime);
+        }
+
+        return sessionDir;
+    }
+
+    /** Write ~/.grok/active_sessions.json (the live pid -> cwd registry). */
+    function writeActiveSessions(entries: Array<{ pid: number; cwd: string; opened_at?: number }>): void {
+        fs.mkdirSync(path.join(tmpHome, '.grok'), { recursive: true });
+        fs.writeFileSync(path.join(tmpHome, '.grok', 'active_sessions.json'), JSON.stringify(entries));
+    }
+
+    function proc(overrides: Partial<ProcessInfo> = {}): ProcessInfo {
+        return { pid: 4242, ppid: 1, command: 'grok', cwd, tty: 'ttys010', startTime: new Date(), ...overrides };
+    }
+
+    describe('initialization', () => {
+        it('exposes the grok_cli type', () => {
+            expect(adapter.type).toBe('grok_cli');
+        });
+    });
+
+    describe('canHandle', () => {
+        it('returns true for a plain grok command', () => {
+            expect(adapter.canHandle(proc({ command: 'grok' }))).toBe(true);
+        });
+
+        it('returns true for grok with a full path and args', () => {
+            expect(adapter.canHandle(proc({ command: '/Users/dev/.grok/bin/grok --always-approve' }))).toBe(true);
+        });
+
+        it('returns false for non-grok processes', () => {
+            expect(adapter.canHandle(proc({ command: 'node app.js' }))).toBe(false);
+        });
+
+        it('returns false when "grok" appears only in an argument path', () => {
+            expect(adapter.canHandle(proc({ command: 'node /path/to/grok-thing.js' }))).toBe(false);
+        });
+    });
+
+    describe('detectAgents', () => {
+        it('returns [] when there are no grok processes', async () => {
+            mockedListAgentProcesses.mockReturnValue([]);
+            expect(await adapter.detectAgents()).toEqual([]);
+        });
+
+        it('resolves the cwd via active_sessions.json (authoritative over the process cwd)', async () => {
+            const realCwd = '/Users/dev/real-project';
+            writeSession({ sessionCwd: realCwd });
+            // The process cwd is stale/wrong; active_sessions.json has the truth.
+            writeActiveSessions([{ pid: 4242, cwd: realCwd, opened_at: 1 }]);
+            mockedListAgentProcesses.mockReturnValue([proc({ cwd: '/wrong/path' })]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents).toHaveLength(1);
+            expect(agents[0]).toMatchObject({
+                type: 'grok_cli',
+                pid: 4242,
+                projectPath: realCwd,
+                sessionId: SESSION_ID,
+                summary: 'fix the bug',
+            });
+            expect(agents[0].sessionFilePath).toBe(
+                path.join(tmpHome, '.grok', 'sessions', encodeURIComponent(realCwd), SESSION_ID, 'chat_history.jsonl'),
+            );
+        });
+
+        it('falls back to the process cwd when the pid is not in active_sessions.json', async () => {
+            writeSession({});
+            writeActiveSessions([{ pid: 9999, cwd: '/somewhere/else' }]);
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents[0]).toMatchObject({ projectPath: cwd, sessionId: SESSION_ID });
+        });
+
+        it('picks the most recently active session dir when a cwd has several', async () => {
+            const older = new Date(Date.now() - 60 * 60 * 1000);
+            writeSession({ id: '019f0000-0000-7000-8000-00000000000a', records: [userRecord('old one')], mtime: older });
+            writeSession({ id: '019f0000-0000-7000-8000-00000000000b', records: [userRecord('newest one')] });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents[0].sessionId).toBe('019f0000-0000-7000-8000-00000000000b');
+            expect(agents[0].summary).toBe('newest one');
+        });
+
+        it('falls back to a process-only RUNNING agent when no session matches', async () => {
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents).toHaveLength(1);
+            expect(agents[0].status).toBe(AgentStatus.RUNNING);
+            expect(agents[0].sessionId).toBe('pid-4242');
+            expect(agents[0].sessionFilePath).toBeUndefined();
+        });
+
+        it('treats a session dir without chat_history.jsonl as no match (process-only)', async () => {
+            writeSession({ chat: false });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents).toHaveLength(1);
+            expect(agents[0].sessionId).toBe('pid-4242');
+        });
+    });
+
+    describe('getConversation', () => {
+        it('maps user (<user_query>) and assistant records to roles', () => {
+            const dir = writeSession({ records: [userRecord('hi'), assistantRecord('hello')] });
+            expect(adapter.getConversation(path.join(dir, 'chat_history.jsonl'))).toEqual([
+                { role: 'user', content: 'hi' },
+                { role: 'assistant', content: 'hello' },
+            ]);
+        });
+
+        it('accepts a session dir path and skips context-injection user records', () => {
+            const dir = writeSession({
+                records: [contextRecord('<user_info>OS: macos</user_info>'), userRecord('do the thing')],
+            });
+            expect(adapter.getConversation(dir)).toEqual([{ role: 'user', content: 'do the thing' }]);
+        });
+
+        it('skips malformed lines', () => {
+            const dir = writeSession({ records: [userRecord('hi')] });
+            fs.appendFileSync(path.join(dir, 'chat_history.jsonl'), '\n{bad json');
+            expect(adapter.getConversation(dir)).toEqual([{ role: 'user', content: 'hi' }]);
+        });
+
+        it('excludes system records unless verbose', () => {
+            const dir = writeSession({ records: [systemRecord('You are Grok'), userRecord('go')] });
+            expect(adapter.getConversation(dir)).toEqual([{ role: 'user', content: 'go' }]);
+            expect(adapter.getConversation(dir, { verbose: true }).map((m) => m.role)).toEqual(['system', 'user']);
+        });
+    });
+
+    describe('detectAgents status + summary mapping', () => {
+        const detectFirst = async () => (await adapter.detectAgents())[0];
+
+        it('marks WAITING when the last transcript turn is an assistant message', async () => {
+            writeSession({ records: [userRecord('go'), assistantRecord('done')] });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).status).toBe(AgentStatus.WAITING);
+        });
+
+        it('marks RUNNING when the last transcript turn is a user message', async () => {
+            writeSession({ records: [userRecord('still there?')] });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).status).toBe(AgentStatus.RUNNING);
+        });
+
+        it('marks IDLE when chat_history.jsonl is older than the threshold', async () => {
+            const old = new Date(Date.now() - 10 * 60 * 1000);
+            writeSession({ records: [userRecord('go')], mtime: old });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).status).toBe(AgentStatus.IDLE);
+        });
+
+        it('uses the last user prompt as the agent summary', async () => {
+            writeSession({ records: [userRecord('refactor the parser'), assistantRecord('on it')] });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).summary).toBe('refactor the parser');
+        });
+    });
+
+    describe('listSessions', () => {
+        it('returns [] when the sessions dir does not exist', async () => {
+            expect(await adapter.listSessions()).toEqual([]);
+        });
+
+        it('lists historical sessions with cwd decoded from the group dir', async () => {
+            writeSession({});
+            const summaries = await adapter.listSessions();
+            expect(summaries).toHaveLength(1);
+            expect(summaries[0]).toMatchObject({
+                type: 'grok_cli',
+                sessionId: SESSION_ID,
+                cwd,
+                firstUserMessage: 'fix the bug',
+            });
+            expect(summaries[0].sessionFilePath).toBe(
+                path.join(tmpHome, '.grok', 'sessions', encodeURIComponent(cwd), SESSION_ID, 'chat_history.jsonl'),
+            );
+        });
+
+        it('applies the cwd filter against the decoded cwd', async () => {
+            writeSession({ sessionCwd: '/Users/dev/project-a', id: '019f0000-0000-7000-8000-00000000000a' });
+            writeSession({ sessionCwd: '/Users/dev/project-b', id: '019f0000-0000-7000-8000-00000000000b' });
+
+            const all = await adapter.listSessions();
+            expect(all).toHaveLength(2);
+
+            const filtered = await adapter.listSessions({ cwd: '/Users/dev/project-a' });
+            expect(filtered).toHaveLength(1);
+            expect(filtered[0].cwd).toBe('/Users/dev/project-a');
+        });
+
+        it('skips non-session entries (e.g. prompt_history.jsonl) in a group dir', async () => {
+            writeSession({});
+            // Grok writes a group-level prompt_history.jsonl alongside session dirs.
+            fs.writeFileSync(
+                path.join(tmpHome, '.grok', 'sessions', encodeURIComponent(cwd), 'prompt_history.jsonl'),
+                '{"text":"noise"}',
+            );
+            const summaries = await adapter.listSessions();
+            expect(summaries).toHaveLength(1);
+        });
+    });
+});

--- a/packages/agent-manager/src/__tests__/utils/agents.test.ts
+++ b/packages/agent-manager/src/__tests__/utils/agents.test.ts
@@ -14,4 +14,11 @@ describe('AGENTS', () => {
         expect(AGENTS.pi.matches('/usr/local/bin/pi --model x')).toBe(true);
         expect(AGENTS.pi.matches('node /repo/feature-pi-adapter/script.js')).toBe(false);
     });
+
+    it('includes Grok as a startable agent', () => {
+        expect(AGENTS.grok_cli.command).toBe('grok');
+        expect(AGENTS.grok_cli.matches('grok')).toBe(true);
+        expect(AGENTS.grok_cli.matches('/Users/dev/.grok/bin/grok --always-approve')).toBe(true);
+        expect(AGENTS.grok_cli.matches('node /repo/feature-grok-cli/script.js')).toBe(false);
+    });
 });

--- a/packages/agent-manager/src/adapters/AgentAdapter.ts
+++ b/packages/agent-manager/src/adapters/AgentAdapter.ts
@@ -8,7 +8,7 @@
 /**
  * Type of AI agent
  */
-export type AgentType = 'claude' | 'gemini_cli' | 'codex' | 'opencode' | 'copilot' | 'pi' | 'other';
+export type AgentType = 'claude' | 'gemini_cli' | 'grok_cli' | 'codex' | 'opencode' | 'copilot' | 'pi' | 'other';
 
 /**
  * Current status of an agent

--- a/packages/agent-manager/src/adapters/GrokCliAdapter.ts
+++ b/packages/agent-manager/src/adapters/GrokCliAdapter.ts
@@ -1,0 +1,388 @@
+import * as path from 'path';
+import type {
+    AgentAdapter,
+    AgentInfo,
+    ProcessInfo,
+    ConversationMessage,
+    SessionSummary,
+    ListSessionsOptions,
+} from './AgentAdapter.js';
+import { AgentStatus } from './AgentAdapter.js';
+import { listAgentProcesses, enrichProcesses } from '../utils/process.js';
+import { isDirectory, safeReadFile, safeReaddir, safeStat } from '../utils/session.js';
+import { generateAgentName } from '../utils/matching.js';
+
+/**
+ * Grok Build CLI Adapter
+ *
+ * Detects running Grok Build CLI agents by:
+ * 1. Finding running `grok` processes via shared listAgentProcesses() — Grok is
+ *    a native binary at ~/.grok/bin/grok, so argv[0] basename is `grok`.
+ * 2. Resolving each live process to its working directory via
+ *    ~/.grok/active_sessions.json, which Grok maintains as a list of
+ *    { pid, cwd, opened_at } for every running session. The cwd is then encoded
+ *    into the session group dir ~/.grok/sessions/<encodeURIComponent(cwd)>/, and
+ *    the most recently active session subdirectory is picked from it. The
+ *    process cwd from lsof is only a fallback when the PID is not registered.
+ * 3. Reading the session transcript from chat_history.jsonl (the authoritative
+ *    record of the conversation). The last user turn (the text inside
+ *    <user_query>...</user_query>) is the summary; the file's mtime is the last
+ *    activity time. summary.json / updates.jsonl are intentionally not used.
+ */
+
+const CHAT_HISTORY_FILE = 'chat_history.jsonl';
+const ACTIVE_SESSIONS_FILE = 'active_sessions.json';
+const CWD_FILE = '.cwd';
+const IDLE_THRESHOLD_MINUTES = 5;
+
+/** One entry of ~/.grok/active_sessions.json. */
+interface ActiveSessionEntry {
+    pid?: number;
+    cwd?: string;
+    opened_at?: number | string;
+}
+
+/** One line of chat_history.jsonl. */
+interface ChatRecord {
+    type?: string;
+    content?: unknown;
+}
+
+interface ChatScan {
+    messages: ConversationMessage[];
+    firstUserMessage?: string;
+    lastUserMessage?: string;
+    lastRole?: ConversationMessage['role'];
+}
+
+/** Parsed state for a single ~/.grok/sessions/<cwd>/<id>/ directory. */
+interface GrokSession {
+    sessionId: string;
+    projectPath: string;
+    summary: string;
+    sessionStart: Date;
+    lastActive: Date;
+    firstUserMessage?: string;
+    lastUserMessage?: string;
+    lastRole?: ConversationMessage['role'];
+}
+
+export class GrokCliAdapter implements AgentAdapter {
+    readonly type = 'grok_cli' as const;
+
+    private base: string;
+    private sessionsDir: string;
+
+    constructor() {
+        // GROK_HOME overrides the ~/.grok base directory; sessions live under
+        // <base>/sessions/ and the active-session registry at
+        // <base>/active_sessions.json.
+        const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+        this.base = process.env.GROK_HOME || path.join(homeDir, '.grok');
+        this.sessionsDir = path.join(this.base, 'sessions');
+    }
+
+    canHandle(processInfo: ProcessInfo): boolean {
+        return this.isGrokExecutable(processInfo.command);
+    }
+
+    private isGrokExecutable(command: string): boolean {
+        const executable = command.trim().split(/\s+/)[0] || '';
+        const base = path.basename(executable).toLowerCase();
+        return base === 'grok' || base === 'grok.exe';
+    }
+
+    async detectAgents(): Promise<AgentInfo[]> {
+        const processes = enrichProcesses(listAgentProcesses('grok'));
+        if (processes.length === 0) {
+            return [];
+        }
+
+        // active_sessions.json is the authoritative pid -> cwd map for live
+        // sessions; the lsof-derived process cwd is only a fallback.
+        const pidToCwd = this.readActiveSessions();
+
+        const agents: AgentInfo[] = [];
+        for (const proc of processes) {
+            const cwd = pidToCwd.get(proc.pid) || proc.cwd || '';
+            const sessionDir = cwd ? this.latestSessionDir(cwd) : null;
+            const session = sessionDir ? this.readSession(sessionDir, cwd) : null;
+
+            if (session && sessionDir) {
+                agents.push(this.mapSessionToAgent(session, proc, sessionDir));
+            } else {
+                agents.push(this.mapProcessOnlyAgent(proc, cwd));
+            }
+        }
+
+        return agents;
+    }
+
+    /**
+     * Read ~/.grok/active_sessions.json into a pid -> cwd map. Grok writes one
+     * { pid, cwd, opened_at } entry per running session and removes it on exit,
+     * so this is the reliable way to learn a live process's working directory.
+     */
+    private readActiveSessions(): Map<number, string> {
+        const map = new Map<number, string>();
+        const content = safeReadFile(path.join(this.base, ACTIVE_SESSIONS_FILE));
+        if (content === undefined) return map;
+
+        let entries: unknown;
+        try {
+            entries = JSON.parse(content);
+        } catch {
+            return map;
+        }
+        if (!Array.isArray(entries)) return map;
+
+        for (const entry of entries as ActiveSessionEntry[]) {
+            if (typeof entry?.pid === 'number' && typeof entry?.cwd === 'string' && entry.cwd) {
+                map.set(entry.pid, entry.cwd);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Return the most recently active session subdirectory for a cwd, i.e. the
+     * ~/.grok/sessions/<encodeURIComponent(cwd)>/<id>/ whose chat_history.jsonl
+     * was written last. Returns null when the group dir or any transcript is
+     * missing.
+     */
+    private latestSessionDir(cwd: string): string | null {
+        const groupDir = this.getProjectDir(cwd);
+        if (!isDirectory(groupDir)) return null;
+
+        let best: { dir: string; mtimeMs: number } | null = null;
+        for (const sessionId of safeReaddir(groupDir)) {
+            const sessionDir = path.join(groupDir, sessionId);
+            if (!isDirectory(sessionDir)) continue;
+            const stat = safeStat(path.join(sessionDir, CHAT_HISTORY_FILE));
+            if (!stat) continue;
+            if (!best || stat.mtimeMs > best.mtimeMs) {
+                best = { dir: sessionDir, mtimeMs: stat.mtimeMs };
+            }
+        }
+        return best?.dir ?? null;
+    }
+
+    private mapSessionToAgent(session: GrokSession, processInfo: ProcessInfo, sessionDir: string): AgentInfo {
+        const projectPath = session.projectPath || processInfo.cwd || '';
+        return {
+            name: generateAgentName(projectPath, processInfo.pid),
+            type: this.type,
+            status: this.determineStatus(session),
+            summary: session.summary || 'Grok CLI session active',
+            pid: processInfo.pid,
+            projectPath,
+            sessionId: session.sessionId,
+            lastActive: session.lastActive,
+            sessionFilePath: path.join(sessionDir, CHAT_HISTORY_FILE),
+        };
+    }
+
+    private mapProcessOnlyAgent(processInfo: ProcessInfo, cwd: string): AgentInfo {
+        const projectPath = cwd || processInfo.cwd || '';
+        return {
+            name: generateAgentName(projectPath, processInfo.pid),
+            type: this.type,
+            status: AgentStatus.RUNNING,
+            summary: 'Grok CLI process running',
+            pid: processInfo.pid,
+            projectPath,
+            sessionId: `pid-${processInfo.pid}`,
+            lastActive: new Date(),
+        };
+    }
+
+    getConversation(sessionFilePath: string, options?: { verbose?: boolean }): ConversationMessage[] {
+        return this.parseChatHistory(this.resolveChatPath(sessionFilePath), options?.verbose ?? false).messages;
+    }
+
+    async listSessions(opts?: ListSessionsOptions): Promise<SessionSummary[]> {
+        if (!isDirectory(this.sessionsDir)) return [];
+
+        const filterCwd = opts?.cwd;
+        const summaries: SessionSummary[] = [];
+
+        for (const groupName of safeReaddir(this.sessionsDir)) {
+            const groupDir = path.join(this.sessionsDir, groupName);
+            if (!isDirectory(groupDir)) continue;
+
+            const decodedCwd = this.decodeGroupCwd(groupName, groupDir);
+
+            for (const sessionId of safeReaddir(groupDir)) {
+                const sessionDir = path.join(groupDir, sessionId);
+                if (!isDirectory(sessionDir)) continue;
+
+                const session = this.readSession(sessionDir, decodedCwd);
+                if (!session) continue;
+
+                const cwd = session.projectPath || decodedCwd;
+                if (filterCwd !== undefined && cwd !== filterCwd) continue;
+
+                summaries.push({
+                    type: this.type,
+                    sessionId: session.sessionId,
+                    cwd,
+                    firstUserMessage: session.firstUserMessage || '',
+                    lastActive: session.lastActive,
+                    startedAt: session.sessionStart,
+                    sessionFilePath: path.join(sessionDir, CHAT_HISTORY_FILE),
+                });
+            }
+        }
+
+        return summaries;
+    }
+
+    // --- Session parsing (chat_history.jsonl) ---
+
+    /**
+     * Parse a session directory into a {@link GrokSession} from its
+     * chat_history.jsonl transcript. Returns null when the transcript is
+     * missing — i.e. there is no real session to surface.
+     */
+    private readSession(sessionDir: string, defaultCwd: string): GrokSession | null {
+        const chatPath = path.join(sessionDir, CHAT_HISTORY_FILE);
+        const chatStat = safeStat(chatPath);
+        if (!chatStat) return null;
+
+        const scan = this.parseChatHistory(chatPath, false);
+        const dirStat = safeStat(sessionDir);
+        const lastActive = chatStat.mtime;
+
+        return {
+            sessionId: path.basename(sessionDir),
+            projectPath: defaultCwd || '',
+            summary: scan.lastUserMessage || 'Grok CLI session active',
+            sessionStart: dirStat?.birthtime || lastActive,
+            lastActive,
+            firstUserMessage: scan.firstUserMessage,
+            lastUserMessage: scan.lastUserMessage,
+            lastRole: scan.lastRole,
+        };
+    }
+
+    /**
+     * Determine agent status from parsed session state.
+     *
+     * - past the idle threshold → IDLE
+     * - last transcript turn is an assistant message → WAITING (awaiting user)
+     * - otherwise (last turn was a user message, or unknown) → RUNNING
+     */
+    private determineStatus(session: GrokSession): AgentStatus {
+        const diffMinutes = (Date.now() - session.lastActive.getTime()) / 60000;
+        if (diffMinutes > IDLE_THRESHOLD_MINUTES) {
+            return AgentStatus.IDLE;
+        }
+        if (session.lastRole === 'assistant') {
+            return AgentStatus.WAITING;
+        }
+        return AgentStatus.RUNNING;
+    }
+
+    /**
+     * Single pass over chat_history.jsonl. Each line is a
+     * { type: 'system' | 'user' | 'assistant', content } record where content is
+     * either a string or an array of { type: 'text', text } blocks.
+     *
+     * Grok wraps the real user prompt in <user_query>...</user_query>; the other
+     * user records are context injections (<user_info>, <system-reminder>, ...)
+     * and are skipped so the summary is the actual prompt, not boilerplate.
+     */
+    private parseChatHistory(chatPath: string, verbose: boolean): ChatScan {
+        const empty: ChatScan = { messages: [] };
+        const content = safeReadFile(chatPath);
+        if (content === undefined) return empty;
+
+        const messages: ConversationMessage[] = [];
+        let lastRole: ConversationMessage['role'] | undefined;
+
+        for (const line of content.trim().split('\n')) {
+            if (!line.trim()) continue;
+
+            let record: ChatRecord;
+            try {
+                record = JSON.parse(line);
+            } catch {
+                continue;
+            }
+
+            const text = this.extractText(record.content);
+            if (record.type === 'user') {
+                const query = this.extractUserQuery(text);
+                if (query === null) continue; // context injection, not a real prompt
+                messages.push({ role: 'user', content: query });
+                lastRole = 'user';
+            } else if (record.type === 'assistant') {
+                if (!text) continue;
+                messages.push({ role: 'assistant', content: text });
+                lastRole = 'assistant';
+            } else if (verbose && record.type === 'system') {
+                if (!text) continue;
+                messages.push({ role: 'system', content: text });
+            }
+        }
+
+        const userTurns = messages.filter((m) => m.role === 'user');
+        return {
+            messages,
+            firstUserMessage: userTurns[0]?.content,
+            lastUserMessage: userTurns[userTurns.length - 1]?.content,
+            lastRole,
+        };
+    }
+
+    /** Flatten a chat record's content (string or text-block array) to text. */
+    private extractText(content: unknown): string {
+        if (typeof content === 'string') return content;
+        if (Array.isArray(content)) {
+            return content
+                .map((block) =>
+                    block && typeof block === 'object' && typeof (block as { text?: unknown }).text === 'string'
+                        ? (block as { text: string }).text
+                        : '',
+                )
+                .join('');
+        }
+        return '';
+    }
+
+    /**
+     * Extract the prompt inside <user_query>...</user_query>. Returns null when
+     * the record has no such tag (a context injection rather than a prompt).
+     */
+    private extractUserQuery(text: string): string | null {
+        const match = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+        return match ? match[1].trim() : null;
+    }
+
+    /** Resolve a session dir or an explicit chat_history.jsonl path to the file. */
+    private resolveChatPath(sessionPath: string): string {
+        return sessionPath.endsWith('.jsonl') ? sessionPath : path.join(sessionPath, CHAT_HISTORY_FILE);
+    }
+
+    private getProjectDir(cwd: string): string {
+        return path.join(this.sessionsDir, encodeURIComponent(cwd));
+    }
+
+    /**
+     * Resolve the working directory a session group dir was created for.
+     *
+     * The common case is `decodeURIComponent(<group-name>)`. For paths whose
+     * encoded form exceeds the filesystem limit Grok uses a slug+hash and records
+     * the original path in a `.cwd` file inside the group — prefer that when
+     * present.
+     */
+    private decodeGroupCwd(groupName: string, groupDir: string): string {
+        const fromFile = safeReadFile(path.join(groupDir, CWD_FILE));
+        if (fromFile !== undefined && fromFile.trim()) return fromFile.trim();
+        try {
+            return decodeURIComponent(groupName);
+        } catch {
+            return '';
+        }
+    }
+}

--- a/packages/agent-manager/src/adapters/GrokCliAdapter.ts
+++ b/packages/agent-manager/src/adapters/GrokCliAdapter.ts
@@ -145,6 +145,17 @@ export class GrokCliAdapter implements AgentAdapter {
     }
 
     /**
+     * Full paths of the session subdirectories directly under a group dir,
+     * skipping any non-directory entries. Shared by latestSessionDir() and
+     * listSessions() so both enumerate session dirs the same way.
+     */
+    private listSessionDirs(groupDir: string): string[] {
+        return safeReaddir(groupDir)
+            .map((sessionId) => path.join(groupDir, sessionId))
+            .filter((sessionDir) => isDirectory(sessionDir));
+    }
+
+    /**
      * Return the most recently active session subdirectory for a cwd, i.e. the
      * ~/.grok/sessions/<encodeURIComponent(cwd)>/<id>/ whose chat_history.jsonl
      * was written last. Returns null when the group dir or any transcript is
@@ -155,9 +166,7 @@ export class GrokCliAdapter implements AgentAdapter {
         if (!isDirectory(groupDir)) return null;
 
         let best: { dir: string; mtimeMs: number } | null = null;
-        for (const sessionId of safeReaddir(groupDir)) {
-            const sessionDir = path.join(groupDir, sessionId);
-            if (!isDirectory(sessionDir)) continue;
+        for (const sessionDir of this.listSessionDirs(groupDir)) {
             const stat = safeStat(path.join(sessionDir, CHAT_HISTORY_FILE));
             if (!stat) continue;
             if (!best || stat.mtimeMs > best.mtimeMs) {
@@ -212,10 +221,7 @@ export class GrokCliAdapter implements AgentAdapter {
 
             const decodedCwd = this.decodeGroupCwd(groupName, groupDir);
 
-            for (const sessionId of safeReaddir(groupDir)) {
-                const sessionDir = path.join(groupDir, sessionId);
-                if (!isDirectory(sessionDir)) continue;
-
+            for (const sessionDir of this.listSessionDirs(groupDir)) {
                 const session = this.readSession(sessionDir, decodedCwd);
                 if (!session) continue;
 

--- a/packages/agent-manager/src/adapters/index.ts
+++ b/packages/agent-manager/src/adapters/index.ts
@@ -2,6 +2,7 @@ export { ClaudeCodeAdapter } from './ClaudeCodeAdapter.js';
 export { CodexAdapter } from './CodexAdapter.js';
 export { CopilotAdapter } from './CopilotAdapter.js';
 export { GeminiCliAdapter } from './GeminiCliAdapter.js';
+export { GrokCliAdapter } from './GrokCliAdapter.js';
 export { OpenCodeAdapter } from './OpenCodeAdapter.js';
 export { PiAdapter } from './PiAdapter.js';
 export { AgentStatus } from './AgentAdapter.js';

--- a/packages/agent-manager/src/index.ts
+++ b/packages/agent-manager/src/index.ts
@@ -4,6 +4,7 @@ export { ClaudeCodeAdapter } from './adapters/ClaudeCodeAdapter.js';
 export { CodexAdapter } from './adapters/CodexAdapter.js';
 export { CopilotAdapter } from './adapters/CopilotAdapter.js';
 export { GeminiCliAdapter } from './adapters/GeminiCliAdapter.js';
+export { GrokCliAdapter } from './adapters/GrokCliAdapter.js';
 export { OpenCodeAdapter } from './adapters/OpenCodeAdapter.js';
 export { PiAdapter } from './adapters/PiAdapter.js';
 export { AgentStatus } from './adapters/AgentAdapter.js';

--- a/packages/agent-manager/src/utils/agents.ts
+++ b/packages/agent-manager/src/utils/agents.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import type { AgentType } from '../adapters/AgentAdapter.js';
 
-export type StartableAgentType = Extract<AgentType, 'claude' | 'codex' | 'copilot' | 'gemini_cli' | 'opencode' | 'pi'>;
+export type StartableAgentType = Extract<AgentType, 'claude' | 'codex' | 'copilot' | 'gemini_cli' | 'grok_cli' | 'opencode' | 'pi'>;
 
 export interface AgentConfig {
     /** Shell command to launch the agent (sent to tmux via `send-keys`). */
@@ -20,6 +20,7 @@ export const AGENTS: Record<StartableAgentType, AgentConfig> = {
     codex:      { command: 'codex',    matches: matchArgv0('codex') },
     copilot:    { command: 'copilot',  matches: matchArgv0Name('copilot-cli') },
     gemini_cli: { command: 'gemini',   matches: matchAnyToken('gemini') },
+    grok_cli:   { command: 'grok',     matches: matchArgv0('grok') },
     opencode:   { command: 'opencode', matches: matchArgv0('opencode') },
     pi:         { command: 'pi',       matches: matchAnyBasename(['pi']) },
 };

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -83,6 +83,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
   CodexAdapter: vi.fn(),
   CopilotAdapter: vi.fn(),
   GeminiCliAdapter: vi.fn(),
+  GrokCliAdapter: vi.fn(),
   OpenCodeAdapter: vi.fn(),
   PiAdapter: vi.fn(),
   TerminalFocusManager: vi.fn(function () { return mockFocusManager; }),
@@ -109,6 +110,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     codex:      { command: 'codex',    matches: () => true },
     copilot:    { command: 'copilot',  matches: () => true },
     gemini_cli: { command: 'gemini',   matches: () => true },
+    grok_cli:   { command: 'grok',     matches: () => true },
     opencode:   { command: 'opencode', matches: () => true },
     pi:         { command: 'pi',       matches: () => true },
   },
@@ -268,7 +270,7 @@ describe('agent command', () => {
     await program.parseAsync(['node', 'test', 'agent', 'list', '--json']);
 
     expect(AgentManager).toHaveBeenCalled();
-    expect(mockManager.registerAdapter).toHaveBeenCalledTimes(6);
+    expect(mockManager.registerAdapter).toHaveBeenCalledTimes(7);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(agents, null, 2));
   });
 

--- a/packages/cli/src/__tests__/commands/channel.test.ts
+++ b/packages/cli/src/__tests__/commands/channel.test.ts
@@ -74,6 +74,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     CodexAdapter: vi.fn(),
     CopilotAdapter: vi.fn(),
     GeminiCliAdapter: vi.fn(),
+    GrokCliAdapter: vi.fn(),
     PiAdapter: vi.fn(),
     TerminalFocusManager: vi.fn(function () { return mockTerminalFocusManager; }),
     TtyWriter: {
@@ -600,7 +601,7 @@ describe('channel command', () => {
             agentPid: 4321,
             bridgePid: process.pid,
         }));
-        expect(mockAgentManager.registerAdapter).toHaveBeenCalledTimes(5);
+        expect(mockAgentManager.registerAdapter).toHaveBeenCalledTimes(6);
         expect(mockChannelService.registerBridge.mock.invocationCallOrder[0])
             .toBeLessThan(mockChannelManager.startAll.mock.invocationCallOrder[0]);
 

--- a/packages/cli/src/__tests__/tui/console/StartAgentPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/StartAgentPane.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('StartAgentPane helpers', () => {
     it('lists supported agent start types in pane order', () => {
-        expect(STARTABLE_AGENT_TYPES).toEqual(['claude', 'codex', 'copilot', 'gemini_cli', 'opencode', 'pi']);
+        expect(STARTABLE_AGENT_TYPES).toEqual(['claude', 'codex', 'copilot', 'gemini_cli', 'grok_cli', 'opencode', 'pi']);
     });
 
     it('cycles to the next agent type', () => {

--- a/packages/cli/src/__tests__/util/sessions.test.ts
+++ b/packages/cli/src/__tests__/util/sessions.test.ts
@@ -45,7 +45,7 @@ describe('sessions util', () => {
         });
 
         it('forwards a valid --type', () => {
-            for (const type of ['claude', 'codex', 'gemini_cli', 'opencode', 'copilot', 'pi'] as const) {
+            for (const type of ['claude', 'codex', 'gemini_cli', 'grok_cli', 'opencode', 'copilot', 'pi'] as const) {
                 const result = resolveListSessionsOptions({ all: true, type });
                 expect(result.adapterOptions.type).toBe(type);
             }
@@ -53,7 +53,7 @@ describe('sessions util', () => {
 
         it('throws on an invalid --type', () => {
             expect(() => resolveListSessionsOptions({ all: true, type: 'wrong' })).toThrow(
-                'Invalid --type "wrong". Expected one of: claude, codex, gemini_cli, opencode, copilot, pi.',
+                'Invalid --type "wrong". Expected one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi.',
             );
         });
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -11,6 +11,7 @@ import {
     CodexAdapter,
     CopilotAdapter,
     GeminiCliAdapter,
+    GrokCliAdapter,
     OpenCodeAdapter,
     PiAdapter,
     AgentStatus,
@@ -89,6 +90,7 @@ const TYPE_LABELS: Record<AgentType, string> = {
     codex: 'Codex',
     copilot: 'Copilot',
     gemini_cli: 'Gemini CLI',
+    grok_cli: 'Grok CLI',
     opencode: 'OpenCode',
     pi: 'Pi',
     other: 'Other',
@@ -171,6 +173,7 @@ function createAgentManager(): AgentManager {
     manager.registerAdapter(new CodexAdapter());
     manager.registerAdapter(new CopilotAdapter());
     manager.registerAdapter(new GeminiCliAdapter());
+    manager.registerAdapter(new GrokCliAdapter());
     manager.registerAdapter(new OpenCodeAdapter());
     manager.registerAdapter(new PiAdapter());
     return manager;
@@ -356,10 +359,10 @@ export function registerAgentCommand(program: Command): void {
 
     agentCommand
         .command('sessions')
-        .description('List historical Claude/Codex/Gemini/OpenCode sessions for resume')
+        .description('List historical Claude/Codex/Gemini/Grok/OpenCode sessions for resume')
         .option('--all', 'Include sessions from every cwd (default: only current cwd)')
         .option('--cwd <path>', 'Override the cwd filter (implies non-default scope)')
-        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, opencode, copilot, pi')
+        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi')
         .option('--limit <n>', 'Max rows to print (default: 50; 0 = no limit)', '50')
         .option('-j, --json', 'Output as JSON')
         .action(withErrorHandler('list sessions', async (options) => {
@@ -415,7 +418,7 @@ export function registerAgentCommand(program: Command): void {
         .description('Show detailed information about a historical session')
         .requiredOption('--id <sessionId>', 'Session ID (as shown in agent sessions)')
         .option('-j, --json', 'Output as JSON')
-        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, opencode, copilot, pi')
+        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi')
         .option('--full', 'Show entire conversation history')
         .option('--tail <n>', 'Show last N messages (default: 20)', '20')
         .option('--verbose', 'Include tool call/result details')

--- a/packages/cli/src/services/channel/channel-runner.ts
+++ b/packages/cli/src/services/channel/channel-runner.ts
@@ -5,6 +5,7 @@ import {
     CodexAdapter,
     CopilotAdapter,
     GeminiCliAdapter,
+    GrokCliAdapter,
     PiAdapter,
     TerminalFocusManager,
     TtyWriter,
@@ -44,6 +45,7 @@ function createAgentManager(): AgentManager {
     manager.registerAdapter(new CodexAdapter());
     manager.registerAdapter(new CopilotAdapter());
     manager.registerAdapter(new GeminiCliAdapter());
+    manager.registerAdapter(new GrokCliAdapter());
     manager.registerAdapter(new PiAdapter());
     return manager;
 }

--- a/packages/cli/src/util/sessions.ts
+++ b/packages/cli/src/util/sessions.ts
@@ -7,7 +7,7 @@ import { truncate } from './text.js';
 
 const FIRST_MESSAGE_MAX_WIDTH = 80;
 const FIRST_MESSAGE_PLACEHOLDER = '(no message yet)';
-const VALID_AGENT_TYPES: AgentType[] = ['claude', 'codex', 'gemini_cli', 'opencode', 'copilot', 'pi'];
+const VALID_AGENT_TYPES: AgentType[] = ['claude', 'codex', 'gemini_cli', 'grok_cli', 'opencode', 'copilot', 'pi'];
 
 export interface ResolvedListSessionsOptions {
     adapterOptions: ListSessionsOptions;


### PR DESCRIPTION
Adds support for xAI's Grok Build CLI (`grok`) as a detectable, listable, and launchable agent in `@ai-devkit/agent-manager`. Closes #107.

`GrokCliAdapter` detects running `grok` processes and maps each to its session directory under `~/.grok/sessions/<encodeURIComponent(cwd)>/<id>/` — by `--resume <id>` when present, otherwise by cwd + birth-time — then reads `summary.json` and the `updates.jsonl` ACP stream for the project path, summary, status, and conversation. It mirrors `ClaudeCodeAdapter`'s detection flow (Grok's storage is Claude-like, not Gemini's hash scheme) but keeps parsing inline like the other recent adapters.

It also adds the `grok_cli` type and an `AGENTS` launch entry (so `agent start grok` and the console picker work), registers the adapter in the agent command and the channel runner, and adds Grok to the README matrix under Remote control.

Schemas were verified against a real `grok 0.2.77` session, and I checked it end-to-end through the CLI: `agent start --type grok_cli` launches Grok in a tmux session and `agent list` shows it; `agent sessions --type grok_cli` lists the on-disk session.

The Grok setup environment (`.grok/skills` for `ai-devkit init`) is left for a follow-up PR, mirroring how the Pi environment landed after its adapter.

Includes the dev-lifecycle docs under `docs/ai/*/feature-grok-cli-adapter.md`.
