### PR TITLE
fix(skills): quote agent-orchestration description to fix invalid YAML frontmatter

### DIFF
--- a/skills/agent-orchestration/SKILL.md
+++ b/skills/agent-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-orchestration
-description: AI DevKit · Supervise multi-agent workflows over repeated passes: poll progress, unblock waiting agents, coordinate dependencies, relay outputs, resolve conflicts, and verify completion. Use only for ongoing multi-agent coordination, not one-off list/detail/send/start/kill actions.
+description: "AI DevKit · Supervise multi-agent workflows over repeated passes: poll progress, unblock waiting agents, coordinate dependencies, relay outputs, resolve conflicts, and verify completion. Use only for ongoing multi-agent coordination, not one-off list/detail/send/start/kill actions."
 ---
 
 # Agent Orchestration


### PR DESCRIPTION
## Summary
- `skills/agent-orchestration/SKILL.md` had an unquoted colon inside its frontmatter `description` value, which YAML interprets as a nested mapping key and breaks parsing (e.g. via `gray-matter`, used by the CLI's skill index).
- Fix: wrap the `description` value in double quotes. No other content changed.

Closes #138

## Validation
- `claude plugin validate .` → `✔ Validation passed`
- `python3 -c "yaml.safe_load(...)"` on the frontmatter: failed before with `mapping values are not allowed here` (line 3, col 78); succeeds after.
- `node -e "gray-matter(...)"` (actual parser used by `packages/cli/src/util/skill.ts`) now correctly extracts `name` and `description`.
- Swept all `skills/*/SKILL.md` files through `gray-matter` — all parse cleanly with `name`/`description` present.
- `npx vitest run src/__tests__/lib/SkillManager.test.ts` (packages/cli) → 60/60 passed.
- Full repo validation before commit: `npm run build` (6 projects), `nx run-many -t lint` (0 errors), `nx run-many -t test` → 901/901 tests passed across all packages (via pre-commit hook).

## Test plan
- [x] `claude plugin validate .`
- [x] `SkillManager.test.ts` suite
- [x] Full monorepo lint + test via pre-commit hook