### PR TITLE
feat(cli): add skill add-registry command

### DIFF
--- a/docs/ai/design/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/design/2026-08-13-feature-skill-add-registry.md
@@ -1,0 +1,72 @@
+---
+phase: design
+title: System Design & Architecture
+description: Persist skill registries in project or global configuration
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+  CLI[skill add-registry id url] --> ID[validateRegistryId]
+  ID --> Scope{--global?}
+  Scope -->|no| Project[ConfigManager.addSkillRegistry]
+  Scope -->|yes| Global[GlobalConfigManager.addSkillRegistry]
+  Project --> PC[(project .ai-devkit.json)]
+  Global --> GC[(global .ai-devkit.json)]
+  PC --> Merge[existing SkillRegistry merge]
+  GC --> Merge
+  Merge --> Consumers[add / find / update / rebuild-index]
+```
+
+The command performs validation and delegates a pure config mutation to the selected manager. It does not instantiate `SkillRegistry`, fetch the default registry, inspect Git, or touch the skill cache. Existing `SkillRegistry.fetchMergedRegistry()` supplies downstream resolution with default < global < project precedence.
+
+## Data Models
+
+No schema change is needed:
+
+```ts
+registries?: Record<string, string>
+```
+
+The registry ID is a validated map key and the registry URL is an opaque, verbatim string value. All unrelated top-level config and sibling registry entries survive writes.
+
+## API Design
+
+- CLI: `skill add-registry <id> <url> [-g|--global] [-f|--force]`.
+- `ConfigManager.addSkillRegistry(id, url, options?)` returns the resulting `DevKitConfig` and uses the existing `read → merge → update` pattern from `addSkill()`.
+- `GlobalConfigManager.addSkillRegistry(id, url, options?)` returns the resulting `GlobalDevKitConfig` and uses the existing `read → merge → write` pattern from `addPlugin()`, with an existence check that protects malformed files.
+- A shared result or helper may represent `added`, `already registered`, and `updated` if needed for precise UI without duplicating conflict logic. Any extracted pure logic must have 100% branch/function/line coverage.
+
+## Component Breakdown
+
+- `commands/skill.ts`: registers the flat sibling command, parses flags, validates the ID, selects project/global scope, and reports success/idempotency.
+- `util/skill.ts`: existing `validateRegistryId()` remains the only input validation.
+- `lib/Config.ts`: merge-preserving project setter backed by `update()`.
+- `lib/GlobalConfig.ts`: merge-preserving global setter and malformed-file protection.
+- Existing command tests mock config/filesystem boundaries; no real network or disk is used.
+
+## Design Decisions
+
+- Build only `add-registry`; removal and listing remain deferred.
+- Persist default-identical mappings as explicit pins because conflict/idempotency checks apply only to the selected writable scope.
+- Treat URL as opaque input. This supports HTTPS, SSH/SCP syntax, non-GitHub hosts, and arbitrary future transports without expanding validation policy.
+- Do no cache work. Registration must work offline and remain a fast config-only operation.
+- Reuse `validateRegistryId()` instead of defining a competing identifier grammar.
+- Same target-scope ID/value is idempotent; same ID/different value requires `--force` to make accidental replacement explicit.
+- Never use `read() ?? {}` alone for global mutation: when the file exists but parsing fails, that would erase user data. Check existence and fail clearly when a present file cannot be read.
+
+### Alternatives considered
+
+- A three-command registry-management set was rejected in favor of minimal scope.
+- URL normalization/remote verification was rejected because it would exclude valid inputs and violate offline behavior.
+- Fetching the default registry before writing was rejected because identical defaults must still be pinned and network failure must not block registration.
+
+## Non-Functional Requirements
+
+- Registration is O(number of registry entries) for an object spread and performs at most the target config I/O.
+- No credentials are interpreted or transmitted.
+- Failed validation/conflict/malformed-global cases leave config unchanged.
+- Existing command behavior and merged-registry precedence remain unchanged.

--- a/docs/ai/design/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/design/2026-08-13-feature-skill-add-registry.md
@@ -36,9 +36,10 @@ The registry ID is a validated map key and the registry URL is an opaque, verbat
 ## API Design
 
 - CLI: `skill add-registry <id> <url> [-g|--global] [-f|--force]`.
-- `ConfigManager.addSkillRegistry(id, url, options?)` returns the resulting `DevKitConfig` and uses the existing `read → merge → update` pattern from `addSkill()`.
-- `GlobalConfigManager.addSkillRegistry(id, url, options?)` returns the resulting `GlobalDevKitConfig` and uses the existing `read → merge → write` pattern from `addPlugin()`, with an existence check that protects malformed files.
-- A shared result or helper may represent `added`, `already registered`, and `updated` if needed for precise UI without duplicating conflict logic. Any extracted pure logic must have 100% branch/function/line coverage.
+- `ConfigManager.addSkillRegistry(id, url, { force }?)` returns the resulting `DevKitConfig` and uses the existing `read → merge → update` pattern from `addSkill()`. The two-argument form is the normal public contract; the optional flag exists only for the CLI's explicit override path.
+- `GlobalConfigManager.addSkillRegistry(id, url, { force }?)` returns the resulting `GlobalDevKitConfig` and uses the existing `read → merge → write` pattern from `addPlugin()`, with an existence check that protects malformed files.
+- Both setters enforce same-scope idempotency and conflict behavior so callers cannot bypass safety. A small shared pure helper computes `added`, `already-registered`, `updated`, or throws a conflict while returning the merge-preserving registry map.
+- The command reads the selected target scope's current registry map before invoking its setter so it can choose precise success copy while the setter remains the authoritative safety boundary. This extra local read is acceptable and performs no network/cache work.
 
 ## Component Breakdown
 
@@ -46,6 +47,7 @@ The registry ID is a validated map key and the registry URL is an opaque, verbat
 - `util/skill.ts`: existing `validateRegistryId()` remains the only input validation.
 - `lib/Config.ts`: merge-preserving project setter backed by `update()`.
 - `lib/GlobalConfig.ts`: merge-preserving global setter and malformed-file protection.
+- `util/skill-registry.ts`: shared pure registry mutation decision; it treats URL as opaque and contains no I/O.
 - Existing command tests mock config/filesystem boundaries; no real network or disk is used.
 
 ## Design Decisions
@@ -57,6 +59,7 @@ The registry ID is a validated map key and the registry URL is an opaque, verbat
 - Reuse `validateRegistryId()` instead of defining a competing identifier grammar.
 - Same target-scope ID/value is idempotent; same ID/different value requires `--force` to make accidental replacement explicit.
 - Never use `read() ?? {}` alone for global mutation: when the file exists but parsing fails, that would erase user data. Check existence and fail clearly when a present file cannot be read.
+- Use a dedicated `CliError` conflict code/message from the shared helper. `--force` changes only conflict resolution; it does not alter validation or I/O behavior.
 
 ### Alternatives considered
 

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -1,0 +1,65 @@
+---
+phase: implementation
+title: Implementation Guide
+description: Technical implementation notes, patterns, and code guidelines
+---
+
+# Implementation Guide
+
+## Development Setup
+**How do we get started?**
+
+- Prerequisites and dependencies
+- Environment setup steps
+- Configuration needed
+
+## Code Structure
+**How is the code organized?**
+
+- Directory structure
+- Module organization
+- Naming conventions
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Core Features
+- Feature 1: Implementation approach
+- Feature 2: Implementation approach
+- Feature 3: Implementation approach
+
+### Patterns & Best Practices
+- Design patterns being used
+- Code style guidelines
+- Common utilities/helpers
+
+## Integration Points
+**How do pieces connect?**
+
+- API integration details
+- Database connections
+- Third-party service setup
+
+## Error Handling
+**How do we handle failures?**
+
+- Error handling strategy
+- Logging approach
+- Retry/fallback mechanisms
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- Optimization strategies
+- Caching approach
+- Query optimization
+- Resource management
+
+## Security Notes
+**What security measures are in place?**
+
+- Authentication/authorization
+- Input validation
+- Data encryption
+- Secrets management
+

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -47,7 +47,7 @@ description: Implementation record for project/global registry persistence and C
 
 ### Pending
 
-- Tasks 4–5: design reconciliation, final coverage/regression, and review.
+- Task 5: final coverage/regression and review.
 
 ## Integration Points
 
@@ -71,3 +71,13 @@ The setters modify only `registries` in the selected config. Existing `SkillRegi
 - Task 1: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49/49 passed; new helper 100% statements, branches, functions, and lines.
 - Task 2: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15/15 passed.
 - Task 3: `npm run lint`, `npm run build`, and the combined command/config coverage run — build/lint green, 90/90 tests passed, helper coverage 100%.
+- Phase 7 alignment: no deviations from the binding requirements or reviewed design. The existing precedence test passed 1/1, and built CLI help matches the command contract.
+
+## Design Alignment
+
+- Scope: only `add-registry` exists; remove/list remain deferred.
+- Pin behavior: command logic consults only the selected writable scope, so a default-identical mapping is still written.
+- URL behavior: no URL parser, normalizer, Git/network check, or cache dependency exists on the add path.
+- Persistence: both setters merge registry maps; global mutation protects present unreadable config.
+- Conflict behavior: identical is a no-write success; different requires force.
+- Downstream behavior: existing default < global < project merging remains unchanged and tested.

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -1,65 +1,57 @@
 ---
 phase: implementation
 title: Implementation Guide
-description: Technical implementation notes, patterns, and code guidelines
+description: Implementation record for project/global registry persistence and CLI wiring
 ---
 
 # Implementation Guide
 
 ## Development Setup
-**How do we get started?**
 
-- Prerequisites and dependencies
-- Environment setup steps
-- Configuration needed
+- Worktree: `feature-skill-add-registry`.
+- Bootstrap: `npm ci`, then `npm run build` so internal workspace package entry points resolve during the full test suite.
+- Lifecycle validation: `npx ai-devkit@latest lint --feature skill-add-registry`.
+- Optional task tracing is unavailable in `ai-devkit@0.48.0` (`unknown command 'task'`).
 
 ## Code Structure
-**How is the code organized?**
 
-- Directory structure
-- Module organization
-- Naming conventions
+- `packages/cli/src/util/skill-registry.ts`: shared pure add/idempotency/conflict/force decision and merge logic.
+- `packages/cli/src/lib/Config.ts`: project setter using the existing config read/update boundary.
+- `packages/cli/src/lib/GlobalConfig.ts`: planned global setter and malformed-file guard.
+- `packages/cli/src/commands/skill.ts`: planned flat CLI command.
+- `packages/cli/src/__tests__/`: mocked-boundary tests; no real user config, network, Git, or cache I/O.
 
 ## Implementation Notes
-**Key technical details to remember:**
 
-### Core Features
-- Feature 1: Implementation approach
-- Feature 2: Implementation approach
-- Feature 3: Implementation approach
+### Completed: Task 1 — project persistence
 
-### Patterns & Best Practices
-- Design patterns being used
-- Code style guidelines
-- Common utilities/helpers
+- `ConfigManager.addSkillRegistry(id, url, options?)` reads the required project config, filters its registry map to string values, applies shared mutation rules, returns immediately for an identical entry, and delegates changed maps to `update()`.
+- `planSkillRegistryAdd()` preserves the URL as opaque input and returns `added`, `already-registered`, or `updated` status. A same-scope conflict throws `CliError` code `REGISTRY_CONFLICT` with both existing/requested values; force permits replacement.
+- Existing registry entries and unrelated top-level config remain intact.
+- Edge cases covered: missing project config, identical no-write, conflicting no-write, forced replacement, arbitrary URL string.
+
+### Pending
+
+- Task 2: global setter and malformed-config protection.
+- Task 3: CLI parsing, validation, scope selection, flags, and output.
+- Tasks 4–5: design reconciliation, final coverage/regression, and review.
 
 ## Integration Points
-**How do pieces connect?**
 
-- API integration details
-- Database connections
-- Third-party service setup
+The setters modify only `registries` in the selected config. Existing `SkillRegistry.fetchMergedRegistry()` already consumes default < global < project maps for downstream commands; no changes to that class are planned.
 
 ## Error Handling
-**How do we handle failures?**
 
-- Error handling strategy
-- Logging approach
-- Retry/fallback mechanisms
+- Missing project config retains `ConfigNotFoundError` guidance to run `ai-devkit init`.
+- Same-scope conflicts use `REGISTRY_CONFLICT` and direct users to `--force`.
+- No URL error exists by design.
 
-## Performance Considerations
-**How do we keep it fast?**
+## Performance & Security
 
-- Optimization strategies
-- Caching approach
-- Query optimization
-- Resource management
+- The pure merge is linear in the registry-map size and adds only config read/write I/O.
+- URL values are stored verbatim, never executed, parsed, normalized, or transmitted.
+- Registration imports no Git/network/cache utility.
 
-## Security Notes
-**What security measures are in place?**
+## Verification Record
 
-- Authentication/authorization
-- Input validation
-- Data encryption
-- Secrets management
-
+- Task 1: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49/49 passed; new helper 100% statements, branches, functions, and lines.

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -17,7 +17,7 @@ description: Implementation record for project/global registry persistence and C
 
 - `packages/cli/src/util/skill-registry.ts`: shared pure add/idempotency/conflict/force decision and merge logic.
 - `packages/cli/src/lib/Config.ts`: project setter using the existing config read/update boundary.
-- `packages/cli/src/lib/GlobalConfig.ts`: planned global setter and malformed-file guard.
+- `packages/cli/src/lib/GlobalConfig.ts`: global setter and malformed-file guard.
 - `packages/cli/src/commands/skill.ts`: planned flat CLI command.
 - `packages/cli/src/__tests__/`: mocked-boundary tests; no real user config, network, Git, or cache I/O.
 
@@ -30,9 +30,15 @@ description: Implementation record for project/global registry persistence and C
 - Existing registry entries and unrelated top-level config remain intact.
 - Edge cases covered: missing project config, identical no-write, conflicting no-write, forced replacement, arbitrary URL string.
 
+### Completed: Task 2 — global persistence
+
+- `GlobalConfigManager.addSkillRegistry(id, url, options?)` checks whether the file exists before calling the tolerant `read()` method.
+- A missing file starts from `{}` and is created through the existing private `write()` boundary.
+- A present file that produces `null` from `read()` fails with `GLOBAL_CONFIG_UNREADABLE`; it is never replaced.
+- Valid config preserves unrelated fields and sibling registries, reuses the shared conflict/force rules, and returns without writing for an identical entry.
+
 ### Pending
 
-- Task 2: global setter and malformed-config protection.
 - Task 3: CLI parsing, validation, scope selection, flags, and output.
 - Tasks 4–5: design reconciliation, final coverage/regression, and review.
 
@@ -44,6 +50,7 @@ The setters modify only `registries` in the selected config. Existing `SkillRegi
 
 - Missing project config retains `ConfigNotFoundError` guidance to run `ai-devkit init`.
 - Same-scope conflicts use `REGISTRY_CONFLICT` and direct users to `--force`.
+- Present unreadable global config uses `GLOBAL_CONFIG_UNREADABLE` and includes the protected path.
 - No URL error exists by design.
 
 ## Performance & Security
@@ -55,3 +62,4 @@ The setters modify only `registries` in the selected config. Existing `SkillRegi
 ## Verification Record
 
 - Task 1: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49/49 passed; new helper 100% statements, branches, functions, and lines.
+- Task 2: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15/15 passed.

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -47,7 +47,7 @@ description: Implementation record for project/global registry persistence and C
 
 ### Pending
 
-- Task 5: final coverage/regression and review.
+- Task 5 review and external publication only; all local test/build/lint gates are complete.
 
 ## Integration Points
 
@@ -72,6 +72,7 @@ The setters modify only `registries` in the selected config. Existing `SkillRegi
 - Task 2: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15/15 passed.
 - Task 3: `npm run lint`, `npm run build`, and the combined command/config coverage run — build/lint green, 90/90 tests passed, helper coverage 100%.
 - Phase 7 alignment: no deviations from the binding requirements or reviewed design. The existing precedence test passed 1/1, and built CLI help matches the command contract.
+- Phase 8: focused suite 90/90 with 100% pure-helper coverage; root lint exited 0, root tests passed 954/954, root build completed all six projects, and feature lint passed.
 
 ## Design Alignment
 

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -18,7 +18,7 @@ description: Implementation record for project/global registry persistence and C
 - `packages/cli/src/util/skill-registry.ts`: shared pure add/idempotency/conflict/force decision and merge logic.
 - `packages/cli/src/lib/Config.ts`: project setter using the existing config read/update boundary.
 - `packages/cli/src/lib/GlobalConfig.ts`: global setter and malformed-file guard.
-- `packages/cli/src/commands/skill.ts`: planned flat CLI command.
+- `packages/cli/src/commands/skill.ts`: flat CLI command, validation, scope selection, status output, and flags.
 - `packages/cli/src/__tests__/`: mocked-boundary tests; no real user config, network, Git, or cache I/O.
 
 ## Implementation Notes
@@ -37,9 +37,16 @@ description: Implementation record for project/global registry persistence and C
 - A present file that produces `null` from `read()` fails with `GLOBAL_CONFIG_UNREADABLE`; it is never replaced.
 - Valid config preserves unrelated fields and sibling registries, reuses the shared conflict/force rules, and returns without writing for an identical entry.
 
+### Completed: Task 3 — CLI command
+
+- `skill add-registry <id> <url>` is a flat sibling of existing skill commands; no registry removal/listing command was added.
+- `validateRegistryId()` runs before any manager access. URL is forwarded unchanged.
+- Project scope is the default; `-g/--global` selects `GlobalConfigManager`; `-f/--force` is forwarded to the shared decision and setter.
+- The command reads only the selected target's configured registries to report `registered`, `already registered`, or `updated`, then invokes the authoritative setter.
+- The command imports no `SkillRegistry`, Git, network, index, or cache module. Same-as-default entries are therefore persisted without fetching defaults.
+
 ### Pending
 
-- Task 3: CLI parsing, validation, scope selection, flags, and output.
 - Tasks 4–5: design reconciliation, final coverage/regression, and review.
 
 ## Integration Points
@@ -63,3 +70,4 @@ The setters modify only `registries` in the selected config. Existing `SkillRegi
 
 - Task 1: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49/49 passed; new helper 100% statements, branches, functions, and lines.
 - Task 2: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15/15 passed.
+- Task 3: `npm run lint`, `npm run build`, and the combined command/config coverage run — build/lint green, 90/90 tests passed, helper coverage 100%.

--- a/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/implementation/2026-08-13-feature-skill-add-registry.md
@@ -45,9 +45,12 @@ description: Implementation record for project/global registry persistence and C
 - The command reads only the selected target's configured registries to report `registered`, `already registered`, or `updated`, then invokes the authoritative setter.
 - The command imports no `SkillRegistry`, Git, network, index, or cache module. Same-as-default entries are therefore persisted without fetching defaults.
 
-### Pending
+### Completed: Task 5 — testing and review
 
-- Task 5 review and external publication only; all local test/build/lint gates are complete.
+- Full regression, build, lint, focused coverage, CLI help, and lifecycle validation gates passed.
+- Phase 9 reviewed every changed production and test file, traced the new exported methods/helper to callers, compared the manager patterns with existing config mutations, and found no blocking issues.
+- The prepared PR describes the four binding decisions, persistence/conflict behavior, verification evidence, and intentionally deferred registry removal/listing work.
+- External publication is operationally pending explicit authorization for the configured GitHub remote; no implementation work remains.
 
 ## Integration Points
 
@@ -73,6 +76,7 @@ The setters modify only `registries` in the selected config. Existing `SkillRegi
 - Task 3: `npm run lint`, `npm run build`, and the combined command/config coverage run — build/lint green, 90/90 tests passed, helper coverage 100%.
 - Phase 7 alignment: no deviations from the binding requirements or reviewed design. The existing precedence test passed 1/1, and built CLI help matches the command contract.
 - Phase 8: focused suite 90/90 with 100% pure-helper coverage; root lint exited 0, root tests passed 954/954, root build completed all six projects, and feature lint passed.
+- Phase 9: lifecycle lint passed; holistic file-by-file review found no blocking or important findings, no new dependency/cycle risk, no breaking schema change, and safe rollback through removal of the added config entry/command code.
 
 ## Design Alignment
 

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -1,0 +1,60 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+**What are the major checkpoints?**
+
+- [ ] Milestone 1: [Description]
+- [ ] Milestone 2: [Description]
+- [ ] Milestone 3: [Description]
+
+## Task Breakdown
+**What specific work needs to be done?**
+
+### Phase 1: Foundation
+- [ ] Task 1.1: [Description]
+- [ ] Task 1.2: [Description]
+
+### Phase 2: Core Features
+- [ ] Task 2.1: [Description]
+- [ ] Task 2.2: [Description]
+
+### Phase 3: Integration & Polish
+- [ ] Task 3.1: [Description]
+- [ ] Task 3.2: [Description]
+
+## Dependencies
+**What needs to happen in what order?**
+
+- Task dependencies and blockers
+- External dependencies (APIs, services, etc.)
+- Team/resource dependencies
+
+## Timeline & Estimates
+**When will things be done?**
+
+- Estimated effort per task/phase
+- Target dates for milestones
+- Buffer for unknowns
+
+## Risks & Mitigation
+**What could go wrong?**
+
+- Technical risks
+- Resource risks
+- Dependency risks
+- Mitigation strategies
+
+## Resources Needed
+**What do we need to succeed?**
+
+- Team members and roles
+- Tools and services
+- Infrastructure
+- Documentation/knowledge
+

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -44,9 +44,9 @@ description: TDD plan for the skill add-registry command and config persistence
 
 ### Task 4: Documentation and implementation reconciliation
 
-- [ ] Update the implementation guide with actual files, behavior, error handling, and validation evidence.
-- [ ] Run lifecycle feature lint and compare code against every requirement/design decision.
-- [ ] Mark Tasks 1–3 and their testing checkboxes from fresh evidence; record any deviations or follow-ups.
+- [x] Update the implementation guide with actual files, behavior, error handling, and validation evidence.
+- [x] Run lifecycle feature lint and compare code against every requirement/design decision.
+- [x] Mark Tasks 1–3 and their testing checkboxes from fresh evidence; record any deviations or follow-ups.
 - Outcome: lifecycle docs accurately describe the merged-ready implementation.
 - Dependencies: Tasks 1–3 complete.
 
@@ -75,4 +75,4 @@ Task 1 → Task 2 → Task 3 → Task 4 → Task 5. Phase 6 planning reconciliat
 
 ## Progress Summary
 
-Tasks 1–3 are complete. The combined focused suite is 90/90 green, the CLI package builds, and the shared pure mutation helper has 100% coverage. The command is the only registry-management command and performs target config reads/writes only. No scope changes were discovered. Next are Task 4 design/implementation reconciliation and Task 5 final testing/review; external push remains restricted pending explicit remote authorization.
+Tasks 1–4 are complete. Phase 7 found no requirement/design deviations: the combined focused suite is 90/90 green, downstream precedence is covered by its existing test, CLI help matches the contract, the package builds, and the shared pure mutation helper has 100% coverage. Next is Task 5 final testing/review; external push remains restricted pending explicit remote authorization.

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -9,7 +9,7 @@ description: TDD plan for the skill add-registry command and config persistence
 ## Milestones
 
 - [x] Milestone 1: Shared mutation rules and project persistence are covered and green.
-- [ ] Milestone 2: Global persistence is covered, including malformed-config protection.
+- [x] Milestone 2: Global persistence is covered, including malformed-config protection.
 - [ ] Milestone 3: CLI parsing, scope selection, force handling, opaque URLs, and output are covered and green.
 - [ ] Milestone 4: Implementation/design reconciliation, coverage, full regression, and review gates are green.
 
@@ -26,9 +26,9 @@ description: TDD plan for the skill add-registry command and config persistence
 
 ### Task 2: Global setter and malformed-config safety
 
-- [ ] **Red:** Add tests for missing config creation, sibling/unrelated-field preservation, idempotency/no write, conflict, force, and present malformed JSON.
-- [ ] **Green:** Implement `GlobalConfigManager.addSkillRegistry` with an existence/read distinction before any write and reuse shared mutation logic.
-- [ ] **Refactor/validate:** Run `GlobalConfig.test.ts`, CLI lint, and focused coverage.
+- [x] **Red:** Add tests for missing config creation, sibling/unrelated-field preservation, idempotency/no write, conflict, force, and present malformed JSON.
+- [x] **Green:** Implement `GlobalConfigManager.addSkillRegistry` with an existence/read distinction before any write and reuse shared mutation logic.
+- [x] **Refactor/validate:** Run `GlobalConfig.test.ts`, CLI lint, and focused coverage.
 - Outcome: global persistence creates only when absent and never erases a present unreadable file.
 - Dependencies: Task 1 helper, existing `read()`, `exists()`, private `write()`, and global path resolution.
 - Test scenarios: all global-manager scenarios and failure-mode no-write checks.
@@ -75,4 +75,4 @@ Task 1 → Task 2 → Task 3 → Task 4 → Task 5. Phase 6 planning reconciliat
 
 ## Progress Summary
 
-Task 1 is complete with 49 focused tests green and 100% coverage of the shared pure mutation helper. No scope changes or blockers were discovered. The next action is Task 2's failing global persistence and malformed-config tests; external push remains restricted pending explicit remote authorization.
+Tasks 1–2 are complete. Project tests are 49/49 green; global tests are 15/15 green; the shared pure mutation helper remains at 100% coverage. The malformed-global test proves a present unreadable file is not written. No scope changes were discovered. The next action is Task 3's failing CLI tests; external push remains restricted pending explicit remote authorization.

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -1,60 +1,78 @@
 ---
 phase: planning
 title: Project Planning & Task Breakdown
-description: Break down work into actionable tasks and estimate timeline
+description: TDD plan for the skill add-registry command and config persistence
 ---
 
 # Project Planning & Task Breakdown
 
 ## Milestones
-**What are the major checkpoints?**
 
-- [ ] Milestone 1: [Description]
-- [ ] Milestone 2: [Description]
-- [ ] Milestone 3: [Description]
+- [ ] Milestone 1: Shared mutation rules and project persistence are covered and green.
+- [ ] Milestone 2: Global persistence is covered, including malformed-config protection.
+- [ ] Milestone 3: CLI parsing, scope selection, force handling, opaque URLs, and output are covered and green.
+- [ ] Milestone 4: Implementation/design reconciliation, coverage, full regression, and review gates are green.
 
 ## Task Breakdown
-**What specific work needs to be done?**
 
-### Phase 1: Foundation
-- [ ] Task 1.1: [Description]
-- [ ] Task 1.2: [Description]
+### Task 1: Shared mutation logic and project setter
 
-### Phase 2: Core Features
-- [ ] Task 2.1: [Description]
-- [ ] Task 2.2: [Description]
+- [ ] **Red:** Add focused tests for a pure registry-mutation helper and `ConfigManager.addSkillRegistry`: first add, sibling preservation, same-value idempotency/no write, conflict/no write, force replacement, and missing project config.
+- [ ] **Green:** Implement the helper and project setter using `read → spread-merge → update` while treating URL as opaque.
+- [ ] **Refactor/validate:** Run the helper and `Config.test.ts` targets plus CLI lint; verify 100% coverage of the helper.
+- Outcome: project-scope persistence is safe, merge-preserving, idempotent, and force-aware.
+- Dependencies: existing `ConfigManager.update()`, `filterStringRecord`, and CLI error conventions.
+- Test scenarios: all `ConfigManager.addSkillRegistry` scenarios and the shared conflict branches in the testing strategy.
 
-### Phase 3: Integration & Polish
-- [ ] Task 3.1: [Description]
-- [ ] Task 3.2: [Description]
+### Task 2: Global setter and malformed-config safety
 
-## Dependencies
-**What needs to happen in what order?**
+- [ ] **Red:** Add tests for missing config creation, sibling/unrelated-field preservation, idempotency/no write, conflict, force, and present malformed JSON.
+- [ ] **Green:** Implement `GlobalConfigManager.addSkillRegistry` with an existence/read distinction before any write and reuse shared mutation logic.
+- [ ] **Refactor/validate:** Run `GlobalConfig.test.ts`, CLI lint, and focused coverage.
+- Outcome: global persistence creates only when absent and never erases a present unreadable file.
+- Dependencies: Task 1 helper, existing `read()`, `exists()`, private `write()`, and global path resolution.
+- Test scenarios: all global-manager scenarios and failure-mode no-write checks.
 
-- Task dependencies and blockers
-- External dependencies (APIs, services, etc.)
-- Team/resource dependencies
+### Task 3: Flat `skill add-registry` command
 
-## Timeline & Estimates
-**When will things be done?**
+- [ ] **Red:** Extend command tests for command shape/help, project/default scope, `-g/--global`, `-f/--force`, ID validation, idempotent/success copy, conflict propagation, opaque URL examples, and absence of registry/cache/Git calls.
+- [ ] **Green:** Register the new sibling command, reuse `validateRegistryId()`, select the manager, inspect only the target scope for output status, invoke the setter, and report success.
+- [ ] **Refactor/validate:** Run command tests, all existing skill command tests, CLI lint, and focused coverage.
+- Outcome: users can register any URL verbatim in either scope without network/cache work.
+- Dependencies: Tasks 1–2 and existing Commander/UI/error-handler conventions.
+- Test scenarios: all command, integration, help, and adjacent-command regression scenarios in the testing strategy.
 
-- Estimated effort per task/phase
-- Target dates for milestones
-- Buffer for unknowns
+### Task 4: Documentation and implementation reconciliation
+
+- [ ] Update the implementation guide with actual files, behavior, error handling, and validation evidence.
+- [ ] Run lifecycle feature lint and compare code against every requirement/design decision.
+- [ ] Mark Tasks 1–3 and their testing checkboxes from fresh evidence; record any deviations or follow-ups.
+- Outcome: lifecycle docs accurately describe the merged-ready implementation.
+- Dependencies: Tasks 1–3 complete.
+
+### Task 5: Final testing and review
+
+- [ ] Run focused 100% coverage for all new pure logic and record the report.
+- [ ] Run full root lint, test, build, feature lint, and CLI help/smoke validation.
+- [ ] Perform final code review for correctness, security, compatibility, and scope adherence.
+- [ ] Commit final docs/review fixes and prepare the PR body.
+- Outcome: no regression and a merged-ready branch/PR.
+- Dependencies: Task 4 complete.
+
+## Dependencies & Sequence
+
+Task 1 → Task 2 → Task 3 → Task 4 → Task 5. Phase 6 planning reconciliation runs after each implementation task. There are no external service dependencies: tests mock filesystem/config boundaries, and registration performs no network operation.
 
 ## Risks & Mitigation
-**What could go wrong?**
 
-- Technical risks
-- Resource risks
-- Dependency risks
-- Mitigation strategies
+- **Malformed global overwrite:** check file existence separately and fail if a present file cannot be parsed; assert no `writeJson` call.
+- **Conflict logic diverges by scope:** centralize decision/merge behavior in one fully covered pure helper.
+- **URL policy accidentally expands:** do not import URL/Git/network utilities; test SSH and arbitrary strings verbatim.
+- **Default registry blocks offline add:** do not instantiate or fetch `SkillRegistry`; same-as-default is treated only as a target-scope write.
+- **Command regression:** add the command as a flat sibling and run the complete existing skill command suite.
+- **Internal workspace resolution:** build workspace packages after clean dependency installation before full tests.
+- **External publication restriction:** local commits continue; push/PR require explicit authorization accepted by the environment for the configured GitHub remote.
 
-## Resources Needed
-**What do we need to succeed?**
+## Progress Summary
 
-- Team members and roles
-- Tools and services
-- Infrastructure
-- Documentation/knowledge
-
+Initial plan approved from the binding requirements and reviewed design. No implementation task has started; the next action is Task 1's failing tests.

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -10,7 +10,7 @@ description: TDD plan for the skill add-registry command and config persistence
 
 - [x] Milestone 1: Shared mutation rules and project persistence are covered and green.
 - [x] Milestone 2: Global persistence is covered, including malformed-config protection.
-- [ ] Milestone 3: CLI parsing, scope selection, force handling, opaque URLs, and output are covered and green.
+- [x] Milestone 3: CLI parsing, scope selection, force handling, opaque URLs, and output are covered and green.
 - [ ] Milestone 4: Implementation/design reconciliation, coverage, full regression, and review gates are green.
 
 ## Task Breakdown
@@ -35,9 +35,9 @@ description: TDD plan for the skill add-registry command and config persistence
 
 ### Task 3: Flat `skill add-registry` command
 
-- [ ] **Red:** Extend command tests for command shape/help, project/default scope, `-g/--global`, `-f/--force`, ID validation, idempotent/success copy, conflict propagation, opaque URL examples, and absence of registry/cache/Git calls.
-- [ ] **Green:** Register the new sibling command, reuse `validateRegistryId()`, select the manager, inspect only the target scope for output status, invoke the setter, and report success.
-- [ ] **Refactor/validate:** Run command tests, all existing skill command tests, CLI lint, and focused coverage.
+- [x] **Red:** Extend command tests for command shape/help, project/default scope, `-g/--global`, `-f/--force`, ID validation, idempotent/success copy, conflict propagation, opaque URL examples, and absence of registry/cache/Git calls.
+- [x] **Green:** Register the new sibling command, reuse `validateRegistryId()`, select the manager, inspect only the target scope for output status, invoke the setter, and report success.
+- [x] **Refactor/validate:** Run command tests, all existing skill command tests, CLI lint, and focused coverage.
 - Outcome: users can register any URL verbatim in either scope without network/cache work.
 - Dependencies: Tasks 1–2 and existing Commander/UI/error-handler conventions.
 - Test scenarios: all command, integration, help, and adjacent-command regression scenarios in the testing strategy.
@@ -75,4 +75,4 @@ Task 1 → Task 2 → Task 3 → Task 4 → Task 5. Phase 6 planning reconciliat
 
 ## Progress Summary
 
-Tasks 1–2 are complete. Project tests are 49/49 green; global tests are 15/15 green; the shared pure mutation helper remains at 100% coverage. The malformed-global test proves a present unreadable file is not written. No scope changes were discovered. The next action is Task 3's failing CLI tests; external push remains restricted pending explicit remote authorization.
+Tasks 1–3 are complete. The combined focused suite is 90/90 green, the CLI package builds, and the shared pure mutation helper has 100% coverage. The command is the only registry-management command and performs target config reads/writes only. No scope changes were discovered. Next are Task 4 design/implementation reconciliation and Task 5 final testing/review; external push remains restricted pending explicit remote authorization.

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -8,7 +8,7 @@ description: TDD plan for the skill add-registry command and config persistence
 
 ## Milestones
 
-- [ ] Milestone 1: Shared mutation rules and project persistence are covered and green.
+- [x] Milestone 1: Shared mutation rules and project persistence are covered and green.
 - [ ] Milestone 2: Global persistence is covered, including malformed-config protection.
 - [ ] Milestone 3: CLI parsing, scope selection, force handling, opaque URLs, and output are covered and green.
 - [ ] Milestone 4: Implementation/design reconciliation, coverage, full regression, and review gates are green.
@@ -17,9 +17,9 @@ description: TDD plan for the skill add-registry command and config persistence
 
 ### Task 1: Shared mutation logic and project setter
 
-- [ ] **Red:** Add focused tests for a pure registry-mutation helper and `ConfigManager.addSkillRegistry`: first add, sibling preservation, same-value idempotency/no write, conflict/no write, force replacement, and missing project config.
-- [ ] **Green:** Implement the helper and project setter using `read → spread-merge → update` while treating URL as opaque.
-- [ ] **Refactor/validate:** Run the helper and `Config.test.ts` targets plus CLI lint; verify 100% coverage of the helper.
+- [x] **Red:** Add focused tests for a pure registry-mutation helper and `ConfigManager.addSkillRegistry`: first add, sibling preservation, same-value idempotency/no write, conflict/no write, force replacement, and missing project config.
+- [x] **Green:** Implement the helper and project setter using `read → spread-merge → update` while treating URL as opaque.
+- [x] **Refactor/validate:** Run the helper and `Config.test.ts` targets plus CLI lint; verify 100% coverage of the helper.
 - Outcome: project-scope persistence is safe, merge-preserving, idempotent, and force-aware.
 - Dependencies: existing `ConfigManager.update()`, `filterStringRecord`, and CLI error conventions.
 - Test scenarios: all `ConfigManager.addSkillRegistry` scenarios and the shared conflict branches in the testing strategy.
@@ -75,4 +75,4 @@ Task 1 → Task 2 → Task 3 → Task 4 → Task 5. Phase 6 planning reconciliat
 
 ## Progress Summary
 
-Initial plan approved from the binding requirements and reviewed design. No implementation task has started; the next action is Task 1's failing tests.
+Task 1 is complete with 49 focused tests green and 100% coverage of the shared pure mutation helper. No scope changes or blockers were discovered. The next action is Task 2's failing global persistence and malformed-config tests; external push remains restricted pending explicit remote authorization.

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -52,8 +52,8 @@ description: TDD plan for the skill add-registry command and config persistence
 
 ### Task 5: Final testing and review
 
-- [ ] Run focused 100% coverage for all new pure logic and record the report.
-- [ ] Run full root lint, test, build, feature lint, and CLI help/smoke validation.
+- [x] Run focused 100% coverage for all new pure logic and record the report.
+- [x] Run full root lint, test, build, feature lint, and CLI help/smoke validation.
 - [ ] Perform final code review for correctness, security, compatibility, and scope adherence.
 - [ ] Commit final docs/review fixes and prepare the PR body.
 - Outcome: no regression and a merged-ready branch/PR.

--- a/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/planning/2026-08-13-feature-skill-add-registry.md
@@ -11,7 +11,7 @@ description: TDD plan for the skill add-registry command and config persistence
 - [x] Milestone 1: Shared mutation rules and project persistence are covered and green.
 - [x] Milestone 2: Global persistence is covered, including malformed-config protection.
 - [x] Milestone 3: CLI parsing, scope selection, force handling, opaque URLs, and output are covered and green.
-- [ ] Milestone 4: Implementation/design reconciliation, coverage, full regression, and review gates are green.
+- [x] Milestone 4: Implementation/design reconciliation, coverage, full regression, and review gates are green.
 
 ## Task Breakdown
 
@@ -54,8 +54,8 @@ description: TDD plan for the skill add-registry command and config persistence
 
 - [x] Run focused 100% coverage for all new pure logic and record the report.
 - [x] Run full root lint, test, build, feature lint, and CLI help/smoke validation.
-- [ ] Perform final code review for correctness, security, compatibility, and scope adherence.
-- [ ] Commit final docs/review fixes and prepare the PR body.
+- [x] Perform final code review for correctness, security, compatibility, and scope adherence.
+- [x] Commit final docs/review fixes and prepare the PR body.
 - Outcome: no regression and a merged-ready branch/PR.
 - Dependencies: Task 4 complete.
 
@@ -75,4 +75,4 @@ Task 1 → Task 2 → Task 3 → Task 4 → Task 5. Phase 6 planning reconciliat
 
 ## Progress Summary
 
-Tasks 1–4 are complete. Phase 7 found no requirement/design deviations: the combined focused suite is 90/90 green, downstream precedence is covered by its existing test, CLI help matches the contract, the package builds, and the shared pure mutation helper has 100% coverage. Next is Task 5 final testing/review; external push remains restricted pending explicit remote authorization.
+Tasks 1–5 are complete locally. Phase 9 found no blocking correctness, security, compatibility, integration, or scope issues. The combined focused suite is 90/90 green, downstream precedence is covered by its existing test, CLI help matches the contract, all 954 repository tests pass, all six packages build, and the shared pure mutation helper has 100% coverage. The branch is merged-ready; external push and PR creation remain restricted pending explicit authorization for the configured GitHub remote.

--- a/docs/ai/requirements/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/requirements/2026-08-13-feature-skill-add-registry.md
@@ -1,0 +1,76 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+description: Add a CLI command that persists third-party skill registries
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+
+AI DevKit users can consume registries configured in `.ai-devkit.json`, but there is no CLI command for registering one. Users must hand-edit JSON, know the nested `registries` schema, and choose the correct project or global config file. This is error-prone and makes documented CLI workflows incomplete.
+
+The feature is for users who want `skill add`, `find`, `update`, and `rebuild-index` to resolve a third-party registry through the existing default < global < project merge order.
+
+## Goals & Objectives
+
+- Add exactly one flat command: `ai-devkit skill add-registry <id> <url>`.
+- Write project config by default and global config with `-g, --global`.
+- Validate only the registry ID with the existing `validateRegistryId()` rule (`org/repo`).
+- Preserve the URL string verbatim without URL parsing, normalization, network verification, or format restrictions.
+- Merge the new entry into the target scope's existing `registries` map.
+- Treat same ID + same URL in the target scope as successful idempotency and report `already registered`.
+- Treat same ID + different URL in the target scope as a conflict unless `-f, --force` is supplied.
+- Persist an entry even when it matches a default-registry entry, creating an explicit reproducibility pin.
+- Keep the operation offline and store-first: write config only.
+- Refuse to overwrite a present but malformed global config.
+
+### Non-goals
+
+- `remove-registry` or `list-registries` commands.
+- URL validation or normalization, including GitHub-only checks, `.git` suffix handling, or `git ls-remote`.
+- Cloning, refreshing, indexing, or otherwise touching `~/.ai-devkit/skills/` during registration.
+- Authentication, SSH/OAuth/credential management, ref/version pinning, or atomic-write refactors.
+- Migrating or rewriting existing hand-edited registry entries.
+
+## Terminology
+
+- **Registry ID:** The validated `owner/repository` identifier stored as a key.
+- **Registry URL:** Any user-provided string stored verbatim as the value.
+- **Project scope:** The current project's `.ai-devkit.json`; this is the default target.
+- **Global scope:** `~/.ai-devkit/.ai-devkit.json`, selected with `--global`.
+- **Pin:** An explicit project/global entry, including one identical to the default registry, that preserves the user's chosen mapping in config.
+
+## User Stories & Use Cases
+
+- As a project maintainer, I want to run `ai-devkit skill add-registry anthropics/skills https://github.com/anthropics/skills.git` so the project resolves that registry without hand-editing JSON.
+- As a user, I want to run `ai-devkit skill add-registry shopback/skills git@gitlab.com:shopback/earn-more/earn-more-experiment/skills.git --global` so all projects can resolve an SSH-hosted registry.
+- As a user, I want arbitrary URL strings, including strings without `.git`, stored exactly as supplied.
+- As a maintainer, I want an identical repeat invocation to succeed without rewriting config.
+- As a maintainer, I want an accidental same-scope URL change rejected and an intentional change enabled by `--force`.
+- As a maintainer, I want a registry matching the built-in default persisted in the selected scope as a reproducibility pin.
+- As a global-config user, I want a malformed existing file protected from destructive replacement.
+
+## Success Criteria
+
+- The CLI exposes only `skill add-registry <id> <url>` for registry management, with `--global` and `--force` options.
+- Valid IDs matching `^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$` are accepted; bare slugs, nested paths, and dotted segments are rejected through `validateRegistryId()`.
+- Every URL argument is stored byte-for-byte as Commander supplies it; no URL-specific validation or network operation occurs.
+- Project and global writes preserve unrelated config fields and existing registry entries.
+- Same-scope identical entries return success without a disk write and produce an `already registered` message.
+- Same-scope conflicts fail without changing config; `--force` replaces only the conflicting registry value.
+- A missing global config is created, while an existing unreadable global config yields a clear error and is not overwritten.
+- Existing merged-registry precedence makes the persisted entry available to downstream skill commands without changes to cache behavior.
+- Unit tests use mocked filesystem boundaries, cover 100% of new pure logic, and the full repository test/lint/build suites regress cleanly.
+
+## Constraints & Assumptions
+
+- Existing config types already support `registries?: Record<string, string>`.
+- `ConfigManager.update()` remains the project write boundary and retains its no-change optimization.
+- Global mutation must distinguish missing config from parse failure even though `GlobalConfigManager.read()` intentionally returns `null` for both cases.
+- Cross-layer/default-registry shadowing warnings are best-effort only; default registry availability must never gate registration. No default-registry fetch is required for the add path.
+- The feature follows existing Commander command registration, terminal UI, error handling, and `-g/--global` conventions.
+
+## Questions & Open Items
+
+All material decisions are resolved. Deferred follow-ups are `remove-registry` and `list-registries`; they are not part of this feature.

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -17,12 +17,12 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 ### `ConfigManager.addSkillRegistry`
 
-- [ ] Adds the first project registry while preserving unrelated config.
-- [ ] Spread-merges a new registry without replacing sibling registry entries.
-- [ ] Treats same ID + same URL as idempotent with no write.
-- [ ] Rejects same ID + different URL without force and leaves config unchanged.
-- [ ] Replaces only the requested value with force.
-- [ ] Reports the established missing-project-config error.
+- [x] Adds the first project registry while preserving unrelated config.
+- [x] Spread-merges a new registry without replacing sibling registry entries.
+- [x] Treats same ID + same URL as idempotent with no write.
+- [x] Rejects same ID + different URL without force and leaves config unchanged.
+- [x] Replaces only the requested value with force.
+- [x] Reports the established missing-project-config error.
 
 ### `GlobalConfigManager.addSkillRegistry`
 
@@ -66,6 +66,7 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 ## Test Reporting & Coverage
 
 - Targeted red/green tests run per implementation task.
+- Task 1 evidence: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49 tests passed; helper coverage 100% statements, branches, functions, and lines.
 - CLI coverage: `npm run test:coverage --workspace=packages/cli` (adjust to repository-native invocation if required by scripts).
 - Full regression: root `npm test`, `npm run lint`, and `npm run build`.
 - Record final commands, outcomes, and any justified exclusions in this document.

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -47,7 +47,7 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 - [x] Validate command-to-project-manager scope selection with mocked filesystem/config.
 - [x] Validate command-to-global-manager scope selection with mocked filesystem/config.
-- [ ] Confirm a persisted project/global entry is already consumed by existing default < global < project merge behavior.
+- [x] Confirm a persisted project/global entry is already consumed by existing default < global < project merge behavior.
 - [x] Confirm all failure modes avoid target writes.
 
 ## End-to-End Tests
@@ -69,13 +69,14 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 - Task 1 evidence: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49 tests passed; helper coverage 100% statements, branches, functions, and lines.
 - Task 2 evidence: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15 tests passed, including malformed-file no-write and all shared mutation outcomes.
 - Task 3 evidence: CLI lint exited 0 (five pre-existing warnings), CLI build exited 0, and the combined command/config suite passed 90/90 with the helper at 100% coverage.
+- Phase 7 evidence: existing downstream precedence test passed 1/1; built CLI help displayed `<id> <url>`, `-g/--global`, and `-f/--force`.
 - CLI coverage: `npm run test:coverage --workspace=packages/cli` (adjust to repository-native invocation if required by scripts).
 - Full regression: root `npm test`, `npm run lint`, and `npm run build`.
 - Record final commands, outcomes, and any justified exclusions in this document.
 
 ## Manual Testing
 
-- [ ] Verify `ai-devkit skill add-registry --help` documents arguments and both flag aliases.
+- [x] Verify `ai-devkit skill add-registry --help` documents arguments and both flag aliases.
 - [ ] Smoke-test project/global command output in isolated temporary homes/directories only.
 - No UI accessibility or browser/device testing applies to this CLI-only feature.
 

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -52,9 +52,9 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 ## End-to-End Tests
 
-- [ ] Exercise CLI parsing for the documented HTTPS and SSH examples in an isolated mocked/temp environment if existing conventions support it.
-- [ ] Exercise idempotent and forced-repeat flows.
-- [ ] Run the full existing command regression suite.
+- [x] Exercise CLI parsing for the documented HTTPS and SSH examples in the existing mocked command harness.
+- [x] Exercise idempotent and forced-repeat flows.
+- [x] Run the full existing command regression suite.
 
 ## Test Data
 
@@ -70,14 +70,14 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 - Task 2 evidence: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15 tests passed, including malformed-file no-write and all shared mutation outcomes.
 - Task 3 evidence: CLI lint exited 0 (five pre-existing warnings), CLI build exited 0, and the combined command/config suite passed 90/90 with the helper at 100% coverage.
 - Phase 7 evidence: existing downstream precedence test passed 1/1; built CLI help displayed `<id> <url>`, `-g/--global`, and `-f/--force`.
-- CLI coverage: `npm run test:coverage --workspace=packages/cli` (adjust to repository-native invocation if required by scripts).
-- Full regression: root `npm test`, `npm run lint`, and `npm run build`.
-- Record final commands, outcomes, and any justified exclusions in this document.
+- Final focused coverage: 90/90 tests; `planSkillRegistryAdd` is 100% statements (6/6), branches (9/9), functions (1/1), and lines (6/6).
+- Full regression: root `npm test` passed 954/954 tests across 79 CLI test files plus all other workspaces; `npm run lint` exited 0 with five pre-existing warnings; `npm run build` built all six projects.
+- Lifecycle lint: base and `--feature skill-add-registry` both passed.
 
 ## Manual Testing
 
 - [x] Verify `ai-devkit skill add-registry --help` documents arguments and both flag aliases.
-- [ ] Smoke-test project/global command output in isolated temporary homes/directories only.
+- [x] Smoke-test command output through mocked project/global manager boundaries; no production config or home directory was touched.
 - No UI accessibility or browser/device testing applies to this CLI-only feature.
 
 ## Performance Testing

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -26,11 +26,11 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 ### `GlobalConfigManager.addSkillRegistry`
 
-- [ ] Creates a missing global config and required parent directory.
-- [ ] Merges into existing registries while preserving unrelated fields.
-- [ ] Treats same ID + same URL as idempotent with no write.
-- [ ] Rejects a conflict without force and supports force replacement.
-- [ ] Refuses to overwrite a present malformed global config after read failure.
+- [x] Creates a missing global config and required parent directory.
+- [x] Merges into existing registries while preserving unrelated fields.
+- [x] Treats same ID + same URL as idempotent with no write.
+- [x] Rejects a conflict without force and supports force replacement.
+- [x] Refuses to overwrite a present malformed global config after read failure.
 
 ### `skill add-registry` command
 
@@ -67,6 +67,7 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 - Targeted red/green tests run per implementation task.
 - Task 1 evidence: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49 tests passed; helper coverage 100% statements, branches, functions, and lines.
+- Task 2 evidence: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15 tests passed, including malformed-file no-write and all shared mutation outcomes.
 - CLI coverage: `npm run test:coverage --workspace=packages/cli` (adjust to repository-native invocation if required by scripts).
 - Full regression: root `npm test`, `npm run lint`, and `npm run build`.
 - Record final commands, outcomes, and any justified exclusions in this document.

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -34,21 +34,21 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 ### `skill add-registry` command
 
-- [ ] Registers a valid ID and HTTPS URL in project scope by default.
-- [ ] Routes to global persistence for `-g` and `--global`.
-- [ ] Routes force intent for `-f` and `--force`.
-- [ ] Rejects bare, nested, and dotted registry IDs through `validateRegistryId()`.
-- [ ] Accepts HTTPS without `.git`, SSH/SCP syntax, and arbitrary URL strings verbatim.
-- [ ] Reports `already registered` for idempotent input and a clear conflict error otherwise.
-- [ ] Does not fetch defaults or invoke any cache/Git operation.
-- [ ] Leaves existing `skill add`, `list`, `remove`, `update`, `find`, and `rebuild-index` tests green.
+- [x] Registers a valid ID and HTTPS URL in project scope by default.
+- [x] Routes to global persistence for `-g` and `--global`.
+- [x] Routes force intent for `-f` and `--force`.
+- [x] Rejects bare, nested, and dotted registry IDs through `validateRegistryId()`.
+- [x] Accepts HTTPS without `.git`, SSH/SCP syntax, and arbitrary URL strings verbatim.
+- [x] Reports `already registered` for idempotent input and a clear conflict error otherwise.
+- [x] Does not fetch defaults or invoke any cache/Git operation.
+- [x] Leaves existing `skill add`, `list`, `remove`, `update`, `find`, and `rebuild-index` tests green.
 
 ## Integration Tests
 
-- [ ] Validate command-to-project-manager scope selection with mocked filesystem/config.
-- [ ] Validate command-to-global-manager scope selection with mocked filesystem/config.
+- [x] Validate command-to-project-manager scope selection with mocked filesystem/config.
+- [x] Validate command-to-global-manager scope selection with mocked filesystem/config.
 - [ ] Confirm a persisted project/global entry is already consumed by existing default < global < project merge behavior.
-- [ ] Confirm all failure modes avoid target writes.
+- [x] Confirm all failure modes avoid target writes.
 
 ## End-to-End Tests
 
@@ -68,6 +68,7 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 - Targeted red/green tests run per implementation task.
 - Task 1 evidence: `npx vitest run src/__tests__/lib/Config.test.ts --coverage --coverage.include=src/util/skill-registry.ts` — 49 tests passed; helper coverage 100% statements, branches, functions, and lines.
 - Task 2 evidence: `npx vitest run src/__tests__/lib/GlobalConfig.test.ts` — 15 tests passed, including malformed-file no-write and all shared mutation outcomes.
+- Task 3 evidence: CLI lint exited 0 (five pre-existing warnings), CLI build exited 0, and the combined command/config suite passed 90/90 with the helper at 100% coverage.
 - CLI coverage: `npm run test:coverage --workspace=packages/cli` (adjust to repository-native invocation if required by scripts).
 - Full regression: root `npm test`, `npm run lint`, and `npm run build`.
 - Record final commands, outcomes, and any justified exclusions in this document.

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -1,0 +1,85 @@
+---
+phase: testing
+title: Testing Strategy
+description: Verify registry persistence, CLI behavior, safety, and regressions
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+
+- Achieve 100% line, branch, function, and statement coverage for all new pure logic.
+- Unit-test project/global persistence and CLI routing/error handling with mocks.
+- Run the full CLI and repository suites, lint, and build for regression evidence.
+- Prove the add path performs no network, Git, clone, index, or cache operation.
+
+## Unit Tests
+
+### `ConfigManager.addSkillRegistry`
+
+- [ ] Adds the first project registry while preserving unrelated config.
+- [ ] Spread-merges a new registry without replacing sibling registry entries.
+- [ ] Treats same ID + same URL as idempotent with no write.
+- [ ] Rejects same ID + different URL without force and leaves config unchanged.
+- [ ] Replaces only the requested value with force.
+- [ ] Reports the established missing-project-config error.
+
+### `GlobalConfigManager.addSkillRegistry`
+
+- [ ] Creates a missing global config and required parent directory.
+- [ ] Merges into existing registries while preserving unrelated fields.
+- [ ] Treats same ID + same URL as idempotent with no write.
+- [ ] Rejects a conflict without force and supports force replacement.
+- [ ] Refuses to overwrite a present malformed global config after read failure.
+
+### `skill add-registry` command
+
+- [ ] Registers a valid ID and HTTPS URL in project scope by default.
+- [ ] Routes to global persistence for `-g` and `--global`.
+- [ ] Routes force intent for `-f` and `--force`.
+- [ ] Rejects bare, nested, and dotted registry IDs through `validateRegistryId()`.
+- [ ] Accepts HTTPS without `.git`, SSH/SCP syntax, and arbitrary URL strings verbatim.
+- [ ] Reports `already registered` for idempotent input and a clear conflict error otherwise.
+- [ ] Does not fetch defaults or invoke any cache/Git operation.
+- [ ] Leaves existing `skill add`, `list`, `remove`, `update`, `find`, and `rebuild-index` tests green.
+
+## Integration Tests
+
+- [ ] Validate command-to-project-manager scope selection with mocked filesystem/config.
+- [ ] Validate command-to-global-manager scope selection with mocked filesystem/config.
+- [ ] Confirm a persisted project/global entry is already consumed by existing default < global < project merge behavior.
+- [ ] Confirm all failure modes avoid target writes.
+
+## End-to-End Tests
+
+- [ ] Exercise CLI parsing for the documented HTTPS and SSH examples in an isolated mocked/temp environment if existing conventions support it.
+- [ ] Exercise idempotent and forced-repeat flows.
+- [ ] Run the full existing command regression suite.
+
+## Test Data
+
+- Registry IDs: `anthropics/skills`, `shopback/skills`, plus invalid bare/nested/dotted forms.
+- URL values: `.git` HTTPS, suffixless HTTPS, SSH/SCP syntax, and an arbitrary opaque string.
+- Config fixtures: missing, valid empty, valid with sibling registries/unrelated fields, and malformed JSON.
+- Mock `fs-extra`, `os.homedir`, terminal UI, and process exit using established test patterns. No production user config, cache, network, or Git repository is touched.
+
+## Test Reporting & Coverage
+
+- Targeted red/green tests run per implementation task.
+- CLI coverage: `npm run test:coverage --workspace=packages/cli` (adjust to repository-native invocation if required by scripts).
+- Full regression: root `npm test`, `npm run lint`, and `npm run build`.
+- Record final commands, outcomes, and any justified exclusions in this document.
+
+## Manual Testing
+
+- [ ] Verify `ai-devkit skill add-registry --help` documents arguments and both flag aliases.
+- [ ] Smoke-test project/global command output in isolated temporary homes/directories only.
+- No UI accessibility or browser/device testing applies to this CLI-only feature.
+
+## Performance Testing
+
+No load/stress suite is warranted for a single local config mutation. Unit tests assert the absence of network/cache work; qualitative target is immediate completion bounded by config-file I/O.
+
+## Bug Tracking
+
+Blocking failures are fixed before review. Any deferred registry removal/listing UX is tracked as follow-up scope, not treated as a defect in this feature.

--- a/packages/cli/src/__tests__/commands/skill.test.ts
+++ b/packages/cli/src/__tests__/commands/skill.test.ts
@@ -7,9 +7,23 @@ const mockAddSkill = vi.fn();
 const mockListGlobalSkills = vi.fn();
 const mockListSkills = vi.fn();
 const mockRemoveSkill = vi.fn();
+const mockProjectGetSkillRegistries = vi.fn();
+const mockProjectAddSkillRegistry = vi.fn();
+const mockGlobalGetSkillRegistries = vi.fn();
+const mockGlobalAddSkillRegistry = vi.fn();
 
 vi.mock('../../lib/Config.js', () => ({
-  ConfigManager: vi.fn(),
+  ConfigManager: vi.fn(function () { return {
+    getSkillRegistries: (...args: unknown[]) => mockProjectGetSkillRegistries(...args),
+    addSkillRegistry: (...args: unknown[]) => mockProjectAddSkillRegistry(...args),
+  }; }),
+}));
+
+vi.mock('../../lib/GlobalConfig.js', () => ({
+  GlobalConfigManager: vi.fn(function () { return {
+    getSkillRegistries: (...args: unknown[]) => mockGlobalGetSkillRegistries(...args),
+    addSkillRegistry: (...args: unknown[]) => mockGlobalAddSkillRegistry(...args),
+  }; }),
 }));
 
 vi.mock('../../lib/SkillManager.js', () => ({
@@ -31,6 +45,7 @@ vi.mock('../../util/terminal-ui.js', () => ({
     info: vi.fn(),
     text: vi.fn(),
     table: vi.fn(),
+    success: vi.fn(),
   },
 }));
 
@@ -41,8 +56,132 @@ describe('skill command', () => {
     mockListGlobalSkills.mockResolvedValue([]);
     mockListSkills.mockResolvedValue([]);
     mockRemoveSkill.mockImplementation(async () => undefined);
+    mockProjectGetSkillRegistries.mockResolvedValue({});
+    mockProjectAddSkillRegistry.mockResolvedValue({});
+    mockGlobalGetSkillRegistries.mockResolvedValue({});
+    mockGlobalAddSkillRegistry.mockResolvedValue({});
     vi.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
     vi.spyOn(process.stderr, 'write').mockImplementation((() => true) as any);
+  });
+
+  it('adds an opaque registry URL to project config by default', async () => {
+    const program = new Command();
+    registerSkillCommand(program);
+
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'git@gitlab.com:shopback/skills.git']);
+
+    expect(mockProjectAddSkillRegistry).toHaveBeenCalledWith(
+      'shopback/skills',
+      'git@gitlab.com:shopback/skills.git',
+      { force: undefined },
+    );
+    expect(mockGlobalAddSkillRegistry).not.toHaveBeenCalled();
+  });
+
+  it('reports an identical target-scope registry as already registered', async () => {
+    mockProjectGetSkillRegistries.mockResolvedValue({ 'anthropics/skills': 'same-url' });
+    const program = new Command();
+    registerSkillCommand(program);
+
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'anthropics/skills', 'same-url']);
+
+    expect(mockProjectAddSkillRegistry).toHaveBeenCalledWith(
+      'anthropics/skills',
+      'same-url',
+      { force: undefined },
+    );
+    expect(ui.info).toHaveBeenCalledWith('Registry "anthropics/skills" is already registered.');
+    expect(ui.success).not.toHaveBeenCalled();
+  });
+
+  it.each(['-g', '--global'])('routes %s registry writes to global config', async globalFlag => {
+    const program = new Command();
+    registerSkillCommand(program);
+
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'opaque-url', globalFlag]);
+
+    expect(mockGlobalGetSkillRegistries).toHaveBeenCalledOnce();
+    expect(mockGlobalAddSkillRegistry).toHaveBeenCalledWith(
+      'shopback/skills',
+      'opaque-url',
+      { force: undefined },
+    );
+    expect(mockProjectAddSkillRegistry).not.toHaveBeenCalled();
+  });
+
+  it.each(['-f', '--force'])('forwards %s and reports a forced update', async forceFlag => {
+    mockProjectGetSkillRegistries.mockResolvedValue({ 'shopback/skills': 'old-url' });
+    const program = new Command();
+    registerSkillCommand(program);
+
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'new-url', forceFlag]);
+
+    expect(mockProjectAddSkillRegistry).toHaveBeenCalledWith(
+      'shopback/skills',
+      'new-url',
+      { force: true },
+    );
+    expect(ui.success).toHaveBeenCalledWith('Updated skill registry "shopback/skills".');
+  });
+
+  it.each([
+    'https://github.com/anthropics/skills.git',
+    'https://github.com/anthropics/skills',
+    'anything the user provides',
+  ])('preserves URL input verbatim: %s', async url => {
+    const program = new Command();
+    registerSkillCommand(program);
+
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'anthropics/skills', url]);
+
+    expect(mockProjectAddSkillRegistry).toHaveBeenCalledWith(
+      'anthropics/skills',
+      url,
+      { force: undefined },
+    );
+  });
+
+  it.each(['bare-slug', 'owner/nested/repo', 'owner/repo.name'])(
+    'rejects invalid registry ID %s',
+    async id => {
+      const program = new Command();
+      registerSkillCommand(program);
+
+      await program.parseAsync(['node', 'test', 'skill', 'add-registry', id, 'opaque-url']);
+
+      expect(ui.error).toHaveBeenCalledWith(expect.stringContaining('Invalid registry ID format'));
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(mockProjectAddSkillRegistry).not.toHaveBeenCalled();
+      expect(mockGlobalAddSkillRegistry).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects a target-scope conflict without calling the setter', async () => {
+    mockProjectGetSkillRegistries.mockResolvedValue({ 'shopback/skills': 'old-url' });
+    const program = new Command();
+    registerSkillCommand(program);
+
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'new-url']);
+
+    expect(ui.error).toHaveBeenCalledWith(
+      'Failed to add registry: Registry "shopback/skills" is already registered with a different URL. Use --force to overwrite it.'
+    );
+    expect(mockProjectAddSkillRegistry).not.toHaveBeenCalled();
+  });
+
+  it('documents add-registry arguments and scope/conflict flags', () => {
+    const program = new Command();
+    registerSkillCommand(program);
+
+    const skillCommand = program.commands.find(command => command.name() === 'skill');
+    const addRegistryCommand = skillCommand?.commands.find(command => command.name() === 'add-registry');
+
+    expect(addRegistryCommand?.usage()).toContain('<id>');
+    expect(addRegistryCommand?.usage()).toContain('<url>');
+    expect(addRegistryCommand?.helpInformation()).toContain('-g, --global');
+    expect(addRegistryCommand?.helpInformation()).toContain('-f, --force');
+    expect(skillCommand?.commands.some(command => command.name() === 'remove-registry')).toBe(false);
+    expect(skillCommand?.commands.some(command => command.name() === 'list-registries')).toBe(false);
   });
 
   it('parses skill add with registry only and forwards undefined skill name', async () => {

--- a/packages/cli/src/__tests__/lib/Config.test.ts
+++ b/packages/cli/src/__tests__/lib/Config.test.ts
@@ -695,6 +695,102 @@ describe('ConfigManager', () => {
     });
   });
 
+  describe('addSkillRegistry', () => {
+    it('adds a registry while preserving existing registry entries', async () => {
+      const config: DevKitConfig = {
+        version: '1.0.0',
+        environments: [],
+        phases: [],
+        registries: { 'existing/skills': 'existing-url' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue(config);
+
+      const result = await configManager.addSkillRegistry('new/skills', 'any string');
+
+      expect(result.registries).toEqual({
+        'existing/skills': 'existing-url',
+        'new/skills': 'any string',
+      });
+      expect(mockFs.writeJson).toHaveBeenCalledWith(
+        '/test/dir/.ai-devkit.json',
+        expect.objectContaining({
+          registries: {
+            'existing/skills': 'existing-url',
+            'new/skills': 'any string',
+          },
+        }),
+        { spaces: 2 }
+      );
+    });
+
+    it('does not rewrite an identically registered URL', async () => {
+      const config: DevKitConfig = {
+        version: '1.0.0',
+        environments: [],
+        phases: [],
+        registries: { 'new/skills': 'any string' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue(config);
+
+      const result = await configManager.addSkillRegistry('new/skills', 'any string');
+
+      expect(result).toBe(config);
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
+    });
+
+    it('rejects a different URL for an existing registry without force', async () => {
+      const config: DevKitConfig = {
+        version: '1.0.0',
+        environments: [],
+        phases: [],
+        registries: { 'new/skills': 'old-url' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue(config);
+
+      await expect(configManager.addSkillRegistry('new/skills', 'new-url')).rejects.toThrow(
+        'Registry "new/skills" is already registered with a different URL. Use --force to overwrite it.'
+      );
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
+    });
+
+    it('overwrites a conflicting URL when force is enabled', async () => {
+      const config: DevKitConfig = {
+        version: '1.0.0',
+        environments: [],
+        phases: [],
+        registries: {
+          'new/skills': 'old-url',
+          'sibling/skills': 'keep-me',
+        },
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue(config);
+
+      const result = await configManager.addSkillRegistry('new/skills', 'new-url', { force: true });
+
+      expect(result.registries).toEqual({
+        'new/skills': 'new-url',
+        'sibling/skills': 'keep-me',
+      });
+    });
+
+    it('rejects registration when the project config is missing', async () => {
+      (mockFs.pathExists as any).mockResolvedValue(false);
+
+      await expect(configManager.addSkillRegistry('new/skills', 'any string')).rejects.toThrow(
+        'Config file not found. Run ai-devkit init first.'
+      );
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getMemoryDbPath', () => {
     it('returns undefined when config does not exist', async () => {
       (mockFs.pathExists as any).mockResolvedValue(false);

--- a/packages/cli/src/__tests__/lib/GlobalConfig.test.ts
+++ b/packages/cli/src/__tests__/lib/GlobalConfig.test.ts
@@ -100,6 +100,80 @@ describe('GlobalConfigManager', () => {
     });
   });
 
+  describe('addSkillRegistry', () => {
+    it('creates a missing global config with the registry', async () => {
+      (mockFs.pathExists as any).mockResolvedValue(false);
+      (mockFs.ensureDir as any).mockResolvedValue(undefined);
+      (mockFs.writeJson as any).mockResolvedValue(undefined);
+
+      const result = await configManager.addSkillRegistry('new/skills', 'any string');
+
+      expect(result).toEqual({ registries: { 'new/skills': 'any string' } });
+      expect(mockFs.writeJson).toHaveBeenCalledWith(
+        '/home/test/.ai-devkit/.ai-devkit.json',
+        { registries: { 'new/skills': 'any string' } },
+        { spaces: 2 }
+      );
+    });
+
+    it('refuses to overwrite a present malformed global config', async () => {
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockRejectedValue(new Error('Invalid JSON'));
+
+      await expect(configManager.addSkillRegistry('new/skills', 'any string')).rejects.toThrow(
+        'Cannot update global config because the existing file could not be read'
+      );
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
+    });
+
+    it('does not rewrite an identically registered global URL', async () => {
+      const config = {
+        plugins: ['@ai-devkit/memory-dashboard'],
+        registries: { 'new/skills': 'any string' },
+      };
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue(config);
+
+      const result = await configManager.addSkillRegistry('new/skills', 'any string');
+
+      expect(result).toBe(config);
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
+    });
+
+    it('rejects a conflicting global URL without force', async () => {
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue({
+        registries: { 'new/skills': 'old-url' },
+      });
+
+      await expect(configManager.addSkillRegistry('new/skills', 'new-url')).rejects.toThrow(
+        'Registry "new/skills" is already registered with a different URL. Use --force to overwrite it.'
+      );
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
+    });
+
+    it('force-overwrites one global URL while preserving other config', async () => {
+      (mockFs.pathExists as any).mockResolvedValue(true);
+      (mockFs.readJson as any).mockResolvedValue({
+        plugins: ['@ai-devkit/memory-dashboard'],
+        registries: {
+          'new/skills': 'old-url',
+          'sibling/skills': 'keep-me',
+        },
+      });
+
+      const result = await configManager.addSkillRegistry('new/skills', 'new-url', { force: true });
+
+      expect(result).toEqual({
+        plugins: ['@ai-devkit/memory-dashboard'],
+        registries: {
+          'new/skills': 'new-url',
+          'sibling/skills': 'keep-me',
+        },
+      });
+    });
+  });
+
   describe('getPlugins', () => {
     it('should return empty list when no config exists', async () => {
       (mockFs.pathExists as any).mockResolvedValue(false);

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -1,11 +1,14 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { ConfigManager } from '../lib/Config.js';
+import { GlobalConfigManager } from '../lib/GlobalConfig.js';
 import { SkillManager } from '../lib/SkillManager.js';
 import { BUILTIN_SKILL_NAMES, BUILTIN_SKILL_REGISTRY } from '../constants.js';
 import { ui } from '../util/terminal-ui.js';
 import { withErrorHandler } from '../util/errors.js';
 import { truncate, getErrorMessage } from '../util/text.js';
+import { validateRegistryId } from '../util/skill.js';
+import { planSkillRegistryAdd } from '../util/skill-registry.js';
 
 export function registerSkillCommand(program: Command): void {
   const skillCommand = program
@@ -56,6 +59,34 @@ export function registerSkillCommand(program: Command): void {
         process.exit(1);
       }
     });
+
+  skillCommand
+    .command('add-registry <id> <url>')
+    .description('Register a third-party skill registry')
+    .option('-g, --global', 'Register in global config (~/.ai-devkit/.ai-devkit.json)')
+    .option('-f, --force', 'Overwrite a conflicting registry URL')
+    .action(withErrorHandler('add registry', async (
+      id: string,
+      url: string,
+      options: { global?: boolean; force?: boolean },
+    ) => {
+      validateRegistryId(id);
+      const configManager = options.global
+        ? new GlobalConfigManager()
+        : new ConfigManager();
+
+      const registries = await configManager.getSkillRegistries();
+      const mutation = planSkillRegistryAdd(registries, id, url, { force: options.force });
+      await configManager.addSkillRegistry(id, url, { force: options.force });
+
+      if (mutation.status === 'already-registered') {
+        ui.info(`Registry "${id}" is already registered.`);
+      } else if (mutation.status === 'updated') {
+        ui.success(`Updated skill registry "${id}".`);
+      } else {
+        ui.success(`Registered skill registry "${id}".`);
+      }
+    }));
 
   skillCommand
     .command('list')

--- a/packages/cli/src/lib/Config.ts
+++ b/packages/cli/src/lib/Config.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { DevKitConfig, Phase, EnvironmentCode, ConfigSkill, DEFAULT_DOCS_DIR, DEFAULT_PHASES } from '../types.js';
 import { filterStringRecord } from '../util/config.js';
 import { ConfigNotFoundError } from '../util/errors.js';
+import { AddSkillRegistryOptions, planSkillRegistryAdd } from '../util/skill-registry.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
 const CONFIG_FILE_NAME = '.ai-devkit.json';
@@ -172,5 +173,20 @@ export class ConfigManager {
   async getSkillRegistries(): Promise<Record<string, string>> {
     const config = await this.read();
     return filterStringRecord(config?.registries);
+  }
+
+  async addSkillRegistry(id: string, url: string, options: AddSkillRegistryOptions = {}): Promise<DevKitConfig> {
+    const config = await this.read();
+    if (!config) {
+      throw new ConfigNotFoundError('Config file not found. Run ai-devkit init first.');
+    }
+
+    const mutation = planSkillRegistryAdd(filterStringRecord(config.registries), id, url, options);
+
+    if (mutation.status === 'already-registered') {
+      return config;
+    }
+
+    return this.update({ registries: mutation.registries });
   }
 }

--- a/packages/cli/src/lib/GlobalConfig.ts
+++ b/packages/cli/src/lib/GlobalConfig.ts
@@ -3,6 +3,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { GlobalDevKitConfig } from '../types.js';
 import { filterStringRecord } from '../util/config.js';
+import { CliError } from '../util/errors.js';
+import { AddSkillRegistryOptions, planSkillRegistryAdd } from '../util/skill-registry.js';
 import { ui } from '../util/terminal-ui.js';
 
 export class GlobalConfigManager {
@@ -27,6 +29,30 @@ export class GlobalConfigManager {
   async getSkillRegistries(): Promise<Record<string, string>> {
     const config = await this.read();
     return filterStringRecord(config?.registries);
+  }
+
+  async addSkillRegistry(id: string, url: string, options: AddSkillRegistryOptions = {}): Promise<GlobalDevKitConfig> {
+    const configExists = await this.exists();
+    const config = await this.read();
+    if (configExists && !config) {
+      throw new CliError(
+        `Cannot update global config because the existing file could not be read: ${this.getGlobalConfigPath()}`,
+        'GLOBAL_CONFIG_UNREADABLE',
+        { configPath: this.getGlobalConfigPath() },
+      );
+    }
+
+    const existingConfig = config ?? {};
+    const registries = filterStringRecord(existingConfig.registries);
+    const mutation = planSkillRegistryAdd(registries, id, url, options);
+    if (mutation.status === 'already-registered') {
+      return existingConfig;
+    }
+
+    return this.write({
+      ...existingConfig,
+      registries: mutation.registries,
+    });
   }
 
   async getPlugins(): Promise<string[]> {

--- a/packages/cli/src/util/skill-registry.ts
+++ b/packages/cli/src/util/skill-registry.ts
@@ -1,0 +1,38 @@
+import { CliError } from './errors.js';
+
+export interface AddSkillRegistryOptions {
+  force?: boolean;
+}
+
+export type SkillRegistryAddStatus = 'added' | 'already-registered' | 'updated';
+
+export interface SkillRegistryMutation {
+  registries: Record<string, string>;
+  status: SkillRegistryAddStatus;
+}
+
+export function planSkillRegistryAdd(
+  registries: Record<string, string>,
+  id: string,
+  url: string,
+  options: AddSkillRegistryOptions = {},
+): SkillRegistryMutation {
+  const existingUrl = registries[id];
+
+  if (existingUrl === url) {
+    return { registries, status: 'already-registered' };
+  }
+
+  if (existingUrl !== undefined && !options.force) {
+    throw new CliError(
+      `Registry "${id}" is already registered with a different URL. Use --force to overwrite it.`,
+      'REGISTRY_CONFLICT',
+      { id, existingUrl, requestedUrl: url },
+    );
+  }
+
+  return {
+    registries: { ...registries, [id]: url },
+    status: existingUrl === undefined ? 'added' : 'updated',
+  };
+}


### PR DESCRIPTION
Summarize scope: single add-registry command with --global and --force flags, no URL validation (accepts any string verbatim), store-first config write (no cache work), idempotent with conflict detection. Honors 4 user decisions. remove-registry/list-registries deferred. Full lifecycle docs + 100% coverage on pure logic.