### PR TITLE
fix(cli): clarify agent console preview formatting

### DIFF
--- a/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
@@ -40,28 +40,28 @@ describe('PreviewPane helpers', () => {
         expect(viewport.rows).toHaveLength(3);
         expect(viewport.rows).toEqual([
             { kind: 'indicator', text: '↑ older', role: null },
-            { kind: 'message', text: 'second question', role: 'user' },
-            { kind: 'message', text: 'second answer', role: 'assistant' },
+            { kind: 'header', text: '', role: 'assistant', timestamp: '2026-07-02T10:00:03Z' },
+            { kind: 'content', text: 'second answer', role: 'assistant' },
         ]);
     });
 
     it('builds a viewport over older conversation content at a positive offset', () => {
-        const viewport = buildPreviewViewport(messages, 3, 3);
+        const viewport = buildPreviewViewport(messages, 3, 10);
 
-        expect(viewport.clampedOffset).toBe(3);
+        expect(viewport.clampedOffset).toBe(10);
         expect(viewport.hasAbove).toBe(false);
         expect(viewport.hasBelow).toBe(true);
         expect(viewport.rows).toHaveLength(3);
         expect(viewport.rows).toEqual([
             { kind: 'indicator', text: '        ↓ newer', role: null },
-            { kind: 'message', text: 'first question', role: 'user' },
-            { kind: 'message', text: 'first answer', role: 'assistant' },
+            { kind: 'header', text: '', role: 'user', timestamp: '2026-07-02T10:00:00Z' },
+            { kind: 'content', text: 'first question', role: 'user' },
         ]);
     });
 
     it('clamps requested offsets to the valid scroll range', () => {
         expect(buildPreviewViewport(messages, 3, -2).clampedOffset).toBe(0);
-        expect(buildPreviewViewport(messages, 3, 99).clampedOffset).toBe(3);
+        expect(buildPreviewViewport(messages, 3, 99).clampedOffset).toBe(10);
     });
 
     it('keeps the rendered body inside the viewport budget when overflow affordances are shown', () => {
@@ -70,22 +70,27 @@ describe('PreviewPane helpers', () => {
         expect(viewport.hasAbove).toBe(true);
         expect(viewport.hasBelow).toBe(true);
         expect(viewport.rows).toHaveLength(4);
-        expect(viewport.rows[0]).toEqual({ kind: 'indicator', text: '↑ older ↓ newer', role: null });
+        expect(viewport.rows[0]).toEqual({
+            kind: 'indicator',
+            text: '↑ older · user continued ↓ newer',
+            role: null,
+        });
     });
 
-    it('keeps role metadata separate from multiline message content', () => {
+    it('builds a structured block for multiline message content', () => {
         const viewport = buildPreviewViewport([
             { role: 'assistant', content: 'Summary\n\n- first item', timestamp: '2026-07-02T10:00:00Z' },
-        ], 4, 0);
+        ], 6, 0);
 
         expect(viewport.rows).toEqual([
-            { kind: 'message', text: 'Summary', role: 'assistant' },
-            { kind: 'message', text: '', role: null },
-            { kind: 'message', text: '- first item', role: null },
+            { kind: 'header', text: '', role: 'assistant', timestamp: '2026-07-02T10:00:00Z' },
+            { kind: 'content', text: 'Summary', role: 'assistant' },
+            { kind: 'content', text: '', role: 'assistant' },
+            { kind: 'content', text: '- first item', role: 'assistant' },
         ]);
     });
 
-    it('renders roles in a fixed gutter and message content in a neutral column', () => {
+    it('renders conversation turns using the agent detail format', () => {
         const agent = {
             name: 'preview-test',
             type: 'codex',
@@ -104,9 +109,9 @@ describe('PreviewPane helpers', () => {
             maxLines: 8,
         }), { columns: 80 }));
 
-        expect(output).toContain('user      │ first question');
-        expect(output).toContain('assistant │ first answer\n          │ with detail');
+        expect(output).toContain('user:\n  first question\n\nassistant:\n  first answer\n  with detail');
         expect(output).not.toContain('assistant: first answer');
+        expect(output).not.toContain('assistant │ first answer');
     });
 
     it('adjusts positive scroll offsets by newly appended rendered rows', () => {

--- a/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToString } from 'ink';
+import { stripVTControlCharacters } from 'node:util';
 import {
     adjustPreviewScrollOffsetForAppendedRows,
     buildPreviewViewport,
     getPreviewPanelTone,
     getPreviewChannelStatusText,
+    PreviewPane,
 } from '../../../tui/console/PreviewPane.js';
-import type { ConversationMessage } from '@ai-devkit/agent-manager';
+import { AgentStatus, type AgentInfo, type ConversationMessage } from '@ai-devkit/agent-manager';
 
 const messages: ConversationMessage[] = [
     { role: 'user', content: 'first question', timestamp: '2026-07-02T10:00:00Z' },
@@ -35,9 +39,9 @@ describe('PreviewPane helpers', () => {
         expect(viewport.hasBelow).toBe(false);
         expect(viewport.rows).toHaveLength(3);
         expect(viewport.rows).toEqual([
-            { text: '↑ older', role: null },
-            { text: 'user: second question', role: 'user' },
-            { text: 'assistant: second answer', role: 'assistant' },
+            { kind: 'indicator', text: '↑ older', role: null },
+            { kind: 'message', text: 'second question', role: 'user' },
+            { kind: 'message', text: 'second answer', role: 'assistant' },
         ]);
     });
 
@@ -49,9 +53,9 @@ describe('PreviewPane helpers', () => {
         expect(viewport.hasBelow).toBe(true);
         expect(viewport.rows).toHaveLength(3);
         expect(viewport.rows).toEqual([
-            { text: '        ↓ newer', role: null },
-            { text: 'user: first question', role: 'user' },
-            { text: 'assistant: first answer', role: 'assistant' },
+            { kind: 'indicator', text: '        ↓ newer', role: null },
+            { kind: 'message', text: 'first question', role: 'user' },
+            { kind: 'message', text: 'first answer', role: 'assistant' },
         ]);
     });
 
@@ -66,7 +70,43 @@ describe('PreviewPane helpers', () => {
         expect(viewport.hasAbove).toBe(true);
         expect(viewport.hasBelow).toBe(true);
         expect(viewport.rows).toHaveLength(4);
-        expect(viewport.rows[0]).toEqual({ text: '↑ older ↓ newer', role: null });
+        expect(viewport.rows[0]).toEqual({ kind: 'indicator', text: '↑ older ↓ newer', role: null });
+    });
+
+    it('keeps role metadata separate from multiline message content', () => {
+        const viewport = buildPreviewViewport([
+            { role: 'assistant', content: 'Summary\n\n- first item', timestamp: '2026-07-02T10:00:00Z' },
+        ], 4, 0);
+
+        expect(viewport.rows).toEqual([
+            { kind: 'message', text: 'Summary', role: 'assistant' },
+            { kind: 'message', text: '', role: null },
+            { kind: 'message', text: '- first item', role: null },
+        ]);
+    });
+
+    it('renders roles in a fixed gutter and message content in a neutral column', () => {
+        const agent = {
+            name: 'preview-test',
+            type: 'codex',
+            status: AgentStatus.RUNNING,
+            projectPath: '/tmp/project',
+            lastActive: new Date(),
+        } as AgentInfo;
+        const output = stripVTControlCharacters(renderToString(React.createElement(PreviewPane, {
+            agent,
+            messages: [
+                { role: 'user', content: 'first question' },
+                { role: 'assistant', content: 'first answer\nwith detail' },
+            ],
+            error: null,
+            isLoading: false,
+            maxLines: 8,
+        }), { columns: 80 }));
+
+        expect(output).toContain('user      │ first question');
+        expect(output).toContain('assistant │ first answer\n          │ with detail');
+        expect(output).not.toContain('assistant: first answer');
     });
 
     it('adjusts positive scroll offsets by newly appended rendered rows', () => {

--- a/packages/cli/src/__tests__/tui/console/computeLayout.test.ts
+++ b/packages/cli/src/__tests__/tui/console/computeLayout.test.ts
@@ -1,12 +1,26 @@
 import { describe, it, expect } from 'vitest';
-// computeLayout is a pure function exported from ConsoleApp — import only the function,
-// not the React component tree, to avoid JSX in the test environment.
-import { computeCenteredDialog, computeLayout } from '../../../tui/console/ConsoleApp.js';
+// Import pure console configuration helpers without rendering the component tree.
+import {
+    AGENT_CONSOLE_RENDER_OPTIONS,
+    computeCenteredDialog,
+    computeLayout,
+} from '../../../tui/console/ConsoleApp.js';
 
 // Constants mirrored from ConsoleApp.tsx for assertions
 const LIST_PANE_WIDTH = 48;
 const MIN_CONTENT_HEIGHT = 12;
 const INPUT_BOX_CHROME_ROWS = 2;
+
+describe('agent console render options', () => {
+    it('uses incremental 60 FPS rendering for responsive scrolling', () => {
+        expect(AGENT_CONSOLE_RENDER_OPTIONS).toEqual({
+            alternateScreen: true,
+            exitOnCtrlC: true,
+            incrementalRendering: true,
+            maxFps: 60,
+        });
+    });
+});
 
 describe('computeLayout', () => {
     describe('wide mode (narrow=false)', () => {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -54,7 +54,7 @@ import {
     createDefaultAgentGroupService,
 } from '../services/agent/agent-group.service.js';
 import { registerAgentGroupCommand } from './agent/group.command.js';
-import { ConsoleApp } from '../tui/console/ConsoleApp.js';
+import { AGENT_CONSOLE_RENDER_OPTIONS, ConsoleApp } from '../tui/console/ConsoleApp.js';
 import { generateAgentName } from '../util/agent.js';
 import { select } from '@inquirer/prompts';
 
@@ -842,7 +842,7 @@ export function registerAgentCommand(program: Command): void {
             const manager = createAgentManager();
             const { waitUntilExit } = render(
                 createElement(ConsoleApp, { manager }),
-                { alternateScreen: true, exitOnCtrlC: true },
+                AGENT_CONSOLE_RENDER_OPTIONS,
             );
             await waitUntilExit();
         }));

--- a/packages/cli/src/tui/console/ConsoleApp.tsx
+++ b/packages/cli/src/tui/console/ConsoleApp.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { Box, useApp, useInput } from 'ink';
+import { Box, useApp, useInput, type RenderOptions } from 'ink';
 import type { AgentManager } from '@ai-devkit/agent-manager';
 import { ConsoleProvider, useConsoleContext } from './state/ConsoleContext.js';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
@@ -35,6 +35,13 @@ const FOOTER_HEIGHT = 2;
 const HEADER_HEIGHT = 1;
 const MIN_CONTENT_HEIGHT = 12;
 const INPUT_BOX_CHROME_ROWS = 2;
+
+export const AGENT_CONSOLE_RENDER_OPTIONS: RenderOptions = {
+    alternateScreen: true,
+    exitOnCtrlC: true,
+    incrementalRendering: true,
+    maxFps: 60,
+};
 
 export function computeCenteredDialog(cols: number, rows: number) {
     const width = Math.min(56, Math.max(24, cols - 6));

--- a/packages/cli/src/tui/console/PreviewPane.tsx
+++ b/packages/cli/src/tui/console/PreviewPane.tsx
@@ -33,6 +33,7 @@ function shortPath(p: string): string {
 }
 
 export interface PreviewViewportRow {
+    kind: 'message' | 'indicator';
     text: string;
     role: ConversationMessage['role'] | null;
 }
@@ -64,12 +65,12 @@ export function buildPreviewViewport(
     requestedOffset: number,
 ): PreviewViewport {
     const budget = Math.max(1, Math.floor(maxLines));
-    const rows = messages.flatMap((msg) => {
+    const rows = messages.flatMap<PreviewViewportRow>((msg) => {
         const contentLines = msg.content.split('\n');
         const first = contentLines[0] ?? '';
         return [
-            { text: `${msg.role}: ${first}`, role: msg.role },
-            ...contentLines.slice(1).map(line => ({ text: `  ${line}`, role: null })),
+            { kind: 'message', text: first, role: msg.role },
+            ...contentLines.slice(1).map<PreviewViewportRow>(line => ({ kind: 'message', text: line, role: null })),
         ];
     });
     const contentBudget = rows.length > budget ? Math.max(1, budget - 1) : budget;
@@ -79,8 +80,8 @@ export function buildPreviewViewport(
     const start = Math.max(0, end - contentBudget);
     const hasAbove = start > 0;
     const hasBelow = end < rows.length;
-    const indicator = hasAbove || hasBelow
-        ? [{ text: `${hasAbove ? '↑ older' : '       '}${hasBelow ? ' ↓ newer' : ''}`, role: null }]
+    const indicator: PreviewViewportRow[] = hasAbove || hasBelow
+        ? [{ kind: 'indicator', text: `${hasAbove ? '↑ older' : '       '}${hasBelow ? ' ↓ newer' : ''}`, role: null }]
         : [];
     return {
         rows: [...indicator, ...rows.slice(start, end)],
@@ -176,9 +177,23 @@ const PreviewPaneInner: React.FC<PreviewPaneProps> = ({
         body = (
             <>
                 {viewport?.rows.map((row, idx) => (
-                    <Box key={idx}>
-                        <Text color={row.role ? ROLE_COLOR[row.role] : undefined}>{row.text}</Text>
-                    </Box>
+                    row.kind === 'indicator' ? (
+                        <Box key={idx}>
+                            <Text dimColor>{row.text}</Text>
+                        </Box>
+                    ) : (
+                        <Box key={idx}>
+                            <Box width={10} flexShrink={0}>
+                                <Text color={row.role ? ROLE_COLOR[row.role] : undefined} bold={row.role !== null}>
+                                    {row.role ?? ''}
+                                </Text>
+                            </Box>
+                            <Text dimColor>│ </Text>
+                            <Box flexGrow={1}>
+                                <Text>{row.text || ' '}</Text>
+                            </Box>
+                        </Box>
+                    )
                 ))}
             </>
         );

--- a/packages/cli/src/tui/console/PreviewPane.tsx
+++ b/packages/cli/src/tui/console/PreviewPane.tsx
@@ -25,7 +25,6 @@ const ROLE_COLOR: Record<ConversationMessage['role'], 'green' | 'cyan' | 'yellow
     system: TUI_COLORS.warning,
 };
 
-
 function shortPath(p: string): string {
     const home = process.env.HOME ?? '';
     if (home && p.startsWith(home)) return '~' + p.slice(home.length);
@@ -33,9 +32,10 @@ function shortPath(p: string): string {
 }
 
 export interface PreviewViewportRow {
-    kind: 'message' | 'indicator';
+    kind: 'header' | 'content' | 'separator' | 'indicator';
     text: string;
     role: ConversationMessage['role'] | null;
+    timestamp?: string;
 }
 
 export interface PreviewViewport {
@@ -47,7 +47,10 @@ export interface PreviewViewport {
 }
 
 export function countPreviewRows(messages: ConversationMessage[]): number {
-    return messages.reduce((total, msg) => total + Math.max(1, msg.content.split('\n').length), 0);
+    return messages.reduce(
+        (total, msg, index) => total + Math.max(1, msg.content.split('\n').length) + 1 + (index > 0 ? 1 : 0),
+        0,
+    );
 }
 
 export function adjustPreviewScrollOffsetForAppendedRows(
@@ -65,12 +68,12 @@ export function buildPreviewViewport(
     requestedOffset: number,
 ): PreviewViewport {
     const budget = Math.max(1, Math.floor(maxLines));
-    const rows = messages.flatMap<PreviewViewportRow>((msg) => {
+    const rows = messages.flatMap<PreviewViewportRow>((msg, index) => {
         const contentLines = msg.content.split('\n');
-        const first = contentLines[0] ?? '';
         return [
-            { kind: 'message', text: first, role: msg.role },
-            ...contentLines.slice(1).map<PreviewViewportRow>(line => ({ kind: 'message', text: line, role: null })),
+            ...(index > 0 ? [{ kind: 'separator' as const, text: '', role: null }] : []),
+            { kind: 'header', text: '', role: msg.role, timestamp: msg.timestamp },
+            ...contentLines.map<PreviewViewportRow>(line => ({ kind: 'content', text: line, role: msg.role })),
         ];
     });
     const contentBudget = rows.length > budget ? Math.max(1, budget - 1) : budget;
@@ -80,8 +83,16 @@ export function buildPreviewViewport(
     const start = Math.max(0, end - contentBudget);
     const hasAbove = start > 0;
     const hasBelow = end < rows.length;
+    const firstVisible = rows[start];
+    const continuation = hasAbove && firstVisible?.kind === 'content' && firstVisible.role
+        ? ` · ${firstVisible.role} continued`
+        : '';
     const indicator: PreviewViewportRow[] = hasAbove || hasBelow
-        ? [{ kind: 'indicator', text: `${hasAbove ? '↑ older' : '       '}${hasBelow ? ' ↓ newer' : ''}`, role: null }]
+        ? [{
+            kind: 'indicator',
+            text: `${hasAbove ? '↑ older' : '       '}${continuation}${hasBelow ? ' ↓ newer' : ''}`,
+            role: null,
+        }]
         : [];
     return {
         rows: [...indicator, ...rows.slice(start, end)],
@@ -181,14 +192,18 @@ const PreviewPaneInner: React.FC<PreviewPaneProps> = ({
                         <Box key={idx}>
                             <Text dimColor>{row.text}</Text>
                         </Box>
+                    ) : row.kind === 'header' && row.role ? (
+                        <Box key={idx}>
+                            {row.timestamp ? <Text dimColor>[{new Date(row.timestamp).toLocaleTimeString()}] </Text> : null}
+                            <Text color={ROLE_COLOR[row.role]} bold>{row.role}:</Text>
+                        </Box>
+                    ) : row.kind === 'separator' ? (
+                        <Box key={idx}>
+                            <Text> </Text>
+                        </Box>
                     ) : (
                         <Box key={idx}>
-                            <Box width={10} flexShrink={0}>
-                                <Text color={row.role ? ROLE_COLOR[row.role] : undefined} bold={row.role !== null}>
-                                    {row.role ?? ''}
-                                </Text>
-                            </Box>
-                            <Text dimColor>│ </Text>
+                            <Text>  </Text>
                             <Box flexGrow={1}>
                                 <Text>{row.text || ' '}</Text>
                             </Box>


### PR DESCRIPTION
## Summary
- format preview turns consistently with `ai-devkit agent detail`
- show timestamped, colored role headers with neutral indented message bodies
- preserve blank lines and Markdown structure while clearly separating turns
- identify the speaker when scrolling begins inside a continued message
- enable Ink incremental rendering at 60 FPS for responsive preview scrolling
- add viewport, render-policy, and ANSI-safe Ink regression coverage

## Performance
- viewport construction: about 0.041 ms per call for 20 messages with 80 lines each
- synthetic 40-row rapid-update benchmark: terminal output reduced from 49,793 bytes to 5,793 bytes (88% reduction)
- wide PTY smoke test confirmed changed-line updates without layout corruption

## Validation
- `npm test --workspace ai-devkit -- --run src/__tests__/tui/console` (125 tests passed)
- `npm run build --workspace ai-devkit`
- full pre-commit `nx run-many -t lint` and `nx run-many -t test` (957 tests passed)

## Risks
- Message headers and separators consume additional preview rows, trading density for scanability and consistency with `agent detail`.
- Incremental rendering relies on Ink 7 terminal cursor updates; verified in the alternate-screen PTY smoke test.
- Existing unrelated lint warnings remain unchanged.