### PR TITLE
feat(agent-manager): add Antigravity CLI adapter

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -201,7 +201,7 @@ ai-devkit init --template ./senior-engineer.yaml
 | [Pi](https://pi.dev) | yes | yes |
 | [Cursor](https://cursor.sh/) | yes | — |
 | [GitHub Copilot](https://code.visualstudio.com/) | yes | — |
-| [Antigravity](https://antigravity.google/) | yes | — |
+| [Antigravity](https://antigravity.google/) | yes | yes |
 | [Amp](https://ampcode.com/) | yes | — |
 | [Kilo Code](https://github.com/Kilo-Org/kilocode) | yes | — |
 | [Roo Code](https://roocode.com/) | testing | — |

--- a/README-zh.md
+++ b/README-zh.md
@@ -201,7 +201,8 @@ ai-devkit init --template ./senior-engineer.yaml
 | [Pi](https://pi.dev) | yes | yes |
 | [Cursor](https://cursor.sh/) | yes | — |
 | [GitHub Copilot](https://code.visualstudio.com/) | yes | — |
-| [Antigravity](https://antigravity.google/) | yes | yes |
+| [Antigravity](https://antigravity.google/) | yes | — |
+| [Antigravity CLI](https://antigravity.google/) | yes | yes |
 | [Amp](https://ampcode.com/) | yes | — |
 | [Kilo Code](https://github.com/Kilo-Org/kilocode) | yes | — |
 | [Roo Code](https://roocode.com/) | testing | — |

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ One `.ai-devkit.json` configures all of them. Add a new agent to your team witho
 | [Pi](https://pi.dev) | yes | yes |
 | [Cursor](https://cursor.sh/) | yes | — |
 | [GitHub Copilot](https://code.visualstudio.com/) | yes | — |
-| [Antigravity](https://antigravity.google/) | yes | — |
+| [Antigravity](https://antigravity.google/) | yes | yes |
 | [Amp](https://ampcode.com/) | yes | — |
 | [Kilo Code](https://github.com/Kilo-Org/kilocode) | yes | — |
 | [Roo Code](https://roocode.com/) | testing | — |

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ One `.ai-devkit.json` configures all of them. Add a new agent to your team witho
 | [Pi](https://pi.dev) | yes | yes |
 | [Cursor](https://cursor.sh/) | yes | — |
 | [GitHub Copilot](https://code.visualstudio.com/) | yes | — |
-| [Antigravity](https://antigravity.google/) | yes | yes |
+| [Antigravity](https://antigravity.google/) | yes | — |
+| [Antigravity CLI](https://antigravity.google/) | yes | yes |
 | [Amp](https://ampcode.com/) | yes | — |
 | [Kilo Code](https://github.com/Kilo-Org/kilocode) | yes | — |
 | [Roo Code](https://roocode.com/) | testing | — |

--- a/docs/ai/design/feature-antigravity-cli-adapter.md
+++ b/docs/ai/design/feature-antigravity-cli-adapter.md
@@ -1,0 +1,37 @@
+---
+phase: design
+title: "Antigravity CLI Adapter in @ai-devkit/agent-manager - Design"
+feature: antigravity-cli-adapter
+description: Architecture for the Antigravity (`agy`) CLI detection adapter, launch map entry, and CLI wiring
+---
+
+# Design: Antigravity CLI Adapter for @ai-devkit/agent-manager
+
+## Responsibilities
+- `AntigravityCliAdapter`: discover running `agy` processes, resolve each to its conversation via `cache/last_conversations.json`, read its transcript, emit `AgentInfo`, and enumerate conversations — parsing kept inline like the other recent adapters.
+- `AGENTS.antigravity_cli`: launch command (`agy`) + `ps` matcher.
+- CLI/channel: register the adapter, label the type, validate `--type`.
+
+## Data model
+Reuse `AgentAdapter`, `AgentInfo`, `AgentStatus`, `AgentType`, `SessionSummary`. `AgentType` gains `'antigravity_cli'`.
+
+- `cache/last_conversations.json` (at the CLI home root): `{ <cwd>: <conversationId> }`. The live process cwd is the join key; there is no pid in this file, so `proc.cwd` is the lookup key.
+- `brain/<conversationId>/.system_generated/logs/transcript.jsonl`: `{ source, type, created_at, content }` per line. `content` is a string or an array of `{ type: "text", text }` blocks. User prompt = text inside `<USER_REQUEST>...</USER_REQUEST>` of a `type: "USER_INPUT"` record; assistant reply = `type: "PLANNER_RESPONSE"`. Other MODEL records (tool calls like RUN_COMMAND) and `SYSTEM` records are execution detail, skipped unless verbose.
+
+Normalized into `AgentInfo`: `name` ← `generateAgentName(projectPath, pid)`; `projectPath` ← cwd from the registry (else process cwd); `sessionId` ← the conversation id; `summary` ← last `<USER_REQUEST>`; `status` ← time-threshold + last-transcript-role heuristic; `sessionFilePath` ← the conversation's `transcript.jsonl`.
+
+## Component breakdown
+1. `packages/agent-manager/src/adapters/AntigravityCliAdapter.ts` (new, self-contained)
+   - `canHandle`: argv[0] basename `agy`/`agy.exe`.
+   - `detectAgents`: `enrichProcesses(listAgentProcesses('agy'))`; per process resolve cwd → conversationId via `readRegistry()`, read the transcript; live processes with no conversation → process-only RUNNING agents.
+   - inline parsing: `readRegistry`, `readSession`, `parseTranscript` (`<USER_REQUEST>` prompts + `PLANNER_RESPONSE` replies), `determineStatus`, `getConversation`.
+   - `listSessions`: iterate the `cwd → id` registry, parse each transcript, strict `cwd` filter.
+2. `AntigravityCliAdapter.test.ts` (new): fixtures from the captured real format.
+3. Exports, launch map, CLI registration, labels, validation.
+
+## Design decisions
+- Resolve a live process's conversation from `cache/last_conversations.json` (cwd → id), not from cwd-encoded session dirs; there is one current conversation per workspace.
+- Parse `transcript.jsonl` for conversation and summary; take the prompt inside `<USER_REQUEST>...</USER_REQUEST>`.
+- `sessionFilePath` points at `transcript.jsonl` so the console's `fs.stat().mtime` cache invalidation tracks conversation growth.
+- Keep parsing resilient — a missing/malformed transcript skips the session; adapter-level failures return empty so other adapters still render.
+- Independent of the `antigravity` IDE environment (same split as `gemini_cli` vs `gemini`).

--- a/docs/ai/design/feature-antigravity-cli-adapter.md
+++ b/docs/ai/design/feature-antigravity-cli-adapter.md
@@ -23,14 +23,16 @@ Normalized into `AgentInfo`: `name` ← `generateAgentName(projectPath, pid)`; `
 ## Component breakdown
 1. `packages/agent-manager/src/adapters/AntigravityCliAdapter.ts` (new, self-contained)
    - `canHandle`: argv[0] basename `agy`/`agy.exe`.
-   - `detectAgents`: `enrichProcesses(listAgentProcesses('agy'))`; per process resolve cwd → conversationId via `readRegistry()`, read the transcript; live processes with no conversation → process-only RUNNING agents.
-   - inline parsing: `readRegistry`, `readSession`, `parseTranscript` (`<USER_REQUEST>` prompts + `PLANNER_RESPONSE` replies), `determineStatus`, `getConversation`.
-   - `listSessions`: iterate the `cwd → id` registry, parse each transcript, strict `cwd` filter.
+   - `detectAgents`: take `agy` processes from the shared `AgentDetectionContext` snapshot (falling back to `captureProcessSnapshot(processNames)`); per process resolve cwd → conversationId via `readRegistry()`, read the transcript; live processes with no conversation → process-only RUNNING agents.
+   - inline parsing: `readRegistry`, `readConversationCwds`, `readSession`, `parseTranscript` (`<USER_REQUEST>` prompts + `PLANNER_RESPONSE` replies), `determineStatus`, `getConversation`.
+   - `listSessions`: enumerate `brain/<id>/`, attach a cwd from the inverted registry when it names that conversation, parse each transcript, strict `cwd` filter.
 2. `AntigravityCliAdapter.test.ts` (new): fixtures from the captured real format.
 3. Exports, launch map, CLI registration, labels, validation.
 
 ## Design decisions
 - Resolve a live process's conversation from `cache/last_conversations.json` (cwd → id), not from cwd-encoded session dirs; there is one current conversation per workspace.
+- Enumerate history from `brain/`, not from that cache. The cache names only the *current* conversation of each workspace, so listing from it hides every older conversation as soon as a new one starts. `brain/` is the full set.
+- Accept partial cwd coverage as the cost of that: Antigravity records the workspace nowhere in the conversation itself (neither `transcript.jsonl` nor `transcript_full.jsonl` contains it, and `conversations/<id>.db` keeps its metadata in opaque protobuf blobs), so a conversation the cache no longer names gets `cwd: ''` and surfaces under `agent sessions --all`. Listing a session with an unknown cwd beats not listing it at all.
 - Parse `transcript.jsonl` for conversation and summary; take the prompt inside `<USER_REQUEST>...</USER_REQUEST>`.
 - `sessionFilePath` points at `transcript.jsonl` so the console's `fs.stat().mtime` cache invalidation tracks conversation growth.
 - Keep parsing resilient — a missing/malformed transcript skips the session; adapter-level failures return empty so other adapters still render.

--- a/docs/ai/implementation/feature-antigravity-cli-adapter.md
+++ b/docs/ai/implementation/feature-antigravity-cli-adapter.md
@@ -1,0 +1,27 @@
+---
+phase: implementation
+title: "Antigravity CLI Adapter in @ai-devkit/agent-manager - Implementation"
+feature: antigravity-cli-adapter
+description: Implementation notes for the Antigravity (`agy`) CLI adapter
+---
+
+# Implementation: Antigravity CLI Adapter
+
+## What shipped
+- `packages/agent-manager/src/adapters/AntigravityCliAdapter.ts` — self-contained adapter.
+- `AgentType`/`StartableAgentType` gain `'antigravity_cli'`; `AGENTS.antigravity_cli = { command: 'agy', matches: matchArgv0('agy') }`; exported from `adapters/index.ts` and `index.ts`.
+- CLI: registered in `commands/agent.ts` and `services/channel/channel-runner.ts`; `TYPE_LABELS.antigravity_cli = 'Antigravity CLI'`; `--type` help + `VALID_AGENT_TYPES` updated.
+
+## Notes
+- Home: `~/.gemini/antigravity-cli/` (override via `ANTIGRAVITY_CLI_HOME`). A live process is resolved to its conversation via `cache/last_conversations.json` (`{cwd:id}`); the process cwd is the join key.
+- Parsing: `transcript.jsonl` → user prompts are the text inside `<USER_REQUEST>...</USER_REQUEST>` of `type:'USER_INPUT'` records; the assistant reply is a `type:'PLANNER_RESPONSE'` record; other MODEL records (tool calls like RUN_COMMAND) and `SYSTEM` records are skipped unless verbose. `lastActive` is the newest record `created_at` (else file mtime).
+- `AgentInfo.sessionFilePath` / `SessionSummary.sessionFilePath` point at `transcript.jsonl`; `getConversation` accepts the file path, a session dir, or a bare conversation id.
+
+## Patterns & best practices
+- Mirror `GrokCliAdapter`'s shape (registry JSON + transcript JSONL), parsing kept **inline** like the other recent adapters.
+- Fail soft: a missing/malformed `transcript.jsonl` skips the session; adapter-level failures return empty so other adapters still render.
+
+## Error handling
+- Missing `cache/last_conversations.json` → empty registry, no throw.
+- Mapped conversation with no transcript → process-only RUNNING agent.
+- A live `agy` process whose cwd is not in the registry → process-only RUNNING agent.

--- a/docs/ai/implementation/feature-antigravity-cli-adapter.md
+++ b/docs/ai/implementation/feature-antigravity-cli-adapter.md
@@ -14,6 +14,8 @@ description: Implementation notes for the Antigravity (`agy`) CLI adapter
 
 ## Notes
 - Home: `~/.gemini/antigravity-cli/` (override via `ANTIGRAVITY_CLI_HOME`). A live process is resolved to its conversation via `cache/last_conversations.json` (`{cwd:id}`); the process cwd is the join key.
+- `detectAgents` reads `agy` processes from the shared `AgentDetectionContext` snapshot and declares `processNames = ['agy']`, so the manager's single `ps` pass covers this adapter too.
+- `listSessions` enumerates `brain/<id>/` and attaches a cwd only when the (inverted) cache still names that conversation — the cache holds one entry per workspace, so older conversations of a cwd are absent from it and would otherwise never be listed. Conversations without a cwd get `''` and show under `agent sessions --all`; nothing else on disk records the workspace (see requirements).
 - Parsing: `transcript.jsonl` → user prompts are the text inside `<USER_REQUEST>...</USER_REQUEST>` of `type:'USER_INPUT'` records; the assistant reply is a `type:'PLANNER_RESPONSE'` record; other MODEL records (tool calls like RUN_COMMAND) and `SYSTEM` records are skipped unless verbose. `lastActive` is the newest record `created_at` (else file mtime).
 - `AgentInfo.sessionFilePath` / `SessionSummary.sessionFilePath` point at `transcript.jsonl`; `getConversation` accepts the file path, a session dir, or a bare conversation id.
 
@@ -22,6 +24,7 @@ description: Implementation notes for the Antigravity (`agy`) CLI adapter
 - Fail soft: a missing/malformed `transcript.jsonl` skips the session; adapter-level failures return empty so other adapters still render.
 
 ## Error handling
-- Missing `cache/last_conversations.json` → empty registry, no throw.
+- Missing `cache/last_conversations.json` → empty registry, no throw; `listSessions` still lists `brain/` with unknown cwds.
+- Missing `brain/` → `listSessions` returns `[]`; a `brain/<id>/` with no transcript is skipped.
 - Mapped conversation with no transcript → process-only RUNNING agent.
 - A live `agy` process whose cwd is not in the registry → process-only RUNNING agent.

--- a/docs/ai/planning/feature-antigravity-cli-adapter.md
+++ b/docs/ai/planning/feature-antigravity-cli-adapter.md
@@ -1,0 +1,24 @@
+---
+phase: planning
+title: "Antigravity CLI Adapter in @ai-devkit/agent-manager - Planning"
+feature: antigravity-cli-adapter
+description: Task plan for the Antigravity (`agy`) CLI adapter
+---
+
+# Planning: Antigravity CLI Adapter
+
+## Key facts
+- Conversation source: `brain/<id>/.system_generated/logs/transcript.jsonl`. Live cwd→id from `cache/last_conversations.json`.
+- Binary `agy`; home `~/.gemini/antigravity-cli/` (override `ANTIGRAVITY_CLI_HOME`).
+
+## Tasks
+- [x] Capture real layout: `agy -p` produces `cache/last_conversations.json` (`{cwd:id}`) + `brain/<id>/.system_generated/logs/transcript.jsonl`.
+- [x] Confirm schemas (`{cwd:id}` registry; transcript `{source,type,created_at,content}` with `<USER_REQUEST>` prompts and `MODEL` responses).
+- [x] Implement self-contained `AntigravityCliAdapter` (`canHandle`, `detectAgents` via registry, inline `transcript.jsonl` parsing, `getConversation`, `listSessions`) + unit tests.
+- [x] Add `'antigravity_cli'` to `AgentType`/`StartableAgentType`; `AGENTS.antigravity_cli` launch map; exports.
+- [x] Wire CLI: register in `agent` command + channel runner; `TYPE_LABELS`; `--type` help; `VALID_AGENT_TYPES`.
+- [x] Update cli test fixtures (adapter mock, registerAdapter counts, `STARTABLE_AGENT_TYPES`, `--type` list).
+
+## Risks
+- Risk: Antigravity CLI schema evolves. Mitigation: defensive parsing, fixtures for partial/malformed inputs.
+- Risk: `proc.cwd` unavailable for some processes → falls back to process-only agent (still listed).

--- a/docs/ai/planning/feature-antigravity-cli-adapter.md
+++ b/docs/ai/planning/feature-antigravity-cli-adapter.md
@@ -9,6 +9,7 @@ description: Task plan for the Antigravity (`agy`) CLI adapter
 
 ## Key facts
 - Conversation source: `brain/<id>/.system_generated/logs/transcript.jsonl`. Live cwd→id from `cache/last_conversations.json`.
+- History source: `brain/` itself. The cache keeps one conversation per workspace, so it is a live-process join table, not a session index.
 - Binary `agy`; home `~/.gemini/antigravity-cli/` (override `ANTIGRAVITY_CLI_HOME`).
 
 ## Tasks
@@ -18,7 +19,9 @@ description: Task plan for the Antigravity (`agy`) CLI adapter
 - [x] Add `'antigravity_cli'` to `AgentType`/`StartableAgentType`; `AGENTS.antigravity_cli` launch map; exports.
 - [x] Wire CLI: register in `agent` command + channel runner; `TYPE_LABELS`; `--type` help; `VALID_AGENT_TYPES`.
 - [x] Update cli test fixtures (adapter mock, registerAdapter counts, `STARTABLE_AGENT_TYPES`, `--type` list).
+- [x] Review follow-up: list history from `brain/` so older conversations of a cwd are not hidden by the cache; keep the cache as the cwd source it actually is.
 
 ## Risks
 - Risk: Antigravity CLI schema evolves. Mitigation: defensive parsing, fixtures for partial/malformed inputs.
 - Risk: `proc.cwd` unavailable for some processes → falls back to process-only agent (still listed).
+- Risk: a listed conversation has no discoverable cwd (the cache moved on and nothing else records it) → listed with `cwd: ''`, reachable via `agent sessions --all` rather than a cwd-scoped listing.

--- a/docs/ai/requirements/feature-antigravity-cli-adapter.md
+++ b/docs/ai/requirements/feature-antigravity-cli-adapter.md
@@ -1,0 +1,31 @@
+---
+phase: requirements
+title: "Antigravity CLI Adapter in @ai-devkit/agent-manager - Requirements"
+feature: antigravity-cli-adapter
+description: Detect, list, and manage Google's Antigravity (`agy`) CLI agents in the ai-devkit control plane
+---
+
+# Requirements: Antigravity CLI Adapter for @ai-devkit/agent-manager
+
+## Problem
+ai-devkit already configures the Antigravity **IDE** via the `antigravity` environment, but it cannot see or control the Antigravity **CLI** (`agy`). Running `agy` sessions do not show in `agent list`, `agent sessions`, the console, or `agent send`. This mirrors how `gemini` (env) and `gemini_cli` (adapter) are separate; Antigravity needs its CLI adapter.
+
+## Goals
+- Detect running `agy` processes and surface them in `agent list` / console.
+- List historical Antigravity CLI conversations in `agent sessions --type antigravity_cli`.
+- Read a conversation transcript for `agent detail` / `agent send` targeting.
+- Keep the existing `antigravity` IDE environment untouched.
+
+## Non-goals
+- Launching is data-driven from `AGENTS`; no bespoke start flow.
+- No changes to the Antigravity IDE environment or its skill paths.
+
+## On-disk facts (verified against `agy`, Google Gemini-family CLI)
+- Home: `~/.gemini/antigravity-cli/` (`ANTIGRAVITY_CLI_HOME` overrides it).
+- `cache/last_conversations.json`: a `{ "<cwd>": "<conversationId>" }` map of the current conversation per workspace. This is the join key from a live process's cwd to its conversation.
+- Transcript: `brain/<conversationId>/.system_generated/logs/transcript.jsonl`, newline-delimited `{ source, type, created_at, content }`. User turns are `type: "USER_INPUT"` with the prompt inside `<USER_REQUEST>...</USER_REQUEST>`; the model reply is a `type: "PLANNER_RESPONSE"` record. Other MODEL records (tool calls such as RUN_COMMAND) and `SYSTEM` records (conversation history, checkpoints) are non-conversational.
+- The `agy` binary's argv[0] basename is `agy`.
+
+## Acceptance
+- Unit tests cover: `canHandle`, no-process, registry cwd→id resolution, process-only fallback, missing transcript, transcript conversation extraction, status mapping, `listSessions` + cwd filter.
+- Verified end-to-end against a real `agy 0.x` session on disk (`agent-manager:test` and `cli:test` pass).

--- a/docs/ai/requirements/feature-antigravity-cli-adapter.md
+++ b/docs/ai/requirements/feature-antigravity-cli-adapter.md
@@ -12,7 +12,7 @@ ai-devkit already configures the Antigravity **IDE** via the `antigravity` envir
 
 ## Goals
 - Detect running `agy` processes and surface them in `agent list` / console.
-- List historical Antigravity CLI conversations in `agent sessions --type antigravity_cli`.
+- List historical Antigravity CLI conversations in `agent sessions --type antigravity_cli` — every conversation on disk, not only the current one per workspace.
 - Read a conversation transcript for `agent detail` / `agent send` targeting.
 - Keep the existing `antigravity` IDE environment untouched.
 
@@ -22,10 +22,12 @@ ai-devkit already configures the Antigravity **IDE** via the `antigravity` envir
 
 ## On-disk facts (verified against `agy`, Google Gemini-family CLI)
 - Home: `~/.gemini/antigravity-cli/` (`ANTIGRAVITY_CLI_HOME` overrides it).
-- `cache/last_conversations.json`: a `{ "<cwd>": "<conversationId>" }` map of the current conversation per workspace. This is the join key from a live process's cwd to its conversation.
+- `cache/last_conversations.json`: a `{ "<cwd>": "<conversationId>" }` map of the current conversation per workspace. This is the join key from a live process's cwd to its conversation. It is *not* a session index: starting a new conversation in a workspace overwrites that workspace's entry, so it names at most one conversation per cwd.
+- `brain/` holds every conversation, current or not — it is the only complete list. On a dev machine with five conversations, the cache named one.
+- No file outside that cache records a conversation's workspace: `transcript.jsonl` and `transcript_full.jsonl` contain no cwd, and `conversations/<id>.db` stores its metadata in protobuf blobs (`trajectory_metadata_blob`, `steps.metadata`) with no readable path column.
 - Transcript: `brain/<conversationId>/.system_generated/logs/transcript.jsonl`, newline-delimited `{ source, type, created_at, content }`. User turns are `type: "USER_INPUT"` with the prompt inside `<USER_REQUEST>...</USER_REQUEST>`; the model reply is a `type: "PLANNER_RESPONSE"` record. Other MODEL records (tool calls such as RUN_COMMAND) and `SYSTEM` records (conversation history, checkpoints) are non-conversational.
 - The `agy` binary's argv[0] basename is `agy`.
 
 ## Acceptance
-- Unit tests cover: `canHandle`, no-process, registry cwd→id resolution, process-only fallback, missing transcript, transcript conversation extraction, status mapping, `listSessions` + cwd filter.
+- Unit tests cover: `canHandle`, no-process, registry cwd→id resolution, process-only fallback, missing transcript, transcript conversation extraction, status mapping, `listSessions` + cwd filter, and conversations the cache no longer names.
 - Verified end-to-end against a real `agy 0.x` session on disk (`agent-manager:test` and `cli:test` pass).

--- a/docs/ai/testing/feature-antigravity-cli-adapter.md
+++ b/docs/ai/testing/feature-antigravity-cli-adapter.md
@@ -1,0 +1,30 @@
+---
+phase: testing
+title: "Antigravity CLI Adapter in @ai-devkit/agent-manager - Testing"
+feature: antigravity-cli-adapter
+description: Test strategy and coverage for the Antigravity (`agy`) CLI adapter
+---
+
+# Testing Strategy: Antigravity CLI Adapter
+
+## Unit Tests (`AntigravityCliAdapter.test.ts`)
+- [x] Exposes `antigravity_cli` type
+- [x] `canHandle` true for `agy` (plain + full path + args); false for non-agy / arg-only matches
+- [x] `detectAgents` returns `[]` with no processes
+- [x] Resolves the conversation via `last_conversations.json` (cwd → id)
+- [x] Process-only RUNNING fallback when the cwd is not in the registry
+- [x] Process-only when the mapped conversation has no transcript
+- [x] `getConversation` maps `USER_INPUT` (`<USER_REQUEST>`) + `PLANNER_RESPONSE` records to roles; excludes MODEL tool calls (RUN_COMMAND) except in verbose; skips malformed lines
+- [x] `getConversation` excludes `SYSTEM` records unless verbose
+- [x] Status: WAITING on trailing MODEL turn; RUNNING on trailing USER_INPUT; IDLE past threshold
+- [x] Agent summary is the last user request
+- [x] `listSessions` returns `[]` without a registry; lists from the registry with cwd; applies the cwd filter
+
+## Integration / launch map
+- [x] `AGENTS.antigravity_cli.command === 'agy'`; registered in `agent` command + channel runner; `STARTABLE_AGENT_TYPES` includes `antigravity_cli`; `--type antigravity_cli` accepted.
+
+## End-to-End (verified against a real `agy` install)
+- [x] `listSessions()` against the real `~/.gemini/antigravity-cli` lists the on-disk conversation with `cwd`, `firstUserMessage`, and the `transcript.jsonl` `sessionFilePath`.
+- [x] `getConversation()` against the real transcript returns the `[{user}, {assistant}]` turns (`<USER_REQUEST>` extracted, `MODEL` response, `SYSTEM` skipped).
+- [x] `detectAgents()` with a live `agy` process + real registry resolves the cwd, picks the conversation, and surfaces `{type:"antigravity_cli", projectPath:<repo>, summary:<prompt>}`.
+- [x] Regression: full `agent-manager` and `cli` suites pass.

--- a/docs/ai/testing/feature-antigravity-cli-adapter.md
+++ b/docs/ai/testing/feature-antigravity-cli-adapter.md
@@ -18,13 +18,15 @@ description: Test strategy and coverage for the Antigravity (`agy`) CLI adapter
 - [x] `getConversation` excludes `SYSTEM` records unless verbose
 - [x] Status: WAITING on trailing MODEL turn; RUNNING on trailing USER_INPUT; IDLE past threshold
 - [x] Agent summary is the last user request
-- [x] `listSessions` returns `[]` without a registry; lists from the registry with cwd; applies the cwd filter
+- [x] `listSessions` returns `[]` without a `brain/` dir; attaches the cwd the cache names; applies the cwd filter
+- [x] `listSessions` lists conversations the cache no longer names (older conversations of the same cwd), with `cwd: ''`
+- [x] `listSessions` skips `brain/` entries with no transcript
 
 ## Integration / launch map
 - [x] `AGENTS.antigravity_cli.command === 'agy'`; registered in `agent` command + channel runner; `STARTABLE_AGENT_TYPES` includes `antigravity_cli`; `--type antigravity_cli` accepted.
 
 ## End-to-End (verified against a real `agy` install)
-- [x] `listSessions()` against the real `~/.gemini/antigravity-cli` lists the on-disk conversation with `cwd`, `firstUserMessage`, and the `transcript.jsonl` `sessionFilePath`.
+- [x] `listSessions()` against the real `~/.gemini/antigravity-cli` lists all 5 on-disk conversations (the cache named 1) with `firstUserMessage` and the `transcript.jsonl` `sessionFilePath`; the 1 the cache still names carries its `cwd`, and `listSessions({ cwd })` returns exactly that one.
 - [x] `getConversation()` against the real transcript returns the `[{user}, {assistant}]` turns (`<USER_REQUEST>` extracted, `MODEL` response, `SYSTEM` skipped).
 - [x] `detectAgents()` with a live `agy` process + real registry resolves the cwd, picks the conversation, and surfaces `{type:"antigravity_cli", projectPath:<repo>, summary:<prompt>}`.
 - [x] Regression: full `agent-manager` and `cli` suites pass.

--- a/packages/agent-manager/src/__tests__/adapters/AntigravityCliAdapter.test.ts
+++ b/packages/agent-manager/src/__tests__/adapters/AntigravityCliAdapter.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for AntigravityCliAdapter
+ *
+ * The adapter resolves a live `agy` process to its conversation via
+ * ~/.gemini/antigravity-cli/cache/last_conversations.json (cwd -> conversationId)
+ * and reads session details from brain/<id>/.system_generated/logs/transcript.jsonl.
+ */
+
+import type { MockedFunction } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { AntigravityCliAdapter } from '../../adapters/AntigravityCliAdapter.js';
+import type { ProcessInfo } from '../../adapters/AgentAdapter.js';
+import { AgentStatus } from '../../adapters/AgentAdapter.js';
+import { listAgentProcesses, enrichProcesses } from '../../utils/process.js';
+import { generateAgentName } from '../../utils/matching.js';
+
+vi.mock('../../utils/process.js', async (importOriginal) => {
+    const actual = (await importOriginal()) as typeof import('../../utils/process.js');
+    return {
+        ...actual,
+        listAgentProcesses: vi.fn(),
+        enrichProcesses: vi.fn(),
+    };
+});
+
+vi.mock('../../utils/matching.js', async (importOriginal) => {
+    const actual = (await importOriginal()) as typeof import('../../utils/matching.js');
+    return {
+        ...actual,
+        generateAgentName: vi.fn(),
+    };
+});
+
+const mockedListAgentProcesses = listAgentProcesses as MockedFunction<typeof listAgentProcesses>;
+const mockedEnrichProcesses = enrichProcesses as MockedFunction<typeof enrichProcesses>;
+const mockedGenerateAgentName = generateAgentName as MockedFunction<typeof generateAgentName>;
+
+const CONVERSATION_ID = '10485e13-2742-4e9e-b286-ac0606f0cb1e';
+
+const iso = (d: Date) => d.toISOString().replace(/\.\d+Z$/, 'Z');
+/** A user transcript record: real prompt wrapped in <USER_REQUEST> like agy writes it. */
+const userRecord = (text: string, at?: Date) => ({
+    source: 'USER_EXPLICIT',
+    type: 'USER_INPUT',
+    created_at: iso(at ?? new Date()),
+    content: `<USER_REQUEST>\n${text}\n</USER_REQUEST>\n<ADDITIONAL_CONTEXT>ignored</ADDITIONAL_CONTEXT>`,
+});
+const modelRecord = (text: string, at?: Date) => ({
+    source: 'MODEL',
+    type: 'PLANNER_RESPONSE',
+    created_at: iso(at ?? new Date()),
+    content: text,
+});
+/** A MODEL tool-call record (e.g. RUN_COMMAND) — execution detail, not a reply. */
+const toolRecord = (text: string, at?: Date) => ({
+    source: 'MODEL',
+    type: 'RUN_COMMAND',
+    created_at: iso(at ?? new Date()),
+    content: text,
+});
+const systemRecord = (text: string, at?: Date) => ({
+    source: 'SYSTEM',
+    type: 'CHECKPOINT',
+    created_at: iso(at ?? new Date()),
+    content: text,
+});
+
+describe('AntigravityCliAdapter', () => {
+    let adapter: AntigravityCliAdapter;
+    let base: string;
+    let cwd: string;
+
+    beforeEach(() => {
+        base = fs.mkdtempSync(path.join(os.tmpdir(), 'agy-adapter-test-'));
+        process.env.ANTIGRAVITY_CLI_HOME = base;
+        cwd = '/Users/dev/my-project';
+
+        adapter = new AntigravityCliAdapter();
+
+        mockedListAgentProcesses.mockReset();
+        mockedEnrichProcesses.mockReset();
+        mockedGenerateAgentName.mockReset();
+
+        mockedEnrichProcesses.mockImplementation((procs) => procs);
+        mockedGenerateAgentName.mockImplementation((c: string, pid: number) => `${path.basename(c) || 'unknown'}-${pid}`);
+    });
+
+    afterEach(() => {
+        delete process.env.ANTIGRAVITY_CLI_HOME;
+        fs.rmSync(base, { recursive: true, force: true });
+    });
+
+    /** Write brain/<id>/.system_generated/logs/transcript.jsonl. */
+    function writeTranscript(opts: { id?: string; records?: object[]; transcript?: boolean }): string {
+        const id = opts.id ?? CONVERSATION_ID;
+        const dir = path.join(base, 'brain', id, '.system_generated', 'logs');
+        fs.mkdirSync(dir, { recursive: true });
+        if (opts.transcript !== false) {
+            const records = opts.records ?? [userRecord('fix the bug')];
+            fs.writeFileSync(path.join(dir, 'transcript.jsonl'), records.map((r) => JSON.stringify(r)).join('\n'));
+        }
+        return path.join(dir, 'transcript.jsonl');
+    }
+
+    /** Write cache/last_conversations.json (cwd -> conversationId). */
+    function writeRegistry(map: Record<string, string>): void {
+        const dir = path.join(base, 'cache');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'last_conversations.json'), JSON.stringify(map));
+    }
+
+    function proc(overrides: Partial<ProcessInfo> = {}): ProcessInfo {
+        return { pid: 4242, ppid: 1, command: 'agy', cwd, tty: 'ttys010', startTime: new Date(), ...overrides };
+    }
+
+    describe('initialization', () => {
+        it('exposes the antigravity_cli type', () => {
+            expect(adapter.type).toBe('antigravity_cli');
+        });
+    });
+
+    describe('canHandle', () => {
+        it('returns true for a plain agy command', () => {
+            expect(adapter.canHandle(proc({ command: 'agy' }))).toBe(true);
+        });
+
+        it('returns true for agy with a full path and args', () => {
+            expect(adapter.canHandle(proc({ command: '/Users/dev/.local/bin/agy --dangerously-skip-permissions' }))).toBe(true);
+        });
+
+        it('returns false for non-agy processes', () => {
+            expect(adapter.canHandle(proc({ command: 'node app.js' }))).toBe(false);
+        });
+
+        it('returns false when "agy" appears only in an argument path', () => {
+            expect(adapter.canHandle(proc({ command: 'node /path/to/agy-thing.js' }))).toBe(false);
+        });
+    });
+
+    describe('detectAgents', () => {
+        it('returns [] when there are no agy processes', async () => {
+            mockedListAgentProcesses.mockReturnValue([]);
+            expect(await adapter.detectAgents()).toEqual([]);
+        });
+
+        it('resolves the conversation via last_conversations.json (cwd -> id)', async () => {
+            writeTranscript({});
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents).toHaveLength(1);
+            expect(agents[0]).toMatchObject({
+                type: 'antigravity_cli',
+                pid: 4242,
+                projectPath: cwd,
+                sessionId: CONVERSATION_ID,
+                summary: 'fix the bug',
+            });
+            expect(agents[0].sessionFilePath).toBe(
+                path.join(base, 'brain', CONVERSATION_ID, '.system_generated', 'logs', 'transcript.jsonl'),
+            );
+        });
+
+        it('falls back to a process-only RUNNING agent when the cwd is not in the registry', async () => {
+            writeTranscript({});
+            writeRegistry({ '/some/other/cwd': CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents).toHaveLength(1);
+            expect(agents[0].status).toBe(AgentStatus.RUNNING);
+            expect(agents[0].sessionId).toBe('pid-4242');
+            expect(agents[0].sessionFilePath).toBeUndefined();
+        });
+
+        it('is process-only when the mapped conversation has no transcript', async () => {
+            writeTranscript({ transcript: false });
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+
+            const agents = await adapter.detectAgents();
+
+            expect(agents[0].sessionId).toBe('pid-4242');
+        });
+    });
+
+    describe('getConversation', () => {
+        it('maps USER_INPUT (<USER_REQUEST>) and MODEL records to roles', () => {
+            const file = writeTranscript({ records: [userRecord('hi'), modelRecord('hello')] });
+            expect(adapter.getConversation(file)).toEqual([
+                { role: 'user', content: 'hi' },
+                { role: 'assistant', content: 'hello' },
+            ]);
+        });
+
+        it('accepts a bare conversation id and skips malformed lines', () => {
+            const file = writeTranscript({ records: [userRecord('hi')] });
+            fs.appendFileSync(file, '\n{bad json');
+            expect(adapter.getConversation(CONVERSATION_ID)).toEqual([{ role: 'user', content: 'hi' }]);
+        });
+
+        it('excludes SYSTEM records unless verbose', () => {
+            const file = writeTranscript({ records: [systemRecord('checkpoint'), userRecord('go')] });
+            expect(adapter.getConversation(file)).toEqual([{ role: 'user', content: 'go' }]);
+            expect(adapter.getConversation(file, { verbose: true }).map((m) => m.role)).toEqual(['system', 'user']);
+        });
+
+        it('excludes MODEL tool-call (RUN_COMMAND) records except in verbose', () => {
+            const file = writeTranscript({ records: [userRecord('go'), toolRecord('ran: echo hi'), modelRecord('done')] });
+            // A tool call is not an assistant reply; only USER_INPUT + PLANNER_RESPONSE show.
+            expect(adapter.getConversation(file)).toEqual([
+                { role: 'user', content: 'go' },
+                { role: 'assistant', content: 'done' },
+            ]);
+            expect(adapter.getConversation(file, { verbose: true }).map((m) => m.role)).toEqual(['user', 'system', 'assistant']);
+        });
+    });
+
+    describe('detectAgents status + summary mapping', () => {
+        const detectFirst = async () => (await adapter.detectAgents())[0];
+
+        it('marks WAITING when the last reply is a PLANNER_RESPONSE (after a tool call)', async () => {
+            writeTranscript({ records: [userRecord('go'), toolRecord('ran: echo hi'), modelRecord('done')] });
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).status).toBe(AgentStatus.WAITING);
+        });
+
+        it('marks RUNNING when the last transcript turn is a USER_INPUT message', async () => {
+            writeTranscript({ records: [userRecord('still there?')] });
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).status).toBe(AgentStatus.RUNNING);
+        });
+
+        it('marks IDLE when the last created_at is older than the threshold', async () => {
+            const old = new Date(Date.now() - 10 * 60 * 1000);
+            writeTranscript({ records: [userRecord('go', old)] });
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).status).toBe(AgentStatus.IDLE);
+        });
+
+        it('uses the last user request as the agent summary', async () => {
+            writeTranscript({ records: [userRecord('refactor the parser'), modelRecord('on it')] });
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            mockedListAgentProcesses.mockReturnValue([proc()]);
+            expect((await detectFirst()).summary).toBe('refactor the parser');
+        });
+    });
+
+    describe('listSessions', () => {
+        it('returns [] when there is no registry', async () => {
+            expect(await adapter.listSessions()).toEqual([]);
+        });
+
+        it('lists sessions from the registry with cwd + first user message', async () => {
+            writeTranscript({});
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+            const summaries = await adapter.listSessions();
+            expect(summaries).toHaveLength(1);
+            expect(summaries[0]).toMatchObject({
+                type: 'antigravity_cli',
+                sessionId: CONVERSATION_ID,
+                cwd,
+                firstUserMessage: 'fix the bug',
+            });
+        });
+
+        it('applies the cwd filter', async () => {
+            writeTranscript({ id: 'aaa0000a-0000-4000-8000-00000000000a', records: [userRecord('a')] });
+            writeTranscript({ id: 'bbb0000b-0000-4000-8000-00000000000b', records: [userRecord('b')] });
+            writeRegistry({
+                '/Users/dev/project-a': 'aaa0000a-0000-4000-8000-00000000000a',
+                '/Users/dev/project-b': 'bbb0000b-0000-4000-8000-00000000000b',
+            });
+
+            const all = await adapter.listSessions();
+            expect(all).toHaveLength(2);
+
+            const filtered = await adapter.listSessions({ cwd: '/Users/dev/project-a' });
+            expect(filtered).toHaveLength(1);
+            expect(filtered[0].cwd).toBe('/Users/dev/project-a');
+        });
+    });
+});

--- a/packages/agent-manager/src/__tests__/adapters/AntigravityCliAdapter.test.ts
+++ b/packages/agent-manager/src/__tests__/adapters/AntigravityCliAdapter.test.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { AntigravityCliAdapter } from '../../adapters/AntigravityCliAdapter.js';
 import type { ProcessInfo } from '../../adapters/AgentAdapter.js';
 import { AgentStatus } from '../../adapters/AgentAdapter.js';
-import { listAgentProcesses, enrichProcesses } from '../../utils/process.js';
+import { listAgentProcesses, enrichProcesses, captureProcessSnapshot } from '../../utils/process.js';
 import { generateAgentName } from '../../utils/matching.js';
 
 vi.mock('../../utils/process.js', async (importOriginal) => {
@@ -23,6 +23,7 @@ vi.mock('../../utils/process.js', async (importOriginal) => {
         ...actual,
         listAgentProcesses: vi.fn(),
         enrichProcesses: vi.fn(),
+        captureProcessSnapshot: vi.fn(),
     };
 });
 
@@ -36,6 +37,7 @@ vi.mock('../../utils/matching.js', async (importOriginal) => {
 
 const mockedListAgentProcesses = listAgentProcesses as MockedFunction<typeof listAgentProcesses>;
 const mockedEnrichProcesses = enrichProcesses as MockedFunction<typeof enrichProcesses>;
+const mockedCaptureProcessSnapshot = captureProcessSnapshot as MockedFunction<typeof captureProcessSnapshot>;
 const mockedGenerateAgentName = generateAgentName as MockedFunction<typeof generateAgentName>;
 
 const CONVERSATION_ID = '10485e13-2742-4e9e-b286-ac0606f0cb1e';
@@ -82,9 +84,14 @@ describe('AntigravityCliAdapter', () => {
 
         mockedListAgentProcesses.mockReset();
         mockedEnrichProcesses.mockReset();
+        mockedCaptureProcessSnapshot.mockReset();
         mockedGenerateAgentName.mockReset();
 
         mockedEnrichProcesses.mockImplementation((procs) => procs);
+        // Compatibility shim for standalone adapter discovery; the manager captures once and slices by name.
+        mockedCaptureProcessSnapshot.mockImplementation(async (names) => (
+            enrichProcesses(names.flatMap((name) => listAgentProcesses(name)))
+        ));
         mockedGenerateAgentName.mockImplementation((c: string, pid: number) => `${path.basename(c) || 'unknown'}-${pid}`);
     });
 
@@ -256,11 +263,11 @@ describe('AntigravityCliAdapter', () => {
     });
 
     describe('listSessions', () => {
-        it('returns [] when there is no registry', async () => {
+        it('returns [] when there is no brain dir', async () => {
             expect(await adapter.listSessions()).toEqual([]);
         });
 
-        it('lists sessions from the registry with cwd + first user message', async () => {
+        it('lists a conversation with the cwd the cache names for it', async () => {
             writeTranscript({});
             writeRegistry({ [cwd]: CONVERSATION_ID });
             const summaries = await adapter.listSessions();
@@ -273,16 +280,42 @@ describe('AntigravityCliAdapter', () => {
             });
         });
 
-        it('applies the cwd filter', async () => {
+        it('lists older conversations of a cwd the cache no longer names', async () => {
+            // The CLI keeps only the newest conversation per workspace in
+            // last_conversations.json, so the previous two exist on disk with no
+            // cache entry. Listing from the cache alone would drop them.
+            writeTranscript({ id: 'aaa0000a-0000-4000-8000-00000000000a', records: [userRecord('older')] });
+            writeTranscript({ id: 'bbb0000b-0000-4000-8000-00000000000b', records: [userRecord('older still')] });
+            writeTranscript({ records: [userRecord('current')] });
+            writeRegistry({ [cwd]: CONVERSATION_ID });
+
+            const summaries = await adapter.listSessions();
+            expect(summaries.map((s) => s.sessionId).sort()).toEqual([
+                'aaa0000a-0000-4000-8000-00000000000a',
+                'bbb0000b-0000-4000-8000-00000000000b',
+                CONVERSATION_ID,
+            ].sort());
+            expect(summaries.find((s) => s.sessionId === CONVERSATION_ID)?.cwd).toBe(cwd);
+            // Antigravity records the workspace nowhere else, so these are cwd-less.
+            expect(summaries.filter((s) => s.cwd === '')).toHaveLength(2);
+        });
+
+        it('skips brain entries without a transcript', async () => {
+            writeTranscript({ transcript: false });
+            expect(await adapter.listSessions()).toEqual([]);
+        });
+
+        it('applies the cwd filter, leaving cwd-less conversations to --all', async () => {
             writeTranscript({ id: 'aaa0000a-0000-4000-8000-00000000000a', records: [userRecord('a')] });
             writeTranscript({ id: 'bbb0000b-0000-4000-8000-00000000000b', records: [userRecord('b')] });
+            writeTranscript({ records: [userRecord('unknown cwd')] });
             writeRegistry({
                 '/Users/dev/project-a': 'aaa0000a-0000-4000-8000-00000000000a',
                 '/Users/dev/project-b': 'bbb0000b-0000-4000-8000-00000000000b',
             });
 
             const all = await adapter.listSessions();
-            expect(all).toHaveLength(2);
+            expect(all).toHaveLength(3);
 
             const filtered = await adapter.listSessions({ cwd: '/Users/dev/project-a' });
             expect(filtered).toHaveLength(1);

--- a/packages/agent-manager/src/__tests__/utils/agents.test.ts
+++ b/packages/agent-manager/src/__tests__/utils/agents.test.ts
@@ -21,4 +21,11 @@ describe('AGENTS', () => {
         expect(AGENTS.grok_cli.matches('/Users/dev/.grok/bin/grok --always-approve')).toBe(true);
         expect(AGENTS.grok_cli.matches('node /repo/feature-grok-cli/script.js')).toBe(false);
     });
+
+    it('includes Antigravity CLI as a startable agent', () => {
+        expect(AGENTS.antigravity_cli.command).toBe('agy');
+        expect(AGENTS.antigravity_cli.matches('agy')).toBe(true);
+        expect(AGENTS.antigravity_cli.matches('/Users/dev/.gemini/antigravity-cli/bin/agy')).toBe(true);
+        expect(AGENTS.antigravity_cli.matches('node /repo/feature-antigravity-cli/script.js')).toBe(false);
+    });
 });

--- a/packages/agent-manager/src/adapters/AgentAdapter.ts
+++ b/packages/agent-manager/src/adapters/AgentAdapter.ts
@@ -8,7 +8,7 @@
 /**
  * Type of AI agent
  */
-export type AgentType = 'claude' | 'gemini_cli' | 'grok_cli' | 'codex' | 'opencode' | 'copilot' | 'pi' | 'other';
+export type AgentType = 'claude' | 'gemini_cli' | 'grok_cli' | 'antigravity_cli' | 'codex' | 'opencode' | 'copilot' | 'pi' | 'other';
 
 /**
  * Current status of an agent

--- a/packages/agent-manager/src/adapters/AntigravityCliAdapter.ts
+++ b/packages/agent-manager/src/adapters/AntigravityCliAdapter.ts
@@ -1,0 +1,350 @@
+import * as path from 'path';
+import type {
+    AgentAdapter,
+    AgentInfo,
+    ProcessInfo,
+    ConversationMessage,
+    SessionSummary,
+    ListSessionsOptions,
+} from './AgentAdapter.js';
+import { AgentStatus } from './AgentAdapter.js';
+import { listAgentProcesses, enrichProcesses } from '../utils/process.js';
+import { safeReadFile, safeStat } from '../utils/session.js';
+import { generateAgentName } from '../utils/matching.js';
+
+/**
+ * Antigravity CLI Adapter
+ *
+ * Detects running Antigravity CLI agents (Google's Gemini-family `agy` CLI) by:
+ * 1. Finding running `agy` processes via shared listAgentProcesses() — Antigravity
+ *    ships a native binary (argv[0] basename `agy`).
+ * 2. Resolving each live process to its conversation via
+ *    ~/.gemini/antigravity-cli/cache/last_conversations.json, which the CLI
+ *    maintains as a `{ <cwd>: <conversationId> }` map of the current conversation
+ *    per workspace. The process cwd is the join key.
+ * 3. Reading the transcript from
+ *    brain/<conversationId>/.system_generated/logs/transcript.jsonl. User turns are
+ *    USER_INPUT records (prompt inside <USER_REQUEST>...</USER_REQUEST>) and the
+ *    model's reply is a PLANNER_RESPONSE record; tool calls (RUN_COMMAND, ...) are
+ *    skipped. The last user turn is the summary; each record's created_at gives the
+ *    last-activity time.
+ *
+ * This is the runtime/agent side of Antigravity; it is independent of the
+ * `antigravity` environment (which configures the Antigravity IDE), the same way
+ * GeminiCliAdapter is independent of the `gemini` environment.
+ */
+
+const REGISTRY_FILE = path.join('cache', 'last_conversations.json');
+const BRAIN_DIR = 'brain';
+const TRANSCRIPT_REL = path.join('.system_generated', 'logs', 'transcript.jsonl');
+const IDLE_THRESHOLD_MINUTES = 5;
+
+/** One line of transcript.jsonl. */
+interface TranscriptRecord {
+    source?: string;
+    type?: string;
+    created_at?: string;
+    content?: unknown;
+}
+
+interface TranscriptScan {
+    messages: ConversationMessage[];
+    firstUserMessage?: string;
+    lastUserMessage?: string;
+    lastRole?: ConversationMessage['role'];
+    lastActive?: Date;
+}
+
+/** Parsed state for a single conversation. */
+interface AntigravitySession {
+    sessionId: string;
+    projectPath: string;
+    summary: string;
+    sessionStart: Date;
+    lastActive: Date;
+    firstUserMessage?: string;
+    lastUserMessage?: string;
+    lastRole?: ConversationMessage['role'];
+}
+
+export class AntigravityCliAdapter implements AgentAdapter {
+    readonly type = 'antigravity_cli' as const;
+
+    private base: string;
+
+    constructor() {
+        // ANTIGRAVITY_CLI_HOME overrides the ~/.gemini/antigravity-cli base dir.
+        const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+        this.base = process.env.ANTIGRAVITY_CLI_HOME || path.join(homeDir, '.gemini', 'antigravity-cli');
+    }
+
+    canHandle(processInfo: ProcessInfo): boolean {
+        return this.isAgyExecutable(processInfo.command);
+    }
+
+    private isAgyExecutable(command: string): boolean {
+        const executable = command.trim().split(/\s+/)[0] || '';
+        const base = path.basename(executable).toLowerCase();
+        return base === 'agy' || base === 'agy.exe';
+    }
+
+    async detectAgents(): Promise<AgentInfo[]> {
+        const processes = enrichProcesses(listAgentProcesses('agy'));
+        if (processes.length === 0) {
+            return [];
+        }
+
+        // last_conversations.json maps a workspace cwd to its current
+        // conversation id; the live process cwd is the join key.
+        const cwdToConversation = this.readRegistry();
+
+        const agents: AgentInfo[] = [];
+        for (const proc of processes) {
+            const cwd = proc.cwd || '';
+            const conversationId = cwd ? cwdToConversation.get(cwd) : undefined;
+            const session = conversationId ? this.readSession(conversationId, cwd) : null;
+
+            if (session) {
+                agents.push(this.mapSessionToAgent(session, proc));
+            } else {
+                agents.push(this.mapProcessOnlyAgent(proc, cwd));
+            }
+        }
+
+        return agents;
+    }
+
+    /**
+     * Read cache/last_conversations.json into a cwd -> conversationId map. The
+     * CLI rewrites this as the current conversation per workspace changes.
+     */
+    private readRegistry(): Map<string, string> {
+        const map = new Map<string, string>();
+        const content = safeReadFile(path.join(this.base, REGISTRY_FILE));
+        if (content === undefined) return map;
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(content);
+        } catch {
+            return map;
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return map;
+
+        for (const [cwd, conversationId] of Object.entries(parsed as Record<string, unknown>)) {
+            if (cwd && typeof conversationId === 'string' && conversationId) {
+                map.set(cwd, conversationId);
+            }
+        }
+        return map;
+    }
+
+    private transcriptPath(conversationId: string): string {
+        return path.join(this.base, BRAIN_DIR, conversationId, TRANSCRIPT_REL);
+    }
+
+    private mapSessionToAgent(session: AntigravitySession, processInfo: ProcessInfo): AgentInfo {
+        const projectPath = session.projectPath || processInfo.cwd || '';
+        return {
+            name: generateAgentName(projectPath, processInfo.pid),
+            type: this.type,
+            status: this.determineStatus(session),
+            summary: session.summary || 'Antigravity CLI session active',
+            pid: processInfo.pid,
+            projectPath,
+            sessionId: session.sessionId,
+            lastActive: session.lastActive,
+            sessionFilePath: this.transcriptPath(session.sessionId),
+        };
+    }
+
+    private mapProcessOnlyAgent(processInfo: ProcessInfo, cwd: string): AgentInfo {
+        const projectPath = cwd || processInfo.cwd || '';
+        return {
+            name: generateAgentName(projectPath, processInfo.pid),
+            type: this.type,
+            status: AgentStatus.RUNNING,
+            summary: 'Antigravity CLI process running',
+            pid: processInfo.pid,
+            projectPath,
+            sessionId: `pid-${processInfo.pid}`,
+            lastActive: new Date(),
+        };
+    }
+
+    getConversation(sessionFilePath: string, options?: { verbose?: boolean }): ConversationMessage[] {
+        return this.parseTranscript(this.resolveTranscriptPath(sessionFilePath), options?.verbose ?? false).messages;
+    }
+
+    async listSessions(opts?: ListSessionsOptions): Promise<SessionSummary[]> {
+        const filterCwd = opts?.cwd;
+        const summaries: SessionSummary[] = [];
+
+        for (const [cwd, conversationId] of this.readRegistry()) {
+            if (filterCwd !== undefined && cwd !== filterCwd) continue;
+
+            const session = this.readSession(conversationId, cwd);
+            if (!session) continue;
+
+            summaries.push({
+                type: this.type,
+                sessionId: session.sessionId,
+                cwd: session.projectPath || cwd,
+                firstUserMessage: session.firstUserMessage || '',
+                lastActive: session.lastActive,
+                startedAt: session.sessionStart,
+                sessionFilePath: this.transcriptPath(conversationId),
+            });
+        }
+
+        return summaries;
+    }
+
+    // --- Session parsing (transcript.jsonl) ---
+
+    /**
+     * Parse a conversation into an {@link AntigravitySession} from its
+     * transcript.jsonl. Returns null when the transcript is missing — i.e. there
+     * is no real session to surface.
+     */
+    private readSession(conversationId: string, defaultCwd: string): AntigravitySession | null {
+        const transcriptPath = this.transcriptPath(conversationId);
+        const stat = safeStat(transcriptPath);
+        if (!stat) return null;
+
+        const scan = this.parseTranscript(transcriptPath, false);
+        const lastActive = scan.lastActive || stat.mtime;
+
+        return {
+            sessionId: conversationId,
+            projectPath: defaultCwd || '',
+            summary: scan.lastUserMessage || 'Antigravity CLI session active',
+            sessionStart: stat.birthtime || lastActive,
+            lastActive,
+            firstUserMessage: scan.firstUserMessage,
+            lastUserMessage: scan.lastUserMessage,
+            lastRole: scan.lastRole,
+        };
+    }
+
+    /**
+     * Determine agent status from parsed session state.
+     *
+     * - past the idle threshold → IDLE
+     * - last transcript turn is an assistant message → WAITING (awaiting user)
+     * - otherwise (last turn was a user message, or unknown) → RUNNING
+     */
+    private determineStatus(session: AntigravitySession): AgentStatus {
+        const diffMinutes = (Date.now() - session.lastActive.getTime()) / 60000;
+        if (diffMinutes > IDLE_THRESHOLD_MINUTES) {
+            return AgentStatus.IDLE;
+        }
+        if (session.lastRole === 'assistant') {
+            return AgentStatus.WAITING;
+        }
+        return AgentStatus.RUNNING;
+    }
+
+    /**
+     * Single pass over transcript.jsonl. Each line is a
+     * { source, type, created_at, content } record. User turns are
+     * `type: 'USER_INPUT'` with the real prompt wrapped in
+     * <USER_REQUEST>...</USER_REQUEST>; the model's reply is `type:
+     * 'PLANNER_RESPONSE'`. Other MODEL records (tool calls like RUN_COMMAND) and
+     * SYSTEM records (conversation history, checkpoints) are execution detail and
+     * are skipped unless verbose.
+     */
+    private parseTranscript(transcriptPath: string, verbose: boolean): TranscriptScan {
+        const empty: TranscriptScan = { messages: [] };
+        const content = safeReadFile(transcriptPath);
+        if (content === undefined) return empty;
+
+        const messages: ConversationMessage[] = [];
+        let lastRole: ConversationMessage['role'] | undefined;
+        let lastActive: Date | undefined;
+
+        for (const line of content.trim().split('\n')) {
+            if (!line.trim()) continue;
+
+            let record: TranscriptRecord;
+            try {
+                record = JSON.parse(line);
+            } catch {
+                continue;
+            }
+
+            const at = this.parseTimestamp(record.created_at);
+            if (at && (!lastActive || at.getTime() > lastActive.getTime())) lastActive = at;
+
+            const text = this.extractText(record.content);
+            if (record.type === 'USER_INPUT') {
+                const request = this.extractUserRequest(text);
+                if (request === null) continue; // not a real prompt
+                messages.push({ role: 'user', content: request });
+                lastRole = 'user';
+            } else if (record.type === 'PLANNER_RESPONSE') {
+                // The model's user-facing reply. Other MODEL records (tool calls
+                // such as RUN_COMMAND, empty planning steps) are execution detail,
+                // not conversation, so they are excluded from the normal view.
+                if (!text) continue;
+                messages.push({ role: 'assistant', content: text });
+                lastRole = 'assistant';
+            } else if (verbose) {
+                // Tool calls (MODEL/RUN_COMMAND, ...) and SYSTEM records surface
+                // only in verbose mode.
+                if (!text) continue;
+                messages.push({ role: 'system', content: text });
+            }
+        }
+
+        const userTurns = messages.filter((m) => m.role === 'user');
+        return {
+            messages,
+            firstUserMessage: userTurns[0]?.content,
+            lastUserMessage: userTurns[userTurns.length - 1]?.content,
+            lastRole,
+            lastActive,
+        };
+    }
+
+    /** Flatten a transcript record's content (string or text-block array) to text. */
+    private extractText(content: unknown): string {
+        if (typeof content === 'string') return content;
+        if (Array.isArray(content)) {
+            return content
+                .map((block) =>
+                    block && typeof block === 'object' && typeof (block as { text?: unknown }).text === 'string'
+                        ? (block as { text: string }).text
+                        : '',
+                )
+                .join('');
+        }
+        return '';
+    }
+
+    /**
+     * Extract the prompt inside <USER_REQUEST>...</USER_REQUEST>. Returns null when
+     * the record has no such tag (context injection rather than a prompt). Falls
+     * back to the trimmed text when a USER_INPUT record has no wrapper.
+     */
+    private extractUserRequest(text: string): string | null {
+        const match = text.match(/<USER_REQUEST>\s*([\s\S]*?)\s*<\/USER_REQUEST>/);
+        if (match) return match[1].trim();
+        const trimmed = text.trim();
+        return trimmed ? trimmed : null;
+    }
+
+    /** Resolve a conversation dir, transcript path, or bare id to the transcript file. */
+    private resolveTranscriptPath(sessionPath: string): string {
+        if (sessionPath.endsWith('.jsonl')) return sessionPath;
+        // A bare conversation id (no separator) resolves under the brain dir.
+        if (!sessionPath.includes(path.sep)) return this.transcriptPath(sessionPath);
+        return path.join(sessionPath, TRANSCRIPT_REL);
+    }
+
+    private parseTimestamp(value?: string): Date | null {
+        if (!value) return null;
+        const ts = new Date(value);
+        return Number.isNaN(ts.getTime()) ? null : ts;
+    }
+}

--- a/packages/agent-manager/src/adapters/AntigravityCliAdapter.ts
+++ b/packages/agent-manager/src/adapters/AntigravityCliAdapter.ts
@@ -7,16 +7,17 @@ import type {
     SessionSummary,
     ListSessionsOptions,
 } from './AgentAdapter.js';
+import type { AgentDetectionContext } from './AgentAdapter.js';
 import { AgentStatus } from './AgentAdapter.js';
-import { listAgentProcesses, enrichProcesses } from '../utils/process.js';
-import { safeReadFile, safeStat } from '../utils/session.js';
+import { captureProcessSnapshot, executableBasename, filterByProcessNames } from '../utils/process.js';
+import { isDirectory, safeReaddir, safeReadFile, safeStat } from '../utils/session.js';
 import { generateAgentName } from '../utils/matching.js';
 
 /**
  * Antigravity CLI Adapter
  *
  * Detects running Antigravity CLI agents (Google's Gemini-family `agy` CLI) by:
- * 1. Finding running `agy` processes via shared listAgentProcesses() — Antigravity
+ * 1. Finding running `agy` processes in the shared process snapshot — Antigravity
  *    ships a native binary (argv[0] basename `agy`).
  * 2. Resolving each live process to its conversation via
  *    ~/.gemini/antigravity-cli/cache/last_conversations.json, which the CLI
@@ -28,6 +29,11 @@ import { generateAgentName } from '../utils/matching.js';
  *    model's reply is a PLANNER_RESPONSE record; tool calls (RUN_COMMAND, ...) are
  *    skipped. The last user turn is the summary; each record's created_at gives the
  *    last-activity time.
+ *
+ * listSessions() enumerates brain/ instead, because that directory — not the
+ * cache — is the full history: the cache only names the *current* conversation
+ * of each workspace, so older conversations of the same cwd are absent from it.
+ * See {@link AntigravityCliAdapter.listSessions} for what that costs us.
  *
  * This is the runtime/agent side of Antigravity; it is independent of the
  * `antigravity` environment (which configures the Antigravity IDE), the same way
@@ -69,6 +75,7 @@ interface AntigravitySession {
 
 export class AntigravityCliAdapter implements AgentAdapter {
     readonly type = 'antigravity_cli' as const;
+    readonly processNames = ['agy'] as const;
 
     private base: string;
 
@@ -83,13 +90,14 @@ export class AntigravityCliAdapter implements AgentAdapter {
     }
 
     private isAgyExecutable(command: string): boolean {
-        const executable = command.trim().split(/\s+/)[0] || '';
-        const base = path.basename(executable).toLowerCase();
+        const base = executableBasename(command);
         return base === 'agy' || base === 'agy.exe';
     }
 
-    async detectAgents(): Promise<AgentInfo[]> {
-        const processes = enrichProcesses(listAgentProcesses('agy'));
+    async detectAgents(context?: AgentDetectionContext): Promise<AgentInfo[]> {
+        const snapshot = context?.processes ?? await captureProcessSnapshot(this.processNames);
+        const relevant = filterByProcessNames(snapshot, this.processNames);
+        const processes = relevant.filter((process) => this.canHandle(process));
         if (processes.length === 0) {
             return [];
         }
@@ -176,11 +184,31 @@ export class AntigravityCliAdapter implements AgentAdapter {
         return this.parseTranscript(this.resolveTranscriptPath(sessionFilePath), options?.verbose ?? false).messages;
     }
 
+    /**
+     * Enumerate every conversation under brain/, not just the ones named in
+     * cache/last_conversations.json: that cache holds the *current* conversation
+     * per workspace, so listing from it would hide every older conversation of a
+     * cwd the moment a new one starts.
+     *
+     * The trade-off is cwd coverage. Antigravity records the workspace nowhere in
+     * the conversation itself — neither transcript.jsonl nor transcript_full.jsonl
+     * carries it, and conversations/<id>.db keeps its metadata in opaque protobuf
+     * blobs — so the cache is the only readable cwd source. Conversations it no
+     * longer names therefore get `cwd: ''` and surface under `--all` rather than
+     * under a cwd-scoped listing.
+     */
     async listSessions(opts?: ListSessionsOptions): Promise<SessionSummary[]> {
+        const brainDir = path.join(this.base, BRAIN_DIR);
+        if (!isDirectory(brainDir)) return [];
+
         const filterCwd = opts?.cwd;
+        const knownCwds = this.readConversationCwds();
         const summaries: SessionSummary[] = [];
 
-        for (const [cwd, conversationId] of this.readRegistry()) {
+        for (const conversationId of safeReaddir(brainDir)) {
+            if (!isDirectory(path.join(brainDir, conversationId))) continue;
+
+            const cwd = knownCwds.get(conversationId) ?? '';
             if (filterCwd !== undefined && cwd !== filterCwd) continue;
 
             const session = this.readSession(conversationId, cwd);
@@ -198,6 +226,19 @@ export class AntigravityCliAdapter implements AgentAdapter {
         }
 
         return summaries;
+    }
+
+    /**
+     * Invert {@link readRegistry} into conversationId -> cwd. Only the current
+     * conversation of each workspace appears, so a miss means "workspace unknown",
+     * not "no such conversation".
+     */
+    private readConversationCwds(): Map<string, string> {
+        const map = new Map<string, string>();
+        for (const [cwd, conversationId] of this.readRegistry()) {
+            map.set(conversationId, cwd);
+        }
+        return map;
     }
 
     // --- Session parsing (transcript.jsonl) ---

--- a/packages/agent-manager/src/adapters/index.ts
+++ b/packages/agent-manager/src/adapters/index.ts
@@ -3,6 +3,7 @@ export { CodexAdapter } from './CodexAdapter.js';
 export { CopilotAdapter } from './CopilotAdapter.js';
 export { GeminiCliAdapter } from './GeminiCliAdapter.js';
 export { GrokCliAdapter } from './GrokCliAdapter.js';
+export { AntigravityCliAdapter } from './AntigravityCliAdapter.js';
 export { OpenCodeAdapter } from './OpenCodeAdapter.js';
 export { PiAdapter } from './PiAdapter.js';
 export { AgentStatus } from './AgentAdapter.js';

--- a/packages/agent-manager/src/index.ts
+++ b/packages/agent-manager/src/index.ts
@@ -5,6 +5,7 @@ export { CodexAdapter } from './adapters/CodexAdapter.js';
 export { CopilotAdapter } from './adapters/CopilotAdapter.js';
 export { GeminiCliAdapter } from './adapters/GeminiCliAdapter.js';
 export { GrokCliAdapter } from './adapters/GrokCliAdapter.js';
+export { AntigravityCliAdapter } from './adapters/AntigravityCliAdapter.js';
 export { OpenCodeAdapter } from './adapters/OpenCodeAdapter.js';
 export { PiAdapter } from './adapters/PiAdapter.js';
 export { AgentStatus } from './adapters/AgentAdapter.js';

--- a/packages/agent-manager/src/index.ts
+++ b/packages/agent-manager/src/index.ts
@@ -11,6 +11,7 @@ export { CodexAdapter } from './adapters/CodexAdapter.js';
 export { CopilotAdapter } from './adapters/CopilotAdapter.js';
 export { GeminiCliAdapter } from './adapters/GeminiCliAdapter.js';
 export { GrokCliAdapter } from './adapters/GrokCliAdapter.js';
+export { AntigravityCliAdapter } from './adapters/AntigravityCliAdapter.js';
 export { OpenCodeAdapter } from './adapters/OpenCodeAdapter.js';
 export { PiAdapter } from './adapters/PiAdapter.js';
 export { AgentStatus } from './adapters/AgentAdapter.js';

--- a/packages/agent-manager/src/utils/agents.ts
+++ b/packages/agent-manager/src/utils/agents.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import type { AgentType } from '../adapters/AgentAdapter.js';
 
-export type StartableAgentType = Extract<AgentType, 'claude' | 'codex' | 'copilot' | 'gemini_cli' | 'grok_cli' | 'opencode' | 'pi'>;
+export type StartableAgentType = Extract<AgentType, 'claude' | 'codex' | 'copilot' | 'gemini_cli' | 'grok_cli' | 'antigravity_cli' | 'opencode' | 'pi'>;
 
 export interface AgentConfig {
     /** Shell command to launch the agent (sent to tmux via `send-keys`). */
@@ -21,6 +21,7 @@ export const AGENTS: Record<StartableAgentType, AgentConfig> = {
     copilot:    { command: 'copilot',  matches: matchArgv0Name('copilot-cli') },
     gemini_cli: { command: 'gemini',   matches: matchAnyToken('gemini') },
     grok_cli:   { command: 'grok',     matches: matchArgv0('grok') },
+    antigravity_cli: { command: 'agy', matches: matchArgv0('agy') },
     opencode:   { command: 'opencode', matches: matchArgv0('opencode') },
     pi:         { command: 'pi',       matches: matchAnyBasename(['pi']) },
 };

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -84,6 +84,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
   CopilotAdapter: vi.fn(),
   GeminiCliAdapter: vi.fn(),
   GrokCliAdapter: vi.fn(),
+  AntigravityCliAdapter: vi.fn(),
   OpenCodeAdapter: vi.fn(),
   PiAdapter: vi.fn(),
   TerminalFocusManager: vi.fn(function () { return mockFocusManager; }),
@@ -111,6 +112,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     copilot:    { command: 'copilot',  matches: () => true },
     gemini_cli: { command: 'gemini',   matches: () => true },
     grok_cli:   { command: 'grok',     matches: () => true },
+    antigravity_cli: { command: 'agy', matches: () => true },
     opencode:   { command: 'opencode', matches: () => true },
     pi:         { command: 'pi',       matches: () => true },
   },
@@ -270,7 +272,7 @@ describe('agent command', () => {
     await program.parseAsync(['node', 'test', 'agent', 'list', '--json']);
 
     expect(AgentManager).toHaveBeenCalled();
-    expect(mockManager.registerAdapter).toHaveBeenCalledTimes(7);
+    expect(mockManager.registerAdapter).toHaveBeenCalledTimes(8);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(agents, null, 2));
   });
 

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -96,6 +96,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
   CopilotAdapter: vi.fn(),
   GeminiCliAdapter: vi.fn(),
   GrokCliAdapter: vi.fn(),
+  AntigravityCliAdapter: vi.fn(),
   OpenCodeAdapter: vi.fn(),
   PiAdapter: vi.fn(),
   DurableAgentRepository: vi.fn(function () { return mockDurableRepository; }),
@@ -125,6 +126,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     copilot:    { command: 'copilot',  matches: () => true },
     gemini_cli: { command: 'gemini',   matches: () => true },
     grok_cli:   { command: 'grok',     matches: () => true },
+    antigravity_cli: { command: 'agy', matches: () => true },
     opencode:   { command: 'opencode', matches: () => true },
     pi:         { command: 'pi',       matches: () => true },
   },
@@ -288,7 +290,7 @@ describe('agent command', () => {
     await program.parseAsync(['node', 'test', 'agent', 'list', '--json']);
 
     expect(AgentManager).toHaveBeenCalled();
-    expect(mockManager.registerAdapter).toHaveBeenCalledTimes(7);
+    expect(mockManager.registerAdapter).toHaveBeenCalledTimes(8);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify([
       { ...agents[0], mode: 'interactive' },
     ], null, 2));

--- a/packages/cli/src/__tests__/commands/channel.test.ts
+++ b/packages/cli/src/__tests__/commands/channel.test.ts
@@ -75,6 +75,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     CopilotAdapter: vi.fn(),
     GeminiCliAdapter: vi.fn(),
     GrokCliAdapter: vi.fn(),
+    AntigravityCliAdapter: vi.fn(),
     PiAdapter: vi.fn(),
     TerminalFocusManager: vi.fn(function () { return mockTerminalFocusManager; }),
     TtyWriter: {
@@ -601,7 +602,7 @@ describe('channel command', () => {
             agentPid: 4321,
             bridgePid: process.pid,
         }));
-        expect(mockAgentManager.registerAdapter).toHaveBeenCalledTimes(6);
+        expect(mockAgentManager.registerAdapter).toHaveBeenCalledTimes(7);
         expect(mockChannelService.registerBridge.mock.invocationCallOrder[0])
             .toBeLessThan(mockChannelManager.startAll.mock.invocationCallOrder[0]);
 

--- a/packages/cli/src/__tests__/commands/channel.test.ts
+++ b/packages/cli/src/__tests__/commands/channel.test.ts
@@ -84,6 +84,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     CopilotAdapter: vi.fn(),
     GeminiCliAdapter: vi.fn(),
     GrokCliAdapter: vi.fn(),
+    AntigravityCliAdapter: vi.fn(),
     PiAdapter: vi.fn(),
     TerminalFocusManager: vi.fn(function () { return mockTerminalFocusManager; }),
     TtyWriter: {
@@ -678,7 +679,7 @@ describe('channel command', () => {
             agentPid: 4321,
             bridgePid: process.pid,
         }));
-        expect(mockAgentManager.registerAdapter).toHaveBeenCalledTimes(6);
+        expect(mockAgentManager.registerAdapter).toHaveBeenCalledTimes(7);
         expect(mockChannelService.registerBridge.mock.invocationCallOrder[0])
             .toBeLessThan(mockChannelManager.startAll.mock.invocationCallOrder[0]);
 

--- a/packages/cli/src/__tests__/tui/console/StartAgentPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/StartAgentPane.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('StartAgentPane helpers', () => {
     it('lists supported agent start types in pane order', () => {
-        expect(STARTABLE_AGENT_TYPES).toEqual(['claude', 'codex', 'copilot', 'gemini_cli', 'grok_cli', 'opencode', 'pi']);
+        expect(STARTABLE_AGENT_TYPES).toEqual(['claude', 'codex', 'copilot', 'gemini_cli', 'grok_cli', 'antigravity_cli', 'opencode', 'pi']);
     });
 
     it('cycles to the next agent type', () => {

--- a/packages/cli/src/__tests__/util/sessions.test.ts
+++ b/packages/cli/src/__tests__/util/sessions.test.ts
@@ -45,7 +45,7 @@ describe('sessions util', () => {
         });
 
         it('forwards a valid --type', () => {
-            for (const type of ['claude', 'codex', 'gemini_cli', 'grok_cli', 'opencode', 'copilot', 'pi'] as const) {
+            for (const type of ['claude', 'codex', 'gemini_cli', 'grok_cli', 'antigravity_cli', 'opencode', 'copilot', 'pi'] as const) {
                 const result = resolveListSessionsOptions({ all: true, type });
                 expect(result.adapterOptions.type).toBe(type);
             }
@@ -53,7 +53,7 @@ describe('sessions util', () => {
 
         it('throws on an invalid --type', () => {
             expect(() => resolveListSessionsOptions({ all: true, type: 'wrong' })).toThrow(
-                'Invalid --type "wrong". Expected one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi.',
+                'Invalid --type "wrong". Expected one of: claude, codex, gemini_cli, grok_cli, antigravity_cli, opencode, copilot, pi.',
             );
         });
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -12,6 +12,7 @@ import {
     CopilotAdapter,
     GeminiCliAdapter,
     GrokCliAdapter,
+    AntigravityCliAdapter,
     OpenCodeAdapter,
     PiAdapter,
     AgentStatus,
@@ -91,6 +92,7 @@ const TYPE_LABELS: Record<AgentType, string> = {
     copilot: 'Copilot',
     gemini_cli: 'Gemini CLI',
     grok_cli: 'Grok CLI',
+    antigravity_cli: 'Antigravity CLI',
     opencode: 'OpenCode',
     pi: 'Pi',
     other: 'Other',
@@ -174,6 +176,7 @@ function createAgentManager(): AgentManager {
     manager.registerAdapter(new CopilotAdapter());
     manager.registerAdapter(new GeminiCliAdapter());
     manager.registerAdapter(new GrokCliAdapter());
+    manager.registerAdapter(new AntigravityCliAdapter());
     manager.registerAdapter(new OpenCodeAdapter());
     manager.registerAdapter(new PiAdapter());
     return manager;
@@ -362,7 +365,7 @@ export function registerAgentCommand(program: Command): void {
         .description('List historical Claude/Codex/Gemini/Grok/OpenCode sessions for resume')
         .option('--all', 'Include sessions from every cwd (default: only current cwd)')
         .option('--cwd <path>', 'Override the cwd filter (implies non-default scope)')
-        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi')
+        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, antigravity_cli, opencode, copilot, pi')
         .option('--limit <n>', 'Max rows to print (default: 50; 0 = no limit)', '50')
         .option('-j, --json', 'Output as JSON')
         .action(withErrorHandler('list sessions', async (options) => {
@@ -418,7 +421,7 @@ export function registerAgentCommand(program: Command): void {
         .description('Show detailed information about a historical session')
         .requiredOption('--id <sessionId>', 'Session ID (as shown in agent sessions)')
         .option('-j, --json', 'Output as JSON')
-        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi')
+        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, antigravity_cli, opencode, copilot, pi')
         .option('--full', 'Show entire conversation history')
         .option('--tail <n>', 'Show last N messages (default: 20)', '20')
         .option('--verbose', 'Include tool call/result details')

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -12,6 +12,7 @@ import {
     CopilotAdapter,
     GeminiCliAdapter,
     GrokCliAdapter,
+    AntigravityCliAdapter,
     OpenCodeAdapter,
     PiAdapter,
     ClaudePrintAgentService,
@@ -104,6 +105,7 @@ const TYPE_LABELS: Record<AgentType, string> = {
     copilot: 'Copilot',
     gemini_cli: 'Gemini CLI',
     grok_cli: 'Grok CLI',
+    antigravity_cli: 'Antigravity CLI',
     opencode: 'OpenCode',
     pi: 'Pi',
     other: 'Other',
@@ -187,6 +189,7 @@ function createAgentManager(): AgentManager {
     manager.registerAdapter(new CopilotAdapter());
     manager.registerAdapter(new GeminiCliAdapter());
     manager.registerAdapter(new GrokCliAdapter());
+    manager.registerAdapter(new AntigravityCliAdapter());
     manager.registerAdapter(new OpenCodeAdapter());
     manager.registerAdapter(new PiAdapter());
     return manager;
@@ -411,7 +414,7 @@ export function registerAgentCommand(program: Command): void {
         .description('List historical Claude/Codex/Gemini/Grok/OpenCode sessions for resume')
         .option('--all', 'Include sessions from every cwd (default: only current cwd)')
         .option('--cwd <path>', 'Override the cwd filter (implies non-default scope)')
-        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi')
+        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, antigravity_cli, opencode, copilot, pi')
         .option('--limit <n>', 'Max rows to print (default: 50; 0 = no limit)', '50')
         .option('-j, --json', 'Output as JSON')
         .action(withErrorHandler('list sessions', async (options) => {
@@ -467,7 +470,7 @@ export function registerAgentCommand(program: Command): void {
         .description('Show detailed information about a historical session')
         .requiredOption('--id <sessionId>', 'Session ID (as shown in agent sessions)')
         .option('-j, --json', 'Output as JSON')
-        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, opencode, copilot, pi')
+        .option('--type <type>', 'Filter to one of: claude, codex, gemini_cli, grok_cli, antigravity_cli, opencode, copilot, pi')
         .option('--full', 'Show entire conversation history')
         .option('--tail <n>', 'Show last N messages (default: 20)', '20')
         .option('--verbose', 'Include tool call/result details')

--- a/packages/cli/src/services/channel/channel-runner.ts
+++ b/packages/cli/src/services/channel/channel-runner.ts
@@ -6,6 +6,7 @@ import {
     CopilotAdapter,
     GeminiCliAdapter,
     GrokCliAdapter,
+    AntigravityCliAdapter,
     PiAdapter,
     TerminalFocusManager,
     TtyWriter,
@@ -46,6 +47,7 @@ function createAgentManager(): AgentManager {
     manager.registerAdapter(new CopilotAdapter());
     manager.registerAdapter(new GeminiCliAdapter());
     manager.registerAdapter(new GrokCliAdapter());
+    manager.registerAdapter(new AntigravityCliAdapter());
     manager.registerAdapter(new PiAdapter());
     return manager;
 }

--- a/packages/cli/src/services/channel/channel-runner.ts
+++ b/packages/cli/src/services/channel/channel-runner.ts
@@ -6,6 +6,7 @@ import {
     CopilotAdapter,
     GeminiCliAdapter,
     GrokCliAdapter,
+    AntigravityCliAdapter,
     PiAdapter,
     TerminalFocusManager,
     TtyWriter,
@@ -49,6 +50,7 @@ function createAgentManager(): AgentManager {
     manager.registerAdapter(new CopilotAdapter());
     manager.registerAdapter(new GeminiCliAdapter());
     manager.registerAdapter(new GrokCliAdapter());
+    manager.registerAdapter(new AntigravityCliAdapter());
     manager.registerAdapter(new PiAdapter());
     return manager;
 }

--- a/packages/cli/src/util/sessions.ts
+++ b/packages/cli/src/util/sessions.ts
@@ -7,7 +7,7 @@ import { truncate } from './text.js';
 
 const FIRST_MESSAGE_MAX_WIDTH = 80;
 const FIRST_MESSAGE_PLACEHOLDER = '(no message yet)';
-const VALID_AGENT_TYPES: AgentType[] = ['claude', 'codex', 'gemini_cli', 'grok_cli', 'opencode', 'copilot', 'pi'];
+const VALID_AGENT_TYPES: AgentType[] = ['claude', 'codex', 'gemini_cli', 'grok_cli', 'antigravity_cli', 'opencode', 'copilot', 'pi'];
 
 export interface ResolvedListSessionsOptions {
     adapterOptions: ListSessionsOptions;


### PR DESCRIPTION
## Summary

Adds an `antigravity_cli` agent adapter so ai-devkit can detect, list, and inspect Google's Antigravity CLI (`agy`) alongside Claude, Codex, Gemini, and Grok. This is the runtime/agent side of Antigravity and is independent of the existing `antigravity` environment (which configures the Antigravity IDE), the same way `gemini_cli` is independent of the `gemini` environment.

## How it works

- Detects `agy` processes from the shared `AgentDetectionContext` snapshot (`processNames = ['agy']`), falling back to `captureProcessSnapshot` for standalone use.
- Resolves each **live** process to its conversation through `~/.gemini/antigravity-cli/cache/last_conversations.json`, a `{ "<cwd>": "<conversationId>" }` map the CLI keeps per workspace (`ANTIGRAVITY_CLI_HOME` overrides the base).
- Lists **history** from `brain/` instead. That cache holds only the current conversation of each workspace, so listing from it would hide every older conversation of a cwd; `brain/` is the complete set. The cache is then used for what it is — the cwd of a workspace's current conversation.
- Reads the transcript from `brain/<conversationId>/.system_generated/logs/transcript.jsonl`: user prompts are the text inside `<USER_REQUEST>...</USER_REQUEST>` of `type: "USER_INPUT"` records, assistant turns are `type: "PLANNER_RESPONSE"`, tool calls and `SYSTEM` records are skipped unless verbose. Summary is the last user request; last activity is the newest record `created_at`.

### Known limitation: cwd for older conversations

Antigravity records a conversation's workspace nowhere except that cache — `transcript.jsonl` and `transcript_full.jsonl` contain no cwd, and `conversations/<id>.db` keeps its metadata in protobuf blobs (`trajectory_metadata_blob`, `steps.metadata`) with no readable path column. A conversation the cache no longer names is therefore listed with `cwd: ''` and surfaces under `agent sessions --all` rather than a cwd-scoped listing. Listing it without a cwd beats hiding it.

## Changes

- New `AntigravityCliAdapter` (self-contained, inline parsing like the other recent adapters) + unit tests.
- `AgentType`/`StartableAgentType` gain `antigravity_cli`; `AGENTS.antigravity_cli = { command: 'agy', matches: matchArgv0('agy') }`; exported from the package.
- Wired into the `agent` command and channel runner; `TYPE_LABELS`, `--type` help, and `VALID_AGENT_TYPES` updated.
- README matrix gains an **Antigravity CLI** row (`yes | yes`) instead of ticking the Antigravity IDE row: remote control drives `agy`, not the IDE, and Setup is already true since the `antigravity-cli` environment shipped in #134. Same separation the web docs already use.
- dev-lifecycle docs under `docs/ai/*/feature-antigravity-cli-adapter.md`.

## Testing

- [x] `npx nx run agent-manager:test` (594) and `npx nx run cli:test` (1057) pass; husky pre-commit ran all packages.
- [x] Verified against real `agy` data on disk: `listSessions()` returns all 5 conversations under `brain/` where the cache named 1, and `listSessions({ cwd })` still returns exactly the one belonging to that workspace.
- [x] `detectAgents()` with a live `agy` process resolves the cwd via `last_conversations.json` to its conversation and summary.
