### PR TITLE
fix: capture ExitPlanMode and restore MultiEdit/NotebookEdit in Claude prompt hook

### DIFF
--- a/packages/cli/assets/claude/settings-hook.json
+++ b/packages/cli/assets/claude/settings-hook.json
@@ -1,5 +1,5 @@
 {
-  "matcher": "Bash|Edit|Write|AskUserQuestion",
+  "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit|ExitPlanMode|AskUserQuestion",
   "hooks": [
     {
       "type": "command",

--- a/packages/cli/src/__tests__/services/setup/setup.service.test.ts
+++ b/packages/cli/src/__tests__/services/setup/setup.service.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 import { createSetupService } from '../../../services/setup/setup.service.js';
 
 describe('setup service', () => {
@@ -305,6 +306,36 @@ describe('setup service — claude agent', () => {
 
     expect(builtInSkillInstalls).toEqual(['claude']);
     expect(existsSync(join(homeDir, '.claude', 'hooks', 'claude-prompt-hook.js'))).toBe(true);
+  });
+
+  it('installs the real settings-hook.json asset with a matcher covering every approval-required tool (regression: #110)', async () => {
+    fsMkdir(join(homeDir, '.claude'));
+
+    // Use the actual shipped asset (not the synthetic fixture below) so this
+    // test fails whenever the real matcher drifts, instead of only checking
+    // a copy that can silently go stale.
+    const realAssetRoot = fileURLToPath(new URL('../../../../assets', import.meta.url));
+    const service = createSetupService({
+      homeDir,
+      assetRoot: realAssetRoot,
+      runCommand: async () => {},
+      installBuiltInSkills: async () => {},
+    });
+
+    await service.run({ agents: ['claude'] });
+
+    const settings = JSON.parse(readFileSync(join(homeDir, '.claude', 'settings.json'), 'utf-8'));
+    const matcher: string = settings.hooks.PreToolUse[0].matcher;
+    const matchedTools = matcher.split('|');
+
+    // Every tool whose invocation surfaces a permission-approval or
+    // selection-question prompt must be captured here, or that prompt is
+    // silently dropped and never reaches Telegram (issue #110). ExitPlanMode
+    // is the plan-mode approval prompt; MultiEdit/NotebookEdit are batch
+    // file-edit approvals.
+    for (const tool of ['Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'ExitPlanMode', 'AskUserQuestion']) {
+      expect(matchedTools).toContain(tool);
+    }
   });
 
   function createService() {


### PR DESCRIPTION
## Summary
Fixes #110 — agent prompts (selection questions, permission approvals) were never showing up in the Telegram chat.

**Root cause:** the `PreToolUse` hook `matcher` regex in `packages/cli/assets/claude/settings-hook.json` only covered `Bash|Edit|Write|AskUserQuestion`. Any Claude Code tool call not matched by this regex never fires the hook, so it's never written to the agent-request store and never reaches the JS dispatch/formatting code (`formatPromptMessage` in `channel-runner.ts`, which already handles every tool name generically once it receives one). The drop happens entirely upstream, in the hook config itself — not in any routing/dispatch logic.

Two concrete gaps in that one matcher:
- `ExitPlanMode` was never included, even in the original design doc — Plan Mode's approval prompt is one of the most common permission-approval prompts in normal Claude Code usage, and is very likely what the issue is describing.
- `MultiEdit|NotebookEdit` were silently dropped by an unexplained "chore" commit (`61a6633`), uncaught because the only existing test exercised a synthetic fixture rather than the real shipped asset.

**Fix:** broaden the matcher to `Bash|Edit|Write|MultiEdit|NotebookEdit|ExitPlanMode|AskUserQuestion`.

A regression test was added that reads the *real* shipped `settings-hook.json` asset (not the synthetic fixture used elsewhere in the same test file), so this matcher can't silently regress again the way it did before.

## Test plan
- [x] New regression test confirmed **failing before** the fix (`AssertionError: expected [...] to include 'MultiEdit'`)
- [x] `npx nx test cli` — 872/872 passing after the fix
- [x] `npx nx lint cli` — 0 errors (5 pre-existing warnings, unrelated files)
- [x] Full monorepo `npm run test` (via pre-commit hook) — all 6 projects green (memory 110/110, channel-connector 69/69, memory-dashboard 22/22, task-manager 112/112, agent-manager 479/479, cli 872/872)