### PR TITLE
feat(cli): add Antigravity CLI environment

### DIFF
--- a/packages/cli/src/__tests__/lib/EnvironmentSelector.test.ts
+++ b/packages/cli/src/__tests__/lib/EnvironmentSelector.test.ts
@@ -132,6 +132,19 @@ describe('EnvironmentSelector', () => {
       expect(getMcpConfigPath('grok')).toBeUndefined();
     });
 
+    it('includes Antigravity CLI with the agy project and global skill paths', () => {
+      expect(isValidEnvironmentCode('antigravity-cli')).toBe(true);
+      expect(getEnvironment('antigravity-cli')).toMatchObject({
+        code: 'antigravity-cli',
+        name: 'Antigravity CLI',
+        skillPath: '.agents/skills',
+        globalSkillPath: '.gemini/config/skills',
+      });
+      expect(getSkillPath('antigravity-cli')).toBe('.agents/skills');
+      expect(getGlobalSkillPath('antigravity-cli')).toBe('.gemini/config/skills');
+      expect(getMcpConfigPath('antigravity-cli')).toBeUndefined();
+    });
+
     it('includes OpenCode with project skills, global skills, and MCP', () => {
       expect(isValidEnvironmentCode('opencode')).toBe(true);
       expect(getEnvironment('opencode')).toMatchObject({

--- a/packages/cli/src/__tests__/lib/SkillManager.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillManager.test.ts
@@ -619,7 +619,7 @@ describe("SkillManager", () => {
 
       await expect(
         skillManager.addSkill(mockRegistryId, mockSkillName),
-      ).rejects.toThrow("Supported: cursor, claude, github, gemini, grok, codex, kilocode, amp, opencode, roo, antigravity, junie, cline, devin, pi");
+      ).rejects.toThrow("Supported: cursor, claude, github, gemini, grok, codex, kilocode, amp, opencode, roo, antigravity, antigravity-cli, junie, cline, devin, pi");
     });
 
     it("should call validation functions with correct parameters", async () => {

--- a/packages/cli/src/__tests__/util/env.test.ts
+++ b/packages/cli/src/__tests__/util/env.test.ts
@@ -19,7 +19,7 @@ import { EnvironmentCode } from '../../types.js';
 describe('Environment Utilities', () => {
   describe('ENVIRONMENT_DEFINITIONS', () => {
     it('should contain all all environment definitions', () => {
-      expect(Object.keys(ENVIRONMENT_DEFINITIONS)).toHaveLength(15);
+      expect(Object.keys(ENVIRONMENT_DEFINITIONS)).toHaveLength(16);
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('cursor');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('claude');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('github');
@@ -31,6 +31,7 @@ describe('Environment Utilities', () => {
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('opencode');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('roo');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('antigravity');
+      expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('antigravity-cli');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('junie');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('cline');
       expect(ENVIRONMENT_DEFINITIONS).toHaveProperty('devin');
@@ -64,7 +65,7 @@ describe('Environment Utilities', () => {
 
   describe('ALL_ENVIRONMENT_CODES', () => {
     it('should contain all all environment codes', () => {
-      expect(ALL_ENVIRONMENT_CODES).toHaveLength(15);
+      expect(ALL_ENVIRONMENT_CODES).toHaveLength(16);
       expect(ALL_ENVIRONMENT_CODES).toEqual(
         expect.arrayContaining([
           'cursor', 'claude', 'github', 'gemini', 'grok', 'codex',
@@ -83,7 +84,7 @@ describe('Environment Utilities', () => {
   describe('getAllEnvironments', () => {
     it('should return all environment definitions', () => {
       const environments = getAllEnvironments();
-      expect(environments).toHaveLength(15);
+      expect(environments).toHaveLength(16);
       expect(environments).toEqual(Object.values(ENVIRONMENT_DEFINITIONS));
     });
 
@@ -384,7 +385,7 @@ describe('Environment Utilities', () => {
       expect(envCodes).toContain('cline');
       expect(envCodes).toContain('devin');
       expect(envCodes).toContain('pi');
-      expect(skillEnvs).toHaveLength(15);
+      expect(skillEnvs).toHaveLength(16);
     });
   });
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -16,7 +16,7 @@ export interface EnvironmentDefinition {
   mcpConfigPath?: string;
 }
 
-export type EnvironmentCode = 'cursor' | 'claude' | 'github' | 'gemini' | 'grok' | 'codex' | 'kilocode' | 'amp' | 'opencode' | 'roo' | 'antigravity' | 'junie' | 'cline' | 'devin' | 'pi';
+export type EnvironmentCode = 'cursor' | 'claude' | 'github' | 'gemini' | 'grok' | 'codex' | 'kilocode' | 'amp' | 'opencode' | 'roo' | 'antigravity' | 'antigravity-cli' | 'junie' | 'cline' | 'devin' | 'pi';
 
 export const DEFAULT_DOCS_DIR = 'docs/ai';
 

--- a/packages/cli/src/util/env.ts
+++ b/packages/cli/src/util/env.ts
@@ -73,6 +73,14 @@ export const ENVIRONMENT_DEFINITIONS: Record<EnvironmentCode, EnvironmentDefinit
     skillPath: '.agent/skills',
     globalSkillPath: '.gemini/antigravity/skills',
   },
+  'antigravity-cli': {
+    code: 'antigravity-cli',
+    name: 'Antigravity CLI',
+    // The `agy` CLI reads project skills from <workspace>/.agents/skills and
+    // user-global skills from ~/.gemini/config/skills.
+    skillPath: '.agents/skills',
+    globalSkillPath: '.gemini/config/skills',
+  },
   junie: {
     code: 'junie',
     name: 'Junie',

--- a/web/content/docs/11-configuration-file.md
+++ b/web/content/docs/11-configuration-file.md
@@ -79,6 +79,7 @@ List of AI coding tools to generate configuration files for. Valid values:
 | `opencode` | opencode |
 | `roo` | Roo |
 | `antigravity` | Antigravity |
+| `antigravity-cli` | Antigravity CLI |
 | `junie` | Junie |
 | `cline` | Cline |
 | `devin` | Devin |

--- a/web/content/docs/2-supported-agents.md
+++ b/web/content/docs/2-supported-agents.md
@@ -70,6 +70,11 @@ These environments have stable setup integrations.
 - `.agent/skills/` — Project-level skills
 - `~/.gemini/antigravity/skills/` — Global skills
 
+### [Antigravity CLI](https://antigravity.google/)
+**What AI DevKit provides:**
+- `.agents/skills/` — Project-level skills
+- `~/.gemini/config/skills/` — Global skills
+
 ### [Junie](https://www.jetbrains.com/junie/)
 **What AI DevKit provides:**
 - `AGENTS.md` — Junie project instructions and context

--- a/web/content/docs/7-skills.md
+++ b/web/content/docs/7-skills.md
@@ -69,6 +69,7 @@ Skills are currently supported by the following AI coding agents:
 | **Codex**       | `.agents/skills`   | `~/.codex/skills` |
 | **opencode**    | `.opencode/skills` | `~/.config/opencode/skills` |
 | **Antigravity** | `.agent/skills`    | `~/.gemini/antigravity/skills` |
+| **Antigravity CLI** | `.agents/skills` | `~/.gemini/config/skills` |
 | **Junie**       | `.junie/skills`    | `~/.junie/skills` |
 | **Cline**       | `.cline/skills`    | `~/.cline/skills` |
 | **Devin**       | `.devin/skills`    | `~/.config/devin/skills` |


### PR DESCRIPTION
## Summary

Adds `antigravity-cli` as an EnvironmentCode so `ai-devkit init` can configure Google's Antigravity CLI (`agy`) and install skills where the CLI actually reads them. This is separate from the existing `antigravity` (IDE) environment, the same way the gemini CLI is distinct from the gemini IDE.

## Skill paths (verified against a real `agy` install)

- Project skills: `.agents/skills` (the CLI loads `<workspace>/.agents/skills/<name>/SKILL.md`).
- Global skills: `~/.gemini/config/skills` (confirmed by having `agy` create a global skill, which landed at `~/.gemini/config/skills/<name>/SKILL.md`).

## Changes

- `types.ts`: `EnvironmentCode` gains `antigravity-cli`.
- `util/env.ts`: `ENVIRONMENT_DEFINITIONS['antigravity-cli']` with the paths above.
- Docs: `2-supported-agents.md`, `7-skills.md`, and `11-configuration-file.md` list the new environment.
- Tests updated (env definitions, selector, skill-manager supported list).

## Testing

- [x] `npx nx run cli:test` passes (husky ran all packages on commit).
- Global path confirmed empirically: `agy` wrote a new global skill to `~/.gemini/config/skills/...`; project path confirmed from the CLI reading `<workspace>/.agents/skills`.
