### PR TITLE
feat(cli): add Grok environment skills support

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -193,6 +193,7 @@ ai-devkit init --template ./senior-engineer.yaml
 | [Claude Code](https://www.anthropic.com/claude-code) | yes | yes |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | yes | yes |
 | [Codex CLI](https://github.com/openai/codex) | yes | yes |
+| [Grok Build CLI](https://x.ai/cli) | yes | yes |
 | [Junie](https://www.jetbrains.com/junie/) | yes | — |
 | [Cline](https://cline.bot/) | yes | — |
 | [Devin](https://devin.ai/) | yes | — |

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ One `.ai-devkit.json` configures all of them. Add a new agent to your team witho
 | [Claude Code](https://www.anthropic.com/claude-code) | yes | yes |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | yes | yes |
 | [Codex CLI](https://github.com/openai/codex) | yes | yes |
+| [Grok Build CLI](https://x.ai/cli) | yes | — |
 | [Junie](https://www.jetbrains.com/junie/) | yes | — |
 | [Cline](https://cline.bot/) | yes | — |
 | [Devin](https://devin.ai/) | yes | — |

--- a/packages/cli/src/__tests__/lib/EnvironmentSelector.test.ts
+++ b/packages/cli/src/__tests__/lib/EnvironmentSelector.test.ts
@@ -119,6 +119,19 @@ describe('EnvironmentSelector', () => {
       expect(getMcpConfigPath('kilocode')).toBe('.kilo/kilo.jsonc');
     });
 
+    it('includes Grok with project and global skill paths', () => {
+      expect(isValidEnvironmentCode('grok')).toBe(true);
+      expect(getEnvironment('grok')).toMatchObject({
+        code: 'grok',
+        name: 'Grok',
+        skillPath: '.grok/skills',
+        globalSkillPath: '.grok/skills',
+      });
+      expect(getSkillPath('grok')).toBe('.grok/skills');
+      expect(getGlobalSkillPath('grok')).toBe('.grok/skills');
+      expect(getMcpConfigPath('grok')).toBeUndefined();
+    });
+
     it('includes OpenCode with project skills, global skills, and MCP', () => {
       expect(isValidEnvironmentCode('opencode')).toBe(true);
       expect(getEnvironment('opencode')).toMatchObject({

--- a/packages/cli/src/__tests__/lib/SkillManager.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillManager.test.ts
@@ -619,7 +619,7 @@ describe("SkillManager", () => {
 
       await expect(
         skillManager.addSkill(mockRegistryId, mockSkillName),
-      ).rejects.toThrow("Supported: cursor, claude, github, gemini, codex, kilocode, amp, opencode, roo, antigravity, junie, cline, devin, pi");
+      ).rejects.toThrow("Supported: cursor, claude, github, gemini, grok, codex, kilocode, amp, opencode, roo, antigravity, junie, cline, devin, pi");
     });
 
     it("should call validation functions with correct parameters", async () => {

--- a/packages/cli/src/__tests__/util/env.test.ts
+++ b/packages/cli/src/__tests__/util/env.test.ts
@@ -19,11 +19,12 @@ import { EnvironmentCode } from '../../types.js';
 describe('Environment Utilities', () => {
   describe('ENVIRONMENT_DEFINITIONS', () => {
     it('should contain all all environment definitions', () => {
-      expect(Object.keys(ENVIRONMENT_DEFINITIONS)).toHaveLength(14);
+      expect(Object.keys(ENVIRONMENT_DEFINITIONS)).toHaveLength(15);
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('cursor');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('claude');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('github');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('gemini');
+      expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('grok');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('codex');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('kilocode');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('amp');
@@ -63,10 +64,10 @@ describe('Environment Utilities', () => {
 
   describe('ALL_ENVIRONMENT_CODES', () => {
     it('should contain all all environment codes', () => {
-      expect(ALL_ENVIRONMENT_CODES).toHaveLength(14);
+      expect(ALL_ENVIRONMENT_CODES).toHaveLength(15);
       expect(ALL_ENVIRONMENT_CODES).toEqual(
         expect.arrayContaining([
-          'cursor', 'claude', 'github', 'gemini', 'codex',
+          'cursor', 'claude', 'github', 'gemini', 'grok', 'codex',
           'kilocode', 'amp', 'opencode', 'roo', 'antigravity',
           'junie', 'cline', 'devin', 'pi'
         ])
@@ -82,7 +83,7 @@ describe('Environment Utilities', () => {
   describe('getAllEnvironments', () => {
     it('should return all environment definitions', () => {
       const environments = getAllEnvironments();
-      expect(environments).toHaveLength(14);
+      expect(environments).toHaveLength(15);
       expect(environments).toEqual(Object.values(ENVIRONMENT_DEFINITIONS));
     });
 
@@ -383,7 +384,7 @@ describe('Environment Utilities', () => {
       expect(envCodes).toContain('cline');
       expect(envCodes).toContain('devin');
       expect(envCodes).toContain('pi');
-      expect(skillEnvs).toHaveLength(14);
+      expect(skillEnvs).toHaveLength(15);
     });
   });
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -16,7 +16,7 @@ export interface EnvironmentDefinition {
   mcpConfigPath?: string;
 }
 
-export type EnvironmentCode = 'cursor' | 'claude' | 'github' | 'gemini' | 'codex' | 'kilocode' | 'amp' | 'opencode' | 'roo' | 'antigravity' | 'junie' | 'cline' | 'devin' | 'pi';
+export type EnvironmentCode = 'cursor' | 'claude' | 'github' | 'gemini' | 'grok' | 'codex' | 'kilocode' | 'amp' | 'opencode' | 'roo' | 'antigravity' | 'junie' | 'cline' | 'devin' | 'pi';
 
 export const DEFAULT_DOCS_DIR = 'docs/ai';
 

--- a/packages/cli/src/util/env.ts
+++ b/packages/cli/src/util/env.ts
@@ -27,6 +27,12 @@ export const ENVIRONMENT_DEFINITIONS: Record<EnvironmentCode, EnvironmentDefinit
     skillPath: '.gemini/skills',
     globalSkillPath: '.gemini/skills',
   },
+  grok: {
+    code: 'grok',
+    name: 'Grok',
+    skillPath: '.grok/skills',
+    globalSkillPath: '.grok/skills',
+  },
   codex: {
     code: 'codex',
     name: 'OpenAI Codex',

--- a/web/content/docs/11-configuration-file.md
+++ b/web/content/docs/11-configuration-file.md
@@ -72,6 +72,7 @@ List of AI coding tools to generate configuration files for. Valid values:
 | `claude` | Claude Code |
 | `github` | GitHub Copilot |
 | `gemini` | Gemini |
+| `grok` | Grok |
 | `codex` | Codex |
 | `kilocode` | Kilocode |
 | `amp` | Amp |

--- a/web/content/docs/2-supported-agents.md
+++ b/web/content/docs/2-supported-agents.md
@@ -53,6 +53,11 @@ These environments have stable setup integrations.
 - `~/.codex/skills/` — Global skills
 - `.codex/config.toml` — Project-level MCP server configuration
 
+### [Grok Build CLI](https://x.ai/cli)
+**What AI DevKit provides:**
+- `.grok/skills/` — Project-level skills
+- `~/.grok/skills/` — Global skills
+
 ### [opencode](https://opencode.ai/)
 **What AI DevKit provides:**
 - `AGENTS.md` — opencode [custom instructions](https://opencode.ai/docs/rules/)

--- a/web/content/docs/6-memory.md
+++ b/web/content/docs/6-memory.md
@@ -171,7 +171,7 @@ The memory skill is ideal when:
 - Your AI agent needs detailed command syntax reference
 - You want consistent memory usage patterns across your team
 
-> **Tip:** The skill works with all skill-capable AI environments: Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Pi, Kilo Code, and Roo Code.
+> **Tip:** The skill works with all skill-capable AI environments: Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Grok, Pi, Kilo Code, and Roo Code.
 
 ## Organizing Your Knowledge
 

--- a/web/content/docs/7-skills.md
+++ b/web/content/docs/7-skills.md
@@ -7,7 +7,7 @@ order: 7
 
 **Skills** are reusable instruction packs that extend what your AI coding agents can do. Each skill teaches an agent a specific workflow or domain practice, such as frontend design, database optimization, security review, or multi-agent coordination.
 
-> **Note:** AI DevKit reads your project configuration from `.ai-devkit.json`. If this file doesn't exist when you run `skill add`, you'll be prompted to select which AI environments to configure. Skills require at least one skill-capable environment (Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Pi, Kilo Code, or Roo Code).
+> **Note:** AI DevKit reads your project configuration from `.ai-devkit.json`. If this file doesn't exist when you run `skill add`, you'll be prompted to select which AI environments to configure. Skills require at least one skill-capable environment (Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Grok, Pi, Kilo Code, or Roo Code).
 
 ## How Skills Work
 
@@ -72,6 +72,7 @@ Skills are currently supported by the following AI coding agents:
 | **Junie**       | `.junie/skills`    | `~/.junie/skills` |
 | **Cline**       | `.cline/skills`    | `~/.cline/skills` |
 | **Devin**       | `.devin/skills`    | `~/.config/devin/skills` |
+| **Grok**        | `.grok/skills`     | `~/.grok/skills` |
 | **Pi**          | `.pi/skills`       | `~/.pi/agent/skills` |
 | **Kilo Code**   | `.kilo/skills`     | `~/.kilo/skills` |
 | **Roo Code**    | `.roo/skills`      | `~/.roo/skills` |
@@ -455,7 +456,7 @@ The skill doesn't exist in the specified registry. Explore the registry reposito
 
 ### "No skill-capable environments configured"
 
-Your project doesn't have any skill-compatible environments. Run `ai-devkit init` and select an environment that supports skills (Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Pi, Kilo Code, or Roo Code).
+Your project doesn't have any skill-compatible environments. Run `ai-devkit init` and select an environment that supports skills (Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Grok, Pi, Kilo Code, or Roo Code).
 
 ### "SKILL.md not found"
 


### PR DESCRIPTION
Adds the Grok setup environment so `ai-devkit init` configures Grok: registers `grok` as an `EnvironmentCode` and installs skills into `.grok/skills` (project) and `~/.grok/skills` (global). Flips Grok to **Setup: yes** in the README matrix.

Follows the same shape as the "Add Pi environment skills support" change — `types.ts` + `util/env.ts`, the env/SkillManager/EnvironmentSelector tests, README + README-zh, and the supported-agents / configuration-file / skills / memory docs.

**Stacked on #129** (the Grok adapter). This branch builds on `feat/grok-cli-adapter`, so until #129 merges the diff here also shows the adapter changes; once #129 lands this reduces to the environment change only. Happy to reorder or merge them into one if you'd prefer.
