### PR TITLE
fix(init): compose templates with built-in skills

### DIFF
--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -89,6 +89,7 @@ vi.mock('../../util/terminal.js', () => ({
 }));
 
 import { initCommand } from '../../commands/init.js';
+import { BUILTIN_SKILL_NAMES, BUILTIN_SKILL_REGISTRY } from '../../constants.js';
 
 function confirmCallsMatching(pattern: RegExp): any[] {
   return mockConfirm.mock.calls.filter(([config]: any[]) =>
@@ -211,7 +212,7 @@ describe('init command', () => {
       expect(mockConfigManager.setEnvironments).not.toHaveBeenCalled();
     });
 
-    it('silently ignores --built-in when the template declares skills', async () => {
+    it('installs template skills and all built-in skills when both options are provided', async () => {
       mockLoadInitTemplate.mockResolvedValue({
         environments: ['codex'],
         phases: ['requirements'],
@@ -220,13 +221,16 @@ describe('init command', () => {
 
       await initCommand({ template: './init.yaml', builtIn: true });
 
-      expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(1);
-      expect(mockSkillManager.addSkill).toHaveBeenCalledWith('codeaholicguy/ai-devkit', 'debug');
+      expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(BUILTIN_SKILL_NAMES.length + 1);
+      expect(mockSkillManager.addSkill).toHaveBeenCalledWith(BUILTIN_SKILL_REGISTRY, 'debug');
+      for (const skill of BUILTIN_SKILL_NAMES) {
+        expect(mockSkillManager.addSkill).toHaveBeenCalledWith(BUILTIN_SKILL_REGISTRY, skill);
+      }
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
     });
 
-    it('silently ignores --built-in when the template has no skills declared', async () => {
+    it('installs all built-in skills when the template has no skills declared', async () => {
       mockLoadInitTemplate.mockResolvedValue({
         environments: ['codex'],
         phases: ['requirements']
@@ -234,7 +238,10 @@ describe('init command', () => {
 
       await initCommand({ template: './init.yaml', builtIn: true });
 
-      expect(mockSkillManager.addSkill).not.toHaveBeenCalled();
+      expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(BUILTIN_SKILL_NAMES.length);
+      for (const skill of BUILTIN_SKILL_NAMES) {
+        expect(mockSkillManager.addSkill).toHaveBeenCalledWith(BUILTIN_SKILL_REGISTRY, skill);
+      }
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
     });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -352,7 +352,9 @@ export async function initCommand(options: InitOptions) {
         ui.warning(`${result.registry}/${result.skill}: ${result.reason || 'Unknown error'}`);
       });
     }
-  } else if (!hasTemplate) {
+  }
+
+  if (options.builtIn || !hasTemplate) {
     const shouldInstall = await shouldInstallBuiltinSkills(options);
 
     if (shouldInstall) {


### PR DESCRIPTION
Summary:
- allow init template application and explicit built-in skill installation to run independently
- preserve template-only and non-template built-in behavior
- replace the prior silent-ignore assertions with regression coverage for templates with and without explicit skills

Validation:
- strict red/green TDD plus reverse-fix red/restored-green
- focused init tests: 23 passed
- CLI tests: 901 passed
- full workspace tests: all 6 projects passed
- CLI typecheck, workspace lint, and workspace build passed
- init E2E selection: 8 passed
- temporary-directory CLI composition and idempotency repro: 20 installed/configured unique built-ins across repeated runs

Caveats:
- the unfiltered E2E invocation was terminated by the execution harness before Vitest emitted its final summary; the complete init-command E2E subset passed
- lint retains six pre-existing unused-catch warnings and zero errors