### PR TITLE
fix(agent-manager): detect agent at tmux pane PID

### DIFF
--- a/packages/agent-manager/src/__tests__/terminal/TmuxManager.test.ts
+++ b/packages/agent-manager/src/__tests__/terminal/TmuxManager.test.ts
@@ -106,6 +106,16 @@ describe('TmuxManager', () => {
             expect(await tmux.findAgentPid('foo', matchesClaude)).toBeNull();
         });
 
+        it('returns the matching pane PID when the agent replaces the shell', async () => {
+            setExecFileHandler((cmd, args) => {
+                if (cmd === 'tmux' && args[0] === 'list-panes') return '100\n';
+                if (cmd === 'pgrep') return new Error('no children');
+                if (cmd === 'ps' && args[1] === '100') return '/usr/local/bin/claude';
+                return '';
+            });
+            expect(await tmux.findAgentPid('foo', matchesClaude)).toBe(100);
+        });
+
         it('returns the matching descendant when found', async () => {
             // pane 100 → child 200 (claude) — no grandchildren
             setExecFileHandler((cmd, args) => {

--- a/packages/agent-manager/src/terminal/TmuxManager.ts
+++ b/packages/agent-manager/src/terminal/TmuxManager.ts
@@ -41,7 +41,7 @@ export class TmuxManager {
     /**
      * Find the actual agent process PID inside a tmux pane.
      *
-     * Strategy: BFS the process tree, return the deepest descendant whose
+     * Strategy: BFS the process tree, return the deepest process whose
      * `ps` command line is accepted by `matches`. The caller supplies the
      * matcher so this method has no agent-type knowledge.
      *
@@ -51,7 +51,7 @@ export class TmuxManager {
      * - Subprocess case: shell → claude (matches) → MCP server child (doesn't match)
      *   → returns claude, not the subprocess
      *
-     * Returns null when no descendant matches yet (agent still starting); the
+     * Returns null when no process matches yet (agent still starting); the
      * caller's poll loop retries.
      */
     async findAgentPid(session: string, matches: (psCommand: string) => boolean): Promise<number | null> {
@@ -67,11 +67,9 @@ export class TmuxManager {
             if (visited.has(pid)) continue;
             visited.add(pid);
 
-            if (pid !== panePid) {
-                const command = await this.getProcessCommand(pid);
-                if (command && matches(command)) {
-                    deepestMatch = pid;
-                }
+            const command = await this.getProcessCommand(pid);
+            if (command && matches(command)) {
+                deepestMatch = pid;
             }
 
             const children = await this.pgrepChildren(pid);


### PR DESCRIPTION
## Summary

- evaluate the tmux pane PID with the same strict agent command matcher used for descendants
- preserve BFS descendant traversal and deepest-match selection
- add a regression test for agents that replace the pane shell

## Root cause

TmuxManager.findAgentPid started its BFS at pane_pid but deliberately skipped command matching for that root node. When Claude or Codex replaces the tmux pane shell, the stable live agent is pane_pid and may have no matching descendant, so every managed-start poll returned null until the 15-second timeout killed the session.

## Risk

Controlled and narrow: pane_pid is not accepted blindly. It must pass the existing per-agent strict command matcher, and the existing five stable PID polls remain unchanged. Descendant traversal and deepest-match behavior are preserved.

## Regression proof

The new focused test expects a matching pane root PID. It failed before the fix with expected 100 / received null, passed with the fix, failed again when the old pane-root exclusion was temporarily restored, and passed again after restoring the fix.

## Validation

- focused TmuxManager suite: 15 passed
- agent-manager suite: 480 passed
- agent-manager typecheck: passed
- agent-manager lint: passed
- agent-manager build: passed
- repository test suite: 901 passed
- repository build across 6 projects: passed
- commit hook repository lint: passed with pre-existing warnings only
- git diff --check: passed