### PR TITLE
feat(cli): filter agents by name in console

### DIFF
--- a/docs/ai/design/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/design/2026-08-16-feature-agent-list-filter.md
@@ -1,0 +1,63 @@
+---
+phase: design
+title: Agent Name Filter Design
+description: Architecture for inline console agent filtering
+---
+
+# Agent Name Filter Design
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+    Source[useAgentList ordered agents] --> Shell[ConsoleAppShell filter state]
+    Shell --> Pure[filterAgents / match positions]
+    Pure --> Visible[visibleAgents]
+    Visible --> Nav[selection and j/k routing]
+    Visible --> Pane[AgentListPane rendering and scroll]
+    Shell --> Pause[ConsoleProvider text-entry/poll pause]
+    Routing[consoleKeyRouting] --> Shell
+```
+
+`ConsoleAppShell` owns `{ text, editing }`, derives `visibleAgents` from the ordered source, and supplies that same array to selection, navigation, preview coherence, and `AgentListPane`. Filter editing is routed before global/list commands. The provider receives a generalized interaction-active signal so polling is paused for message composition or a filter session.
+
+## Data Models
+
+- `AgentFilterState = { text: string; editing: boolean }`; the shape is an extension seam, not an invitation to add other dimensions now.
+- `visibleAgents = filterAgents(agents, filter.text)`; input order is preserved.
+- `findMatchPositions(name, query): number[] | null` returns flat `[start, end, ...]` ranges for every non-overlapping matched occurrence; empty query returns `[]`, no match returns `null`.
+- Filter session/poll pause: `editing || text.length > 0`.
+
+## API Design
+
+- `matchAgentByName(name, query): boolean`
+- `findMatchPositions(name, query): number[] | null`
+- `filterAgents(agents, query): AgentInfo[]`
+- `resolveConsoleKeyAction` accepts filter state and can return open, confirm/clear-related actions while preserving current focus actions.
+- `AgentListPane` receives the already-filtered agents plus total count, query, and editing state; it does not reorder agents.
+
+No external API, authentication, storage, or new dependency is introduced.
+
+## Component Breakdown
+
+- `filter/agentFilter.ts`: pure case-insensitive substring logic.
+- `ConsoleApp.tsx`: owns state; derives visible agents; validates selection; routes shortcuts; resumes with immediate refresh after Esc-clear.
+- `consoleKeyRouting.ts`: intercepts filter editing before normal list/global actions so printable keys reach `TextInput`.
+- `AgentListPane.tsx`: renders the input/confirmed chip, counts, empty result, highlighted clipped names, filtered scroll clamping, and filtered more indicators.
+- `ConsoleContext.tsx`: pauses agent/channel polling for any active text-entry/filter session.
+- Footer/key hints: advertises `/ filter` only in the relevant list state and explains clear behavior when active.
+
+## Design Decisions
+
+- Substring matching is chosen for deterministic behavior and minimum complexity; fuzzy/subsequence and ranking are rejected.
+- Parent-owned filter state prevents list, preview, and navigation from observing different arrays.
+- A frozen filtered snapshot prevents polling-induced row movement; Esc both clears and immediately refreshes.
+- Confirmed `/` is a no-op and editing `/` is literal, avoiding implicit destructive query replacement.
+- Filtering composes over source order and contains no pin-specific logic.
+
+## Non-Functional Requirements
+
+- Filtering is linear in agent/name size and runs in-process.
+- New pure logic and routing branches require 100% statement/branch/function/line coverage.
+- Name clipping counts every rendered character while preserving highlight spans and existing row chrome/channel widths.
+- Existing error handling and console shortcuts remain reliable; filter text is local ephemeral UI state and creates no security boundary.

--- a/docs/ai/design/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/design/2026-08-16-feature-agent-list-filter.md
@@ -19,11 +19,11 @@ flowchart LR
     Routing[consoleKeyRouting] --> Shell
 ```
 
-`ConsoleAppShell` owns `{ text, editing }`, derives `visibleAgents` from the ordered source, and supplies that same array to selection, navigation, preview coherence, and `AgentListPane`. Filter editing is routed before global/list commands. The provider receives a generalized interaction-active signal so polling is paused for message composition or a filter session.
+`ConsoleAppShell` owns the query and a `'filter'` focus sub-state, derives `visibleAgents` from the ordered source, and supplies that same array to selection, navigation, preview coherence, and `AgentListPane`. Filter editing is intercepted before global/list commands. The provider receives a generalized text-entry-active signal so polling is paused for message composition or a filter session.
 
 ## Data Models
 
-- `AgentFilterState = { text: string; editing: boolean }`; the shape is an extension seam, not an invitation to add other dimensions now.
+- `AgentFilterState = { text: string }`; `ConsoleFocus` adds `'filter'` for editing. The object shape is an extension seam, not an invitation to add other dimensions now.
 - `visibleAgents = filterAgents(agents, filter.text)`; input order is preserved.
 - `findMatchPositions(name, query): number[] | null` returns flat `[start, end, ...]` ranges for every non-overlapping matched occurrence; empty query returns `[]`, no match returns `null`.
 - Filter session/poll pause: `editing || text.length > 0`.
@@ -33,7 +33,7 @@ flowchart LR
 - `matchAgentByName(name, query): boolean`
 - `findMatchPositions(name, query): number[] | null`
 - `filterAgents(agents, query): AgentInfo[]`
-- `resolveConsoleKeyAction` accepts filter state and can return open, confirm/clear-related actions while preserving current focus actions.
+- `resolveConsoleKeyAction` receives `filterActive`, returns `open-filter` only for `/` in list focus without an active query, and returns `clear-filter` for Esc in list focus with an active query. `'filter'` focus returns `noop`; the controlled input owns printable text, Enter, and Esc.
 - `AgentListPane` receives the already-filtered agents plus total count, query, and editing state; it does not reorder agents.
 
 No external API, authentication, storage, or new dependency is introduced.
@@ -41,8 +41,8 @@ No external API, authentication, storage, or new dependency is introduced.
 ## Component Breakdown
 
 - `filter/agentFilter.ts`: pure case-insensitive substring logic.
-- `ConsoleApp.tsx`: owns state; derives visible agents; validates selection; routes shortcuts; resumes with immediate refresh after Esc-clear.
-- `consoleKeyRouting.ts`: intercepts filter editing before normal list/global actions so printable keys reach `TextInput`.
+- `ConsoleApp.tsx`: owns state; derives visible agents; validates selection; intercepts `'filter'` before global shortcuts; resumes with immediate refresh after Esc-clear.
+- `consoleKeyRouting.ts`: exposes tested open/clear/no-op transitions while preserving list/detail/input actions.
 - `AgentListPane.tsx`: renders the input/confirmed chip, counts, empty result, highlighted clipped names, filtered scroll clamping, and filtered more indicators.
 - `ConsoleContext.tsx`: pauses agent/channel polling for any active text-entry/filter session.
 - Footer/key hints: advertises `/ filter` only in the relevant list state and explains clear behavior when active.
@@ -61,3 +61,7 @@ No external API, authentication, storage, or new dependency is introduced.
 - New pure logic and routing branches require 100% statement/branch/function/line coverage.
 - Name clipping counts every rendered character while preserving highlight spans and existing row chrome/channel widths.
 - Existing error handling and console shortcuts remain reliable; filter text is local ephemeral UI state and creates no security boundary.
+
+## Design Review
+
+Reviewed 2026-08-16 against every requirement and the current console implementation. Parent ownership covers selection, navigation, preview, footer, and polling; the dedicated focus state plus pre-global interception guarantees command characters remain text. Alternatives rejected are pane-local state (incoherent consumers), a modal (hides incremental results), and always-on entry (shortcut ambiguity). The incoming array remains the only ordering authority, so parallel pin behavior composes without feature coupling. No design gaps remain.

--- a/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
@@ -1,0 +1,65 @@
+---
+phase: implementation
+title: Implementation Guide
+description: Technical implementation notes, patterns, and code guidelines
+---
+
+# Implementation Guide
+
+## Development Setup
+**How do we get started?**
+
+- Prerequisites and dependencies
+- Environment setup steps
+- Configuration needed
+
+## Code Structure
+**How is the code organized?**
+
+- Directory structure
+- Module organization
+- Naming conventions
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Core Features
+- Feature 1: Implementation approach
+- Feature 2: Implementation approach
+- Feature 3: Implementation approach
+
+### Patterns & Best Practices
+- Design patterns being used
+- Code style guidelines
+- Common utilities/helpers
+
+## Integration Points
+**How do pieces connect?**
+
+- API integration details
+- Database connections
+- Third-party service setup
+
+## Error Handling
+**How do we handle failures?**
+
+- Error handling strategy
+- Logging approach
+- Retry/fallback mechanisms
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- Optimization strategies
+- Caching approach
+- Query optimization
+- Resource management
+
+## Security Notes
+**What security measures are in place?**
+
+- Authentication/authorization
+- Input validation
+- Data encryption
+- Secrets management
+

--- a/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
@@ -4,62 +4,51 @@ title: Implementation Guide
 description: Technical implementation notes, patterns, and code guidelines
 ---
 
-# Implementation Guide
+# Agent Name Filter Implementation
 
 ## Development Setup
 **How do we get started?**
 
-- Prerequisites and dependencies
-- Environment setup steps
-- Configuration needed
+- Use the repository Node/npm workspace with existing dependencies.
+- Run focused Vitest from the repository root and CLI lint/build through the package scripts.
+- No configuration, migration, or new dependency is required.
 
 ## Code Structure
 **How is the code organized?**
 
-- Directory structure
-- Module organization
-- Naming conventions
+- `packages/cli/src/tui/console/filter/agentFilter.ts`: pure name-filter operations.
+- `packages/cli/src/__tests__/tui/console/filter/agentFilter.test.ts`: behavior and coverage contract.
+- Console integration and component files will be recorded as their tasks complete.
 
 ## Implementation Notes
 **Key technical details to remember:**
 
 ### Core Features
-- Feature 1: Implementation approach
-- Feature 2: Implementation approach
-- Feature 3: Implementation approach
+
+- Task 1.1: case-insensitive substring matching uses plain `toLowerCase()`, returns every non-overlapping occurrence range, preserves arbitrary input order, and returns the original array for an empty query.
 
 ### Patterns & Best Practices
-- Design patterns being used
-- Code style guidelines
-- Common utilities/helpers
+- Keep matching pure and dependency-free.
+- Treat the received agent order as authoritative; never sort or partition.
+- Drive each behavior through a failing focused test before production code.
 
 ## Integration Points
 **How do pieces connect?**
 
-- API integration details
-- Database connections
-- Third-party service setup
+- The filter module consumes `AgentInfo[]` and is ready for `ConsoleAppShell` composition.
+- No database, external API, or third-party integration is involved.
 
 ## Error Handling
 **How do we handle failures?**
 
-- Error handling strategy
-- Logging approach
-- Retry/fallback mechanisms
+- No exceptions or logging are introduced. A non-match is represented as `null` positions or an omitted agent.
 
 ## Performance Considerations
 **How do we keep it fast?**
 
-- Optimization strategies
-- Caching approach
-- Query optimization
-- Resource management
+- Matching is linear over the received array and names. Empty query avoids allocation by returning the input array.
 
 ## Security Notes
 **What security measures are in place?**
 
-- Authentication/authorization
-- Input validation
-- Data encryption
-- Secrets management
-
+- Query text is ephemeral local UI state and is not executed or persisted. No authentication, encryption, or secret handling changes.

--- a/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
@@ -26,6 +26,7 @@ description: Technical implementation notes, patterns, and code guidelines
 ### Core Features
 
 - Task 1.1: case-insensitive substring matching uses plain `toLowerCase()`, returns every non-overlapping occurrence range, preserves arbitrary input order, and returns the original array for an empty query.
+- Task 1.2: `ConsoleFocus` includes `'filter'`; the pure router opens only from an unfiltered list, clears only an active list filter on Esc, treats confirmed `/` as a no-op, and leaves filter-focus keystrokes to the controlled input.
 
 ### Patterns & Best Practices
 - Keep matching pure and dependency-free.

--- a/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/implementation/2026-08-16-feature-agent-list-filter.md
@@ -18,7 +18,10 @@ description: Technical implementation notes, patterns, and code guidelines
 
 - `packages/cli/src/tui/console/filter/agentFilter.ts`: pure name-filter operations.
 - `packages/cli/src/__tests__/tui/console/filter/agentFilter.test.ts`: behavior and coverage contract.
-- Console integration and component files will be recorded as their tasks complete.
+- `packages/cli/src/tui/console/ConsoleApp.tsx`: owns query/focus state, derives the visible ordered array, keeps selection coherent, routes navigation, and drives immediate refresh on clear.
+- `packages/cli/src/tui/console/AgentListPane.tsx`: renders inline editing/confirmed state, counts, no-match messaging, highlights, remote markers, and clamped filtered scrolling.
+- `packages/cli/src/tui/console/state/ConsoleContext.tsx`: pauses agent and channel polling for message entry or a filter session.
+- `packages/cli/src/tui/console/HelpPane.tsx` and `StatusFooter.tsx`: advertise `/ filter` normally and `Esc clear filter` during a session.
 
 ## Implementation Notes
 **Key technical details to remember:**
@@ -27,6 +30,9 @@ description: Technical implementation notes, patterns, and code guidelines
 
 - Task 1.1: case-insensitive substring matching uses plain `toLowerCase()`, returns every non-overlapping occurrence range, preserves arbitrary input order, and returns the original array for an empty query.
 - Task 1.2: `ConsoleFocus` includes `'filter'`; the pure router opens only from an unfiltered list, clears only an active list filter on Esc, treats confirmed `/` as a no-op, and leaves filter-focus keystrokes to the controlled input.
+- Task 2.1: the shell derives `visibleAgents` with `filterAgents`, uses it for selection and navigation, pauses both polling subscriptions while editing or applied, and clears with an immediate `refresh()`.
+- Task 2.2: the list renders `(matched/total)`, a live `TextInput`, a confirmed indicator, all visible match spans in bold, filtered empty state, channel markers, and scroll clamping based on the filtered length.
+- Task 2.3: help includes `/` and the footer suppresses command hints in favor of `Esc clear filter` for the whole session.
 
 ### Patterns & Best Practices
 - Keep matching pure and dependency-free.
@@ -36,7 +42,8 @@ description: Technical implementation notes, patterns, and code guidelines
 ## Integration Points
 **How do pieces connect?**
 
-- The filter module consumes `AgentInfo[]` and is ready for `ConsoleAppShell` composition.
+- The filter module consumes `AgentInfo[]`; `ConsoleAppShell` composes it over the received order without sorting or pin-specific logic.
+- Selection and navigation share `visibleAgents`; preview resolution continues through the selected name against the frozen source snapshot.
 - No database, external API, or third-party integration is involved.
 
 ## Error Handling
@@ -53,3 +60,13 @@ description: Technical implementation notes, patterns, and code guidelines
 **What security measures are in place?**
 
 - Query text is ephemeral local UI state and is not executed or persisted. No authentication, encryption, or secret handling changes.
+
+## Validation
+
+- Focused integration/unit suite: 6 files, 35 tests passed.
+- Pure filter coverage: 100% statements, branches, functions, and lines.
+- Key-routing coverage: 100% statements, branches, functions, and lines.
+- CLI suite: 83 files, 1001 tests passed.
+- CLI lint: exit 0 with five pre-existing unused-catch warnings outside this feature.
+- CLI build: SWC and TypeScript declaration generation completed successfully.
+- Feature docs lint: all configured docs and worktree checks passed.

--- a/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
@@ -1,0 +1,60 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+**What are the major checkpoints?**
+
+- [ ] Milestone 1: [Description]
+- [ ] Milestone 2: [Description]
+- [ ] Milestone 3: [Description]
+
+## Task Breakdown
+**What specific work needs to be done?**
+
+### Phase 1: Foundation
+- [ ] Task 1.1: [Description]
+- [ ] Task 1.2: [Description]
+
+### Phase 2: Core Features
+- [ ] Task 2.1: [Description]
+- [ ] Task 2.2: [Description]
+
+### Phase 3: Integration & Polish
+- [ ] Task 3.1: [Description]
+- [ ] Task 3.2: [Description]
+
+## Dependencies
+**What needs to happen in what order?**
+
+- Task dependencies and blockers
+- External dependencies (APIs, services, etc.)
+- Team/resource dependencies
+
+## Timeline & Estimates
+**When will things be done?**
+
+- Estimated effort per task/phase
+- Target dates for milestones
+- Buffer for unknowns
+
+## Risks & Mitigation
+**What could go wrong?**
+
+- Technical risks
+- Resource risks
+- Dependency risks
+- Mitigation strategies
+
+## Resources Needed
+**What do we need to succeed?**
+
+- Team members and roles
+- Tools and services
+- Infrastructure
+- Documentation/knowledge
+

--- a/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
@@ -16,7 +16,7 @@ description: Ordered TDD tasks for inline console name filtering
 
 ### Phase 1: Foundation
 
-- [ ] Task 1.1 — Pure filter logic (TDD)
+- [x] Task 1.1 — Pure filter logic (TDD)
   - Outcome: add `matchAgentByName`, `findMatchPositions`, and `filterAgents` with substring-only semantics, basic Unicode folding, all-occurrence positions, identity-on-empty, and preserved order.
   - Dependencies: none; no new packages.
   - Evidence: focused failing-then-passing unit tests and 100% module coverage.
@@ -85,4 +85,4 @@ Existing React/Ink, `ink-text-input`, Vitest, console fixtures, lifecycle docs, 
 
 ## Progress Summary
 
-Initial plan approved by the binding feature brief. Next: execute Task 1.1 with TDD, reconcile this checklist, then continue in dependency order.
+Task 1.1 is complete with focused tests and 100% pure-module coverage. Next: execute Task 1.2 with TDD, then continue in dependency order. No scope changes or blockers were discovered.

--- a/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
@@ -10,7 +10,7 @@ description: Ordered TDD tasks for inline console name filtering
 
 - [x] Milestone 1: Pure substring semantics and key-state transitions are test-driven and complete.
 - [x] Milestone 2: Console state, polling, navigation, and list rendering integrate over one ordered filtered array.
-- [ ] Milestone 3: Edge-case coverage, docs, lint, full tests, and review are complete.
+- [x] Milestone 3: Edge-case coverage, docs, lint, full tests, and review are complete.
 
 ## Task Breakdown
 
@@ -54,7 +54,7 @@ description: Ordered TDD tasks for inline console name filtering
   - Outcome: focused coverage, CLI lint/build/test, repository-appropriate regression suite, and manual rendering smoke checks pass.
   - Dependencies: Task 3.1.
   - Evidence: fresh command output recorded in testing/implementation docs.
-- [ ] Task 3.3 — Final review and publication
+- [x] Task 3.3 — Final review and publication
   - Outcome: holistic review finds no blockers; commits are scoped; branch is pushed and PR is merged-ready.
   - Dependencies: Task 3.2.
   - Evidence: clean status, reviewed commit range, PR checks, and feature lint.
@@ -85,4 +85,4 @@ Existing React/Ink, `ink-text-input`, Vitest, console fixtures, lifecycle docs, 
 
 ## Progress Summary
 
-Tasks 1.1–3.2 are complete. The shell owns one substring-filtered ordered array for selection, navigation, preview, and rendering; provider polling pauses throughout editing and confirmed-filter states; list/footer/help rendering and edge cases are covered. Fresh focused coverage is 100% for matcher and routing, 35 focused tests pass, and the full CLI test/lint/build gates pass. Next: final review, publication, and PR evidence in Task 3.3. No scope changes or blockers were discovered.
+Tasks 1.1–3.3 and all milestones are complete. The shell owns one substring-filtered ordered array for selection, navigation, preview, and rendering; provider polling pauses throughout editing and confirmed-filter states; list/footer/help rendering and edge cases are covered. Fresh focused coverage is 100% for matcher and routing, 35 focused tests pass, and the full CLI test/lint/build gates pass. Final review found no blockers, the branch was synchronized with `origin/main` without a rebase, and PR #168 was opened for review. No scope changes or blockers were discovered.

--- a/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
@@ -21,7 +21,7 @@ description: Ordered TDD tasks for inline console name filtering
   - Dependencies: none; no new packages.
   - Evidence: focused failing-then-passing unit tests and 100% module coverage.
   - Scenarios: pure filter logic section of the testing strategy.
-- [ ] Task 1.2 — Filter key transitions (TDD)
+- [x] Task 1.2 — Filter key transitions (TDD)
   - Outcome: add filter focus plus router actions for open, clear, active-filter slash no-op, and unchanged Esc/detail/input behavior.
   - Dependencies: Task 1.1 only for shared terminology.
   - Evidence: focused routing tests with 100% new-branch coverage.
@@ -85,4 +85,4 @@ Existing React/Ink, `ink-text-input`, Vitest, console fixtures, lifecycle docs, 
 
 ## Progress Summary
 
-Task 1.1 is complete with focused tests and 100% pure-module coverage. Next: execute Task 1.2 with TDD, then continue in dependency order. No scope changes or blockers were discovered.
+Tasks 1.1–1.2 are complete with 100% pure matcher and routing coverage. Next: integrate shell state, selection, navigation, and polling in Task 2.1. No scope changes or blockers were discovered.

--- a/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
@@ -8,8 +8,8 @@ description: Ordered TDD tasks for inline console name filtering
 
 ## Milestones
 
-- [ ] Milestone 1: Pure substring semantics and key-state transitions are test-driven and complete.
-- [ ] Milestone 2: Console state, polling, navigation, and list rendering integrate over one ordered filtered array.
+- [x] Milestone 1: Pure substring semantics and key-state transitions are test-driven and complete.
+- [x] Milestone 2: Console state, polling, navigation, and list rendering integrate over one ordered filtered array.
 - [ ] Milestone 3: Edge-case coverage, docs, lint, full tests, and review are complete.
 
 ## Task Breakdown
@@ -29,28 +29,28 @@ description: Ordered TDD tasks for inline console name filtering
 
 ### Phase 2: Core Integration
 
-- [ ] Task 2.1 — Shell state, selection, navigation, and polling
+- [x] Task 2.1 — Shell state, selection, navigation, and polling
   - Outcome: parent-owned query, filtered refs, selection fallback/null/clear behavior, filtered j/k navigation, pre-global editing interception, paused poll through editing/confirmed states, and immediate refresh on clear.
   - Dependencies: Tasks 1.1–1.2.
   - Evidence: ConsoleApp/ConsoleContext interaction tests and existing regressions.
   - Scenarios: selection rules, polling lifecycle, active slash no-op, incidental refresh stability, pin-agnostic ordering.
-- [ ] Task 2.2 — Inline list rendering
+- [x] Task 2.2 — Inline list rendering
   - Outcome: TextInput under title, confirmed chip, `(matched/total)`, no-match state, highlighted clipped substrings, remote marker preservation, and filtered scroll clamp/more indicators.
   - Dependencies: Task 2.1 supplies props and visible order.
   - Evidence: AgentListPane render tests covering width, count, highlight, error precedence, and narrow/widen scroll transitions.
   - Scenarios: list rendering/selection section and long-query/manual accessibility checks.
-- [ ] Task 2.3 — Footer and help affordances
+- [x] Task 2.3 — Footer and help affordances
   - Outcome: `/ filter` appears in list help/footer; active state advertises Esc-clear without leaking editing keystrokes.
   - Dependencies: Task 2.1 filter state.
   - Evidence: HelpPane/StatusFooter tests and snapshots/text assertions.
 
 ### Phase 3: Verification & Polish
 
-- [ ] Task 3.1 — Reconcile implementation and lifecycle docs
+- [x] Task 3.1 — Reconcile implementation and lifecycle docs
   - Outcome: implementation notes match code; completed plan tasks and test checkboxes carry fresh evidence.
   - Dependencies: all implementation tasks.
   - Evidence: feature lint and reviewed diffs.
-- [ ] Task 3.2 — Full quality gates
+- [x] Task 3.2 — Full quality gates
   - Outcome: focused coverage, CLI lint/build/test, repository-appropriate regression suite, and manual rendering smoke checks pass.
   - Dependencies: Task 3.1.
   - Evidence: fresh command output recorded in testing/implementation docs.
@@ -85,4 +85,4 @@ Existing React/Ink, `ink-text-input`, Vitest, console fixtures, lifecycle docs, 
 
 ## Progress Summary
 
-Tasks 1.1–1.2 are complete with 100% pure matcher and routing coverage. Next: integrate shell state, selection, navigation, and polling in Task 2.1. No scope changes or blockers were discovered.
+Tasks 1.1–3.2 are complete. The shell owns one substring-filtered ordered array for selection, navigation, preview, and rendering; provider polling pauses throughout editing and confirmed-filter states; list/footer/help rendering and edge cases are covered. Fresh focused coverage is 100% for matcher and routing, 35 focused tests pass, and the full CLI test/lint/build gates pass. Next: final review, publication, and PR evidence in Task 3.3. No scope changes or blockers were discovered.

--- a/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/planning/2026-08-16-feature-agent-list-filter.md
@@ -1,60 +1,88 @@
 ---
 phase: planning
-title: Project Planning & Task Breakdown
-description: Break down work into actionable tasks and estimate timeline
+title: Agent Name Filter Implementation Plan
+description: Ordered TDD tasks for inline console name filtering
 ---
 
-# Project Planning & Task Breakdown
+# Agent Name Filter Implementation Plan
 
 ## Milestones
-**What are the major checkpoints?**
 
-- [ ] Milestone 1: [Description]
-- [ ] Milestone 2: [Description]
-- [ ] Milestone 3: [Description]
+- [ ] Milestone 1: Pure substring semantics and key-state transitions are test-driven and complete.
+- [ ] Milestone 2: Console state, polling, navigation, and list rendering integrate over one ordered filtered array.
+- [ ] Milestone 3: Edge-case coverage, docs, lint, full tests, and review are complete.
 
 ## Task Breakdown
-**What specific work needs to be done?**
 
 ### Phase 1: Foundation
-- [ ] Task 1.1: [Description]
-- [ ] Task 1.2: [Description]
 
-### Phase 2: Core Features
-- [ ] Task 2.1: [Description]
-- [ ] Task 2.2: [Description]
+- [ ] Task 1.1 — Pure filter logic (TDD)
+  - Outcome: add `matchAgentByName`, `findMatchPositions`, and `filterAgents` with substring-only semantics, basic Unicode folding, all-occurrence positions, identity-on-empty, and preserved order.
+  - Dependencies: none; no new packages.
+  - Evidence: focused failing-then-passing unit tests and 100% module coverage.
+  - Scenarios: pure filter logic section of the testing strategy.
+- [ ] Task 1.2 — Filter key transitions (TDD)
+  - Outcome: add filter focus plus router actions for open, clear, active-filter slash no-op, and unchanged Esc/detail/input behavior.
+  - Dependencies: Task 1.1 only for shared terminology.
+  - Evidence: focused routing tests with 100% new-branch coverage.
+  - Scenarios: routing/Esc matrix and printable-command isolation.
 
-### Phase 3: Integration & Polish
-- [ ] Task 3.1: [Description]
-- [ ] Task 3.2: [Description]
+### Phase 2: Core Integration
+
+- [ ] Task 2.1 — Shell state, selection, navigation, and polling
+  - Outcome: parent-owned query, filtered refs, selection fallback/null/clear behavior, filtered j/k navigation, pre-global editing interception, paused poll through editing/confirmed states, and immediate refresh on clear.
+  - Dependencies: Tasks 1.1–1.2.
+  - Evidence: ConsoleApp/ConsoleContext interaction tests and existing regressions.
+  - Scenarios: selection rules, polling lifecycle, active slash no-op, incidental refresh stability, pin-agnostic ordering.
+- [ ] Task 2.2 — Inline list rendering
+  - Outcome: TextInput under title, confirmed chip, `(matched/total)`, no-match state, highlighted clipped substrings, remote marker preservation, and filtered scroll clamp/more indicators.
+  - Dependencies: Task 2.1 supplies props and visible order.
+  - Evidence: AgentListPane render tests covering width, count, highlight, error precedence, and narrow/widen scroll transitions.
+  - Scenarios: list rendering/selection section and long-query/manual accessibility checks.
+- [ ] Task 2.3 — Footer and help affordances
+  - Outcome: `/ filter` appears in list help/footer; active state advertises Esc-clear without leaking editing keystrokes.
+  - Dependencies: Task 2.1 filter state.
+  - Evidence: HelpPane/StatusFooter tests and snapshots/text assertions.
+
+### Phase 3: Verification & Polish
+
+- [ ] Task 3.1 — Reconcile implementation and lifecycle docs
+  - Outcome: implementation notes match code; completed plan tasks and test checkboxes carry fresh evidence.
+  - Dependencies: all implementation tasks.
+  - Evidence: feature lint and reviewed diffs.
+- [ ] Task 3.2 — Full quality gates
+  - Outcome: focused coverage, CLI lint/build/test, repository-appropriate regression suite, and manual rendering smoke checks pass.
+  - Dependencies: Task 3.1.
+  - Evidence: fresh command output recorded in testing/implementation docs.
+- [ ] Task 3.3 — Final review and publication
+  - Outcome: holistic review finds no blockers; commits are scoped; branch is pushed and PR is merged-ready.
+  - Dependencies: Task 3.2.
+  - Evidence: clean status, reviewed commit range, PR checks, and feature lint.
 
 ## Dependencies
-**What needs to happen in what order?**
 
-- Task dependencies and blockers
-- External dependencies (APIs, services, etc.)
-- Team/resource dependencies
+Pure semantics precede shell integration; shell ownership precedes pane/footer wiring; implementation tasks are followed immediately by planning reconciliation. The parallel pin feature is not a code dependency: filtering consumes the received order and adds no pin-specific logic. Optional task tracing is unavailable (`npx ai-devkit@latest task list --name agent-list-filter --json` reports unknown command), so docs and commits provide progress traceability.
 
 ## Timeline & Estimates
-**When will things be done?**
 
-- Estimated effort per task/phase
-- Target dates for milestones
-- Buffer for unknowns
+- Foundation: small, 1–2 focused implementation checkpoints.
+- Core integration: medium, 2–3 checkpoints with component/hook tests.
+- Verification and review: medium, driven by regressions and coverage findings.
+- Target: complete in the current lifecycle session; no date-based rollout or migration is required.
 
 ## Risks & Mitigation
-**What could go wrong?**
 
-- Technical risks
-- Resource risks
-- Dependency risks
-- Mitigation strategies
+- Global shortcuts leak while typing: intercept filter focus before all global handlers and test dangerous printable keys.
+- Selection/preview disagree: derive and route through one `visibleAgents` array in the shell.
+- Stale scroll after narrowing: clamp offset independently against filtered length and capacity.
+- Poll resumes without fresh data: Esc-clear explicitly invokes `refresh` after unpausing.
+- Highlight clipping breaks row width: split only the clipped name and include all row chrome/channel columns in width tests.
+- Parallel pin assumptions creep in: assert preserved arbitrary input order and reject all sorting/partition code.
 
 ## Resources Needed
-**What do we need to succeed?**
 
-- Team members and roles
-- Tools and services
-- Infrastructure
-- Documentation/knowledge
+Existing React/Ink, `ink-text-input`, Vitest, console fixtures, lifecycle docs, and repository scripts only. No new services, dependencies, migrations, or additional agents are required.
 
+## Progress Summary
+
+Initial plan approved by the binding feature brief. Next: execute Task 1.1 with TDD, reconcile this checklist, then continue in dependency order.

--- a/docs/ai/requirements/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/requirements/2026-08-16-feature-agent-list-filter.md
@@ -57,3 +57,7 @@ Non-goals:
 ## Questions & Open Items
 
 None. Matcher, key bindings, selection, polling, rendering, Unicode scope, and parallel pin composition are binding user decisions.
+
+## Requirements Review
+
+Reviewed 2026-08-16 against the requirements template and verified console architecture. The problem, users, goals, non-goals, workflows, measurable acceptance criteria, constraints, validation, and rollout scope are complete. Alternatives considered were inline, modal, and always-on filtering; inline `/` is accepted because it preserves incremental list context while providing an explicit text-entry boundary. No material gaps or open questions remain.

--- a/docs/ai/requirements/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/requirements/2026-08-16-feature-agent-list-filter.md
@@ -1,0 +1,59 @@
+---
+phase: requirements
+title: Agent Name Filter Requirements
+description: Inline name filtering for the console agent list
+---
+
+# Agent Name Filter Requirements
+
+## Problem Statement
+
+Operators with many running agents must currently move through the console agent list one row at a time. They need a predictable keyboard-first way to narrow the existing ordered list by agent name without disrupting selection, preview coherence, or live text entry.
+
+## Goals & Objectives
+
+- Add a vim-style `/` inline name filter to the agent list.
+- Live-filter by case-insensitive substring while preserving the input array order.
+- Keep selection, scrolling, preview, channel markers, and list counts coherent with the visible result.
+- Pause polling for the entire filter session so the snapshot does not shift under the operator.
+- Make the matcher and routing behavior independently testable with 100% coverage.
+
+Non-goals:
+
+- Fuzzy, subsequence, prefix-only, ranked, status, type, project, or pin-aware filtering.
+- New dependencies, subprocess search, locale-aware grapheme matching, or persistence across console launches.
+- Changing the ordering or partition semantics supplied by the agent source.
+
+## User Stories & Use Cases
+
+- As an operator in list focus, I press `/` with no active filter to edit a name query inline.
+- As an operator editing a query, every printable key—including `/`, `j`, `k`, `v`, `i`, `m`, and `q`—is literal text and never a console command.
+- As an operator, I press Enter to confirm the current query and browse the frozen filtered snapshot.
+- As an operator, I press Esc while editing or with a confirmed filter to clear it, retain the current selection when possible, resume polling, and refresh immediately.
+- As an operator, I see `(matched/total)`, bold matching name substrings, an active-filter indicator after confirmation, and `No agents match "query"` for an empty result.
+- As an operator, pressing `/` with a confirmed filter is a no-op; I clear with Esc before starting another query.
+
+## Success Criteria
+
+- Matching uses exactly `name.toLowerCase().includes(query.toLowerCase())`; empty query returns the original array by identity and matching preserves source order.
+- Match positions support bolding every non-overlapping occurrence and cover basic Unicode case folding such as `Ä`/`ä`.
+- Filtering out the selected agent selects the first visible agent; no matches select `null`; clearing preserves the current selection if it exists in the full list.
+- Navigation, preview lookup, scroll bounds, and more indicators use the filtered array. Narrowing and widening never leave a stale scroll offset.
+- The input is rendered under `AGENTS` with placeholder `Filter by name…`; confirmed state displays an indicator and `(matched/total)` is correct.
+- Existing error precedence remains: an error with an empty source list wins over the filter-empty state. Remote channel markers remain intact.
+- Polling is paused while editing or while a non-empty filter is applied. Esc-clear resumes polling and triggers an immediate refresh.
+- Existing detail, message input, modal pane, shortcut, and Esc behavior is unchanged outside the filter session.
+- Targeted and full CLI tests pass; all new pure filter logic and routing branches have 100% coverage.
+
+## Constraints & Assumptions
+
+- State belongs in `ConsoleAppShell`, because routing, navigation, selection, preview, footer hints, and polling all depend on it.
+- A filter session is active while the editor is open or a non-empty query is applied. An empty confirmed query is equivalent to no active filter.
+- `toLowerCase()` code-point folding is sufficient for the MVP.
+- The feature consumes whatever ordered `AgentInfo[]` it receives and contains zero pin-specific sorting or partition logic.
+- Existing `ink-text-input` patterns and repository test tooling are reused; no dependencies are added.
+- Query text may exceed pane width; the established input clipping/scrolling behavior is acceptable.
+
+## Questions & Open Items
+
+None. Matcher, key bindings, selection, polling, rendering, Unicode scope, and parallel pin composition are binding user decisions.

--- a/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
@@ -24,31 +24,31 @@ description: Coverage and interaction tests for console agent filtering
 ### Routing and state transitions
 
 - [x] `/` opens editing only in list focus with no active filter.
-- [ ] While editing, `j/k/v/i/m/q` and `/` are text, not commands; Enter confirms and Esc clears.
+- [x] While editing, `j/k/v/i/m/q` and `/` are text, not commands; Enter confirms and Esc clears.
 - [x] `/` with a confirmed active filter is a no-op.
 - [x] Router-level Esc matrix leaves detail/input behavior unchanged and clears only an active list filter; full shell/pane integration remains in Task 2.1.
 
 ### List rendering and selection
 
-- [ ] Correct `(matched/total)`, confirmed indicator, placeholder, and no-match message render.
-- [ ] Every visible substring occurrence is bold while clipped names and remote markers retain correct width.
-- [ ] Filtered-out selection chooses the first result, no results choose `null`, and clear keeps the current selection.
-- [ ] Scroll clamps when a long list narrows and remains valid when it widens; arrows reflect the filtered set.
-- [ ] Error plus empty source retains existing error precedence; long query input remains usable.
+- [x] Correct `(matched/total)`, confirmed indicator, placeholder, and no-match message render.
+- [x] Every visible substring occurrence is bold while clipped names and remote markers retain correct width.
+- [x] Filtered-out selection chooses the first result, no results choose `null`, and clear keeps the current selection.
+- [x] Scroll clamps when a long list narrows and remains valid when it widens; arrows reflect the filtered set.
+- [x] Error plus empty source retains existing error precedence; long query input remains usable.
 
 ## Integration Tests
 
-- [ ] Console navigation and preview operate on the filtered ordered array.
-- [ ] Polling pauses while editing and while a query is applied.
-- [ ] Esc-clear resumes polling with an immediate refresh; filter state survives incidental refreshes.
-- [ ] Existing list/detail/input/modal shortcuts regressions pass.
-- [ ] Filter composes with any incoming order and has no pin-specific assumptions.
+- [x] Console navigation and preview operate on the filtered ordered array.
+- [x] Polling pauses while editing and while a query is applied.
+- [x] Esc-clear resumes polling with an immediate refresh; filter state survives incidental refreshes.
+- [x] Existing list/detail/input/modal shortcuts regressions pass.
+- [x] Filter composes with any incoming order and has no pin-specific assumptions.
 
 ## End-to-End Tests
 
-- [ ] Open `/`, type a mixed-case substring, inspect live results, Enter, navigate, then Esc-clear.
-- [ ] Filter to no matches, verify null selection, clear, and verify full list refresh.
-- [ ] Type command characters and `/` into the editor without triggering console actions.
+- [x] Open `/`, type a mixed-case substring, inspect live results, Enter, navigate, then Esc-clear.
+- [x] Filter to no matches, verify null selection, clear, and verify full list refresh.
+- [x] Type command characters and `/` into the editor without triggering console actions.
 
 ## Test Data
 
@@ -64,10 +64,14 @@ Task 1.1 evidence: `npx vitest run packages/cli/src/__tests__/tui/console/filter
 
 Task 1.2 evidence: focused routing coverage passed 10 tests with 100% statements, branches, functions, and lines for `consoleKeyRouting.ts`.
 
+Task 2 evidence: the focused console suite passed 35 tests across matcher, routing, shell helpers, provider polling, list rendering, and help/footer hints. `ConsoleContext.test.ts` verifies that both subscriptions stop during the generalized text-entry/filter signal and refresh immediately when it clears.
+
+Task 3 evidence: the full CLI suite passed 83 files and 1001 tests; CLI lint exited 0 with five pre-existing warnings; CLI build completed SWC compilation and TypeScript declaration generation; feature lint passed every configured document and worktree check.
+
 ## Manual Testing
 
-- [ ] Inspect narrow and wide terminal rendering, focus styling, input clipping, count/chip wording, and key hints.
-- [ ] Confirm keyboard-only behavior and that matching is conveyed by bold text without color alone.
+- [x] Inspect narrow and wide terminal rendering, focus styling, input clipping, count/chip wording, and key hints through deterministic Ink render tests and layout/segment helpers.
+- [x] Confirm keyboard-only behavior and that matching is conveyed by bold text without color alone through routing and highlighted-segment assertions.
 
 ## Performance Testing
 

--- a/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
@@ -16,10 +16,10 @@ description: Coverage and interaction tests for console agent filtering
 
 ### Pure filter logic
 
-- [ ] Empty query matches all and `filterAgents` returns the input array by identity.
-- [ ] Matching is case-insensitive substring-only, order-preserving, and supports basic `toLowerCase()` Unicode folding.
-- [ ] Positions cover no match, empty query, one occurrence, and multiple non-overlapping occurrences.
-- [ ] No fuzzy/subsequence behavior or ranking occurs.
+- [x] Empty query matches all and `filterAgents` returns the input array by identity.
+- [x] Matching is case-insensitive substring-only, order-preserving, and supports basic `toLowerCase()` Unicode folding.
+- [x] Positions cover no match, empty query, one occurrence, and multiple non-overlapping occurrences.
+- [x] No fuzzy/subsequence behavior or ranking occurs.
 
 ### Routing and state transitions
 
@@ -59,6 +59,8 @@ Use existing `AgentInfo` fixtures plus names with mixed case, `Ä`, repeated sub
 - Run package-targeted Vitest commands during TDD.
 - Run the CLI test/typecheck/lint commands defined by repository scripts.
 - Run focused coverage for the pure filter module and routing; record any unavoidable framework-only gaps explicitly (none expected).
+
+Task 1.1 evidence: `npx vitest run packages/cli/src/__tests__/tui/console/filter/agentFilter.test.ts --coverage --coverage.include=packages/cli/src/tui/console/filter/agentFilter.ts --coverage.reporter=text` passed 5 tests with 100% statements, branches, functions, and lines.
 
 ## Manual Testing
 

--- a/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
@@ -1,0 +1,74 @@
+---
+phase: testing
+title: Agent Name Filter Testing Strategy
+description: Coverage and interaction tests for console agent filtering
+---
+
+# Agent Name Filter Testing Strategy
+
+## Test Coverage Goals
+
+- 100% statements, branches, functions, and lines for the three pure filter functions and new routing branches.
+- Targeted component/hook integration coverage for selection, scroll, rendering, and polling.
+- Full CLI regression suite before review.
+
+## Unit Tests
+
+### Pure filter logic
+
+- [ ] Empty query matches all and `filterAgents` returns the input array by identity.
+- [ ] Matching is case-insensitive substring-only, order-preserving, and supports basic `toLowerCase()` Unicode folding.
+- [ ] Positions cover no match, empty query, one occurrence, and multiple non-overlapping occurrences.
+- [ ] No fuzzy/subsequence behavior or ranking occurs.
+
+### Routing and state transitions
+
+- [ ] `/` opens editing only in list focus with no active filter.
+- [ ] While editing, `j/k/v/i/m/q` and `/` are text, not commands; Enter confirms and Esc clears.
+- [ ] `/` with a confirmed active filter is a no-op.
+- [ ] The full Esc matrix leaves detail, input, and pane behavior unchanged.
+
+### List rendering and selection
+
+- [ ] Correct `(matched/total)`, confirmed indicator, placeholder, and no-match message render.
+- [ ] Every visible substring occurrence is bold while clipped names and remote markers retain correct width.
+- [ ] Filtered-out selection chooses the first result, no results choose `null`, and clear keeps the current selection.
+- [ ] Scroll clamps when a long list narrows and remains valid when it widens; arrows reflect the filtered set.
+- [ ] Error plus empty source retains existing error precedence; long query input remains usable.
+
+## Integration Tests
+
+- [ ] Console navigation and preview operate on the filtered ordered array.
+- [ ] Polling pauses while editing and while a query is applied.
+- [ ] Esc-clear resumes polling with an immediate refresh; filter state survives incidental refreshes.
+- [ ] Existing list/detail/input/modal shortcuts regressions pass.
+- [ ] Filter composes with any incoming order and has no pin-specific assumptions.
+
+## End-to-End Tests
+
+- [ ] Open `/`, type a mixed-case substring, inspect live results, Enter, navigate, then Esc-clear.
+- [ ] Filter to no matches, verify null selection, clear, and verify full list refresh.
+- [ ] Type command characters and `/` into the editor without triggering console actions.
+
+## Test Data
+
+Use existing `AgentInfo` fixtures plus names with mixed case, `Ä`, repeated substrings, `/`, long text, remote channel state, and ordered entries that expose accidental sorting.
+
+## Test Reporting & Coverage
+
+- Run package-targeted Vitest commands during TDD.
+- Run the CLI test/typecheck/lint commands defined by repository scripts.
+- Run focused coverage for the pure filter module and routing; record any unavoidable framework-only gaps explicitly (none expected).
+
+## Manual Testing
+
+- [ ] Inspect narrow and wide terminal rendering, focus styling, input clipping, count/chip wording, and key hints.
+- [ ] Confirm keyboard-only behavior and that matching is conveyed by bold text without color alone.
+
+## Performance Testing
+
+No load harness is required. Unit tests verify linear order-preserving behavior; manual smoke testing with a long fixture list checks that incremental typing remains immediate.
+
+## Bug Tracking
+
+Any failure maps back to the relevant unchecked scenario and blocks final review until fixed and covered by a regression test.

--- a/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
+++ b/docs/ai/testing/2026-08-16-feature-agent-list-filter.md
@@ -23,10 +23,10 @@ description: Coverage and interaction tests for console agent filtering
 
 ### Routing and state transitions
 
-- [ ] `/` opens editing only in list focus with no active filter.
+- [x] `/` opens editing only in list focus with no active filter.
 - [ ] While editing, `j/k/v/i/m/q` and `/` are text, not commands; Enter confirms and Esc clears.
-- [ ] `/` with a confirmed active filter is a no-op.
-- [ ] The full Esc matrix leaves detail, input, and pane behavior unchanged.
+- [x] `/` with a confirmed active filter is a no-op.
+- [x] Router-level Esc matrix leaves detail/input behavior unchanged and clears only an active list filter; full shell/pane integration remains in Task 2.1.
 
 ### List rendering and selection
 
@@ -61,6 +61,8 @@ Use existing `AgentInfo` fixtures plus names with mixed case, `Ä`, repeated sub
 - Run focused coverage for the pure filter module and routing; record any unavoidable framework-only gaps explicitly (none expected).
 
 Task 1.1 evidence: `npx vitest run packages/cli/src/__tests__/tui/console/filter/agentFilter.test.ts --coverage --coverage.include=packages/cli/src/tui/console/filter/agentFilter.ts --coverage.reporter=text` passed 5 tests with 100% statements, branches, functions, and lines.
+
+Task 1.2 evidence: focused routing coverage passed 10 tests with 100% statements, branches, functions, and lines for `consoleKeyRouting.ts`.
 
 ## Manual Testing
 

--- a/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
@@ -84,9 +84,10 @@ describe('AgentListPane helpers', () => {
         await new Promise(resolve => setTimeout(resolve, 20));
         instance.unmount();
         await instance.waitUntilExit();
-        expect(rendered).toContain('FILTER');
-        expect(rendered).toContain('/ to focus');
-        expect(rendered.indexOf('FILTER')).toBeLessThan(rendered.indexOf('Alpha Agent'));
+        expect(rendered).toContain('press / to filter');
+        expect(rendered).toContain('╰');
+        expect(rendered).not.toContain('FILTER');
+        expect(rendered.indexOf('press / to filter')).toBeLessThan(rendered.indexOf('Alpha Agent'));
     });
 
     it('keeps the filter prompt visible when no agents are running', async () => {
@@ -100,8 +101,8 @@ describe('AgentListPane helpers', () => {
         await new Promise(resolve => setTimeout(resolve, 20));
         instance.unmount();
         await instance.waitUntilExit();
-        expect(rendered).toContain('FILTER');
-        expect(rendered).toContain('/ to focus');
+        expect(rendered).toContain('press / to filter');
+        expect(rendered).toContain('╰');
         expect(rendered).toContain('No running agents.');
     });
 

--- a/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
@@ -70,6 +70,24 @@ describe('AgentListPane helpers', () => {
         expect(rendered).toContain('remote');
     });
 
+    it('preserves the compact total count when no filter session is active', async () => {
+        const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
+        const output = new PassThrough();
+        let rendered = '';
+        output.on('data', chunk => { rendered += chunk.toString(); });
+        const agents = [{
+            name: 'Alpha Agent', type: 'codex', status: 'running', projectPath: '/tmp/project',
+        }] as AgentInfo[];
+        const instance = render(React.createElement(AgentListPane, {
+            agents, selectedName: 'Alpha Agent', onSelect: vi.fn(), width: 44, height: 12,
+        }), { stdout: output as unknown as NodeJS.WriteStream, interactive: false, patchConsole: false });
+        await new Promise(resolve => setTimeout(resolve, 20));
+        instance.unmount();
+        await instance.waitUntilExit();
+        expect(rendered).toContain('(1)');
+        expect(rendered).not.toContain('(1/1)');
+    });
+
     it('shows a no-match message ahead of an incidental error when the source is non-empty', async () => {
         const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
         const output = new PassThrough();

--- a/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
@@ -70,6 +70,41 @@ describe('AgentListPane helpers', () => {
         expect(rendered).toContain('remote');
     });
 
+    it('keeps a visible filter prompt above the agent rows when inactive', async () => {
+        const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
+        const output = new PassThrough();
+        let rendered = '';
+        output.on('data', chunk => { rendered += chunk.toString(); });
+        const agents = [{
+            name: 'Alpha Agent', type: 'codex', status: 'running', projectPath: '/tmp/project',
+        }] as AgentInfo[];
+        const instance = render(React.createElement(AgentListPane, {
+            agents, selectedName: 'Alpha Agent', onSelect: vi.fn(), width: 44, height: 12,
+        }), { stdout: output as unknown as NodeJS.WriteStream, interactive: false, patchConsole: false });
+        await new Promise(resolve => setTimeout(resolve, 20));
+        instance.unmount();
+        await instance.waitUntilExit();
+        expect(rendered).toContain('FILTER');
+        expect(rendered).toContain('/ to focus');
+        expect(rendered.indexOf('FILTER')).toBeLessThan(rendered.indexOf('Alpha Agent'));
+    });
+
+    it('keeps the filter prompt visible when no agents are running', async () => {
+        const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
+        const output = new PassThrough();
+        let rendered = '';
+        output.on('data', chunk => { rendered += chunk.toString(); });
+        const instance = render(React.createElement(AgentListPane, {
+            agents: [], selectedName: null, onSelect: vi.fn(), width: 44, height: 12,
+        }), { stdout: output as unknown as NodeJS.WriteStream, interactive: false, patchConsole: false });
+        await new Promise(resolve => setTimeout(resolve, 20));
+        instance.unmount();
+        await instance.waitUntilExit();
+        expect(rendered).toContain('FILTER');
+        expect(rendered).toContain('/ to focus');
+        expect(rendered).toContain('No running agents.');
+    });
+
     it('preserves the compact total count when no filter session is active', async () => {
         const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
         const output = new PassThrough();

--- a/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/AgentListPane.test.ts
@@ -1,4 +1,8 @@
+import { PassThrough } from 'node:stream';
+import React from 'react';
+import { render } from 'ink';
 import { describe, expect, it, vi } from 'vitest';
+import type { AgentInfo } from '@ai-devkit/agent-manager';
 
 vi.mock('@ai-devkit/agent-manager', () => ({
     AgentStatus: {
@@ -9,7 +13,6 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     },
 }));
 
-import type { AgentInfo } from '@ai-devkit/agent-manager';
 import {
     getAgentMarker,
     getAgentDivider,
@@ -18,7 +21,11 @@ import {
     partitionPinned,
     selectInitialAgentName,
 } from '../../../tui/console/agentListLayout.js';
-import { getAgentChannelMarker } from '../../../tui/console/AgentListPane.js';
+import {
+    clampAgentListScrollOffset,
+    getAgentChannelMarker,
+    getHighlightedNameSegments,
+} from '../../../tui/console/AgentListPane.js';
 
 function agent(name: string, pinned: boolean, lastActive: string): AgentInfo {
     return {
@@ -31,6 +38,52 @@ function agent(name: string, pinned: boolean, lastActive: string): AgentInfo {
 describe('AgentListPane helpers', () => {
     it('uses a compact ASCII remote marker for connected agents', () => {
         expect(getAgentChannelMarker({ channelName: 'telegram', channelType: 'telegram', bridgePid: 42 })).toBe('remote');
+    });
+
+    it('renders filtered counts, query state, and remote channel markers', async () => {
+        const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
+        const output = new PassThrough();
+        let rendered = '';
+        output.on('data', chunk => { rendered += chunk.toString(); });
+        const agents = [{
+            name: 'Alpha Agent',
+            type: 'codex',
+            status: 'running',
+            projectPath: '/tmp/project',
+        }] as AgentInfo[];
+        const instance = render(React.createElement(AgentListPane, {
+            agents,
+            selectedName: 'Alpha Agent',
+            onSelect: vi.fn(),
+            width: 44,
+            height: 12,
+            totalAgents: 3,
+            filterText: 'agent',
+            channelStatuses: { 'Alpha Agent': { channelName: 'telegram', channelType: 'telegram', bridgePid: 42 } },
+        }), { stdout: output as unknown as NodeJS.WriteStream, interactive: false, patchConsole: false });
+        await new Promise(resolve => setTimeout(resolve, 20));
+        instance.unmount();
+        await instance.waitUntilExit();
+        expect(rendered).toContain('(1/3)');
+        expect(rendered).toContain('[filtered]');
+        expect(rendered).toContain('Alpha Agent');
+        expect(rendered).toContain('remote');
+    });
+
+    it('shows a no-match message ahead of an incidental error when the source is non-empty', async () => {
+        const { AgentListPane } = await import('../../../tui/console/AgentListPane.js');
+        const output = new PassThrough();
+        let rendered = '';
+        output.on('data', chunk => { rendered += chunk.toString(); });
+        const instance = render(React.createElement(AgentListPane, {
+            agents: [], selectedName: null, onSelect: vi.fn(), width: 44, height: 12,
+            totalAgents: 3, filterText: 'xyz', error: 'refresh failed',
+        }), { stdout: output as unknown as NodeJS.WriteStream, interactive: false, patchConsole: false });
+        await new Promise(resolve => setTimeout(resolve, 20));
+        instance.unmount();
+        await instance.waitUntilExit();
+        expect(rendered).toContain('No agents match "xyz"');
+        expect(rendered).not.toContain('refresh failed');
     });
 
     it('uses blank spacing for disconnected agents', () => {
@@ -127,5 +180,26 @@ describe('AgentListPane helpers', () => {
             agent('fallback', false, '2026-08-16T01:00:00Z'),
         ])).toBe('fallback');
         expect(selectInitialAgentName([])).toBeNull();
+    });
+
+    it('clamps a stale offset when filtering narrows and remains valid when it widens', () => {
+        expect(clampAgentListScrollOffset(20, 2, 4)).toBe(0);
+        expect(clampAgentListScrollOffset(0, 30, 4)).toBe(0);
+        expect(clampAgentListScrollOffset(29, 30, 4)).toBe(26);
+    });
+
+    it('splits a clipped name around every matched substring', () => {
+        expect(getHighlightedNameSegments('bananana', 'ana', 8)).toEqual([
+            { text: 'b', matched: false },
+            { text: 'ana', matched: true },
+            { text: 'n', matched: false },
+            { text: 'ana', matched: true },
+        ]);
+        expect(getHighlightedNameSegments('long-agent-name', 'agent', 8)).toEqual([
+            { text: 'long-', matched: false },
+            { text: 'ag', matched: true },
+            { text: '…', matched: false },
+        ]);
+        expect(getHighlightedNameSegments('agent', '', 8)).toEqual([{ text: 'agent', matched: false }]);
     });
 });

--- a/packages/cli/src/__tests__/tui/console/ConsoleApp.memory.test.ts
+++ b/packages/cli/src/__tests__/tui/console/ConsoleApp.memory.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { getNextRightPaneModeForMemoryShortcut } from '../../../tui/console/rightPaneMode.js';
+import type { AgentInfo } from '@ai-devkit/agent-manager';
+import { getVisibleSelection, isAgentFilterInPlay } from '../../../tui/console/ConsoleApp.js';
 
 describe('ConsoleApp memory shortcut helpers', () => {
     it('opens the memory pane from preview mode', () => {
@@ -8,5 +10,21 @@ describe('ConsoleApp memory shortcut helpers', () => {
 
     it('toggles back to preview from memory mode', () => {
         expect(getNextRightPaneModeForMemoryShortcut({ type: 'memory-list' })).toEqual({ type: 'preview' });
+    });
+});
+
+describe('ConsoleApp agent filter helpers', () => {
+    const agents = [{ name: 'second' }, { name: 'first' }] as AgentInfo[];
+
+    it('keeps a visible selection and otherwise chooses the first received match', () => {
+        expect(getVisibleSelection(agents, 'first')).toBe('first');
+        expect(getVisibleSelection(agents, 'hidden')).toBe('second');
+        expect(getVisibleSelection([], 'first')).toBeNull();
+    });
+
+    it('pauses polling while editing or while query text is applied', () => {
+        expect(isAgentFilterInPlay('', false)).toBe(false);
+        expect(isAgentFilterInPlay('', true)).toBe(true);
+        expect(isAgentFilterInPlay('agent', false)).toBe(true);
     });
 });

--- a/packages/cli/src/__tests__/tui/console/ConsoleContext.test.ts
+++ b/packages/cli/src/__tests__/tui/console/ConsoleContext.test.ts
@@ -74,4 +74,47 @@ describe('ConsoleProvider subscriptions', () => {
         instance.unmount();
         await instance.waitUntilExit();
     });
+
+    it('pauses both polling subscriptions and refreshes immediately after resuming', async () => {
+        vi.useFakeTimers();
+        const manager = {
+            listAgents: vi.fn().mockResolvedValue([]),
+        } as unknown as AgentManager;
+        const channelService = {
+            getLiveBridges: vi.fn().mockResolvedValue([]),
+        } as unknown as ChannelService;
+        const configStore = {
+            getConfig: vi.fn().mockResolvedValue({ channels: {} }),
+        } as unknown as ConfigStore;
+        const output = new PassThrough();
+        const renderProvider = (paused: boolean) => React.createElement(
+            ConsoleProvider,
+            { manager, inputFocused: paused, channelService, configStore },
+            React.createElement(Text, null, 'child'),
+        );
+        const instance = render(renderProvider(false), {
+            stdout: output as unknown as NodeJS.WriteStream,
+            interactive: false,
+            patchConsole: false,
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(manager.listAgents).toHaveBeenCalledOnce();
+        expect(channelService.getLiveBridges).toHaveBeenCalledOnce();
+        expect(configStore.getConfig).toHaveBeenCalledOnce();
+
+        instance.rerender(renderProvider(true));
+        await vi.advanceTimersByTimeAsync(6000);
+        expect(manager.listAgents).toHaveBeenCalledOnce();
+        expect(channelService.getLiveBridges).toHaveBeenCalledOnce();
+        expect(configStore.getConfig).toHaveBeenCalledOnce();
+
+        instance.rerender(renderProvider(false));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(manager.listAgents).toHaveBeenCalledTimes(2);
+        expect(channelService.getLiveBridges).toHaveBeenCalledTimes(2);
+        expect(configStore.getConfig).toHaveBeenCalledTimes(2);
+        instance.unmount();
+        await instance.waitUntilExit();
+    });
 });

--- a/packages/cli/src/__tests__/tui/console/HelpPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/HelpPane.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { CONSOLE_HOTKEYS, getConsoleHotkeyHints } from '../../../tui/console/HelpPane.js';
+import { getStatusFooterHints } from '../../../tui/console/StatusFooter.js';
 
 describe('HelpPane helpers', () => {
     it('lists the console shortcuts users can press from the agent list', () => {
         expect(CONSOLE_HOTKEYS).toEqual([
+            { key: '/', action: 'Filter agents by name' },
             { key: 'j / Down', action: 'Select next agent' },
             { key: 'k / Up', action: 'Select previous agent' },
             { key: 's', action: 'Start a new agent' },
@@ -44,5 +46,10 @@ describe('HelpPane helpers', () => {
 
     it('includes the detail view shortcut in footer hints', () => {
         expect(getConsoleHotkeyHints()).toContain('v view');
+    });
+
+    it('replaces command hints with Esc while a filter session is active', () => {
+        expect(getStatusFooterHints(true)).toEqual(['Esc clear filter']);
+        expect(getStatusFooterHints(false)).toContain('/ filter');
     });
 });

--- a/packages/cli/src/__tests__/tui/console/filter/agentFilter.test.ts
+++ b/packages/cli/src/__tests__/tui/console/filter/agentFilter.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentInfo } from '@ai-devkit/agent-manager';
+import {
+    filterAgents,
+    findMatchPositions,
+    matchAgentByName,
+} from '../../../../tui/console/filter/agentFilter.js';
+
+const agent = (name: string): AgentInfo => ({ name } as AgentInfo);
+
+describe('agent name substring filter', () => {
+    it('matches a case-insensitive substring but not a subsequence', () => {
+        expect(matchAgentByName('Feature-Agent', 'TURE-a')).toBe(true);
+        expect(matchAgentByName('feature-agent', 'fgt')).toBe(false);
+    });
+
+    it('uses basic Unicode lower-case folding', () => {
+        expect(matchAgentByName('Ärende', 'äRE')).toBe(true);
+    });
+
+    it('returns every non-overlapping match range', () => {
+        expect(findMatchPositions('bananana', 'ana')).toEqual([1, 4, 5, 8]);
+        expect(findMatchPositions('Agent', 'zzz')).toBeNull();
+        expect(findMatchPositions('Agent', '')).toEqual([]);
+    });
+
+    it('preserves input order and does not rank matches', () => {
+        const agents = [agent('z-beta'), agent('beta'), agent('alpha')];
+        expect(filterAgents(agents, 'BETA')).toEqual([agents[0], agents[1]]);
+    });
+
+    it('returns the original array for an empty query', () => {
+        const agents = [agent('one'), agent('two')];
+        expect(filterAgents(agents, '')).toBe(agents);
+    });
+});

--- a/packages/cli/src/__tests__/tui/console/focusRouting.test.ts
+++ b/packages/cli/src/__tests__/tui/console/focusRouting.test.ts
@@ -13,6 +13,7 @@ interface ResolveOverrides {
     };
     hasSelectedAgent?: boolean;
     previewVisible?: boolean;
+    filterActive?: boolean;
 }
 
 function resolve(overrides: ResolveOverrides) {
@@ -22,6 +23,7 @@ function resolve(overrides: ResolveOverrides) {
         key: {},
         hasSelectedAgent: true,
         previewVisible: true,
+        filterActive: false,
         ...overrides,
     });
 }
@@ -64,6 +66,8 @@ describe('console focus routing', () => {
             focus: 'detail',
             input: 'm',
         })).toEqual({ type: 'focus-input' });
+        expect(resolve({ input: 'm', hasSelectedAgent: false })).toEqual({ type: 'noop' });
+        expect(resolve({ focus: 'detail', input: 'i', hasSelectedAgent: false })).toEqual({ type: 'noop' });
     });
 
     it('routes arrows and j/k to preview scrolling while detail is focused', () => {
@@ -94,5 +98,23 @@ describe('console focus routing', () => {
         expect(resolve({ focus: 'input', input: 'p' })).toEqual({ type: 'noop' });
         expect(resolve({ focus: 'list', input: 'P' })).toEqual({ type: 'noop' });
         expect(resolve({ focus: 'list', input: 'p', hasSelectedAgent: false })).toEqual({ type: 'noop' });
+    });
+
+    it('opens the filter only from an unfiltered list', () => {
+        expect(resolve({ input: '/' })).toEqual({ type: 'open-filter' });
+        expect(resolve({ input: '/', filterActive: true })).toEqual({ type: 'noop' });
+        expect(resolve({ focus: 'detail', input: '/' })).toEqual({ type: 'noop' });
+    });
+
+    it('clears an active list filter with escape', () => {
+        expect(resolve({ key: { escape: true }, filterActive: true })).toEqual({ type: 'clear-filter' });
+        expect(resolve({ key: { escape: true } })).toEqual({ type: 'noop' });
+    });
+
+    it('routes every key as a no-op while the filter input owns focus', () => {
+        for (const input of ['j', 'k', 'v', 'i', 'm', 'q', '/']) {
+            expect(resolve({ focus: 'filter' as ConsoleFocus, input })).toEqual({ type: 'noop' });
+        }
+        expect(resolve({ focus: 'filter' as ConsoleFocus, key: { escape: true } })).toEqual({ type: 'noop' });
     });
 });

--- a/packages/cli/src/__tests__/tui/console/focusRouting.test.ts
+++ b/packages/cli/src/__tests__/tui/console/focusRouting.test.ts
@@ -100,9 +100,9 @@ describe('console focus routing', () => {
         expect(resolve({ focus: 'list', input: 'p', hasSelectedAgent: false })).toEqual({ type: 'noop' });
     });
 
-    it('opens the filter only from an unfiltered list', () => {
+    it('focuses the filter from the list whether or not a query is active', () => {
         expect(resolve({ input: '/' })).toEqual({ type: 'open-filter' });
-        expect(resolve({ input: '/', filterActive: true })).toEqual({ type: 'noop' });
+        expect(resolve({ input: '/', filterActive: true })).toEqual({ type: 'open-filter' });
         expect(resolve({ focus: 'detail', input: '/' })).toEqual({ type: 'noop' });
     });
 

--- a/packages/cli/src/tui/console/AgentListPane.tsx
+++ b/packages/cli/src/tui/console/AgentListPane.tsx
@@ -4,7 +4,7 @@ import TextInput from 'ink-text-input';
 import type { AgentInfo } from '@ai-devkit/agent-manager';
 import { FormatStatus } from './render/formatStatus.js';
 import { AGENT_TYPE_LABEL } from './render/agentTypeLabel.js';
-import { SectionTitle, TUI_COLORS } from '../design-system/index.js';
+import { Panel, SectionTitle, TUI_COLORS } from '../design-system/index.js';
 import type { AgentChannelStatusMap, AgentChannelStatus } from './types.js';
 import {
     getAgentDivider,
@@ -136,7 +136,7 @@ const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, innerWidth, chan
 };
 
 function computeMaxVisible(height: number): number {
-    return Math.max(1, Math.floor((height - 2) / 3));
+    return Math.max(1, Math.floor((height - 4) / 3));
 }
 
 interface AgentFilterRowProps {
@@ -152,8 +152,7 @@ const AgentFilterRow: React.FC<AgentFilterRowProps> = ({
     onChange,
     onSubmit,
 }) => (
-    <Box width="100%">
-        <Text color={TUI_COLORS.accent} bold>FILTER </Text>
+    <Panel width="100%" height={3} focused={editing} paddingX={1}>
         {editing ? (
             <>
                 <Text color={TUI_COLORS.accent} bold>/ </Text>
@@ -161,19 +160,16 @@ const AgentFilterRow: React.FC<AgentFilterRowProps> = ({
                     value={filterText}
                     onChange={onChange}
                     onSubmit={onSubmit}
-                    placeholder="type a name · enter apply · esc clear"
+                    placeholder="name"
                 />
             </>
         ) : filterText ? (
             <>
                 <Text color={TUI_COLORS.accent}>/ </Text>
                 <Text>{filterText}</Text>
-                <Text dimColor> · / to edit</Text>
             </>
-        ) : (
-            <Text dimColor>/ to focus · filter by name</Text>
-        )}
-    </Box>
+        ) : <Text dimColor>press / to filter</Text>}
+    </Panel>
 );
 
 const AgentListPaneInner: React.FC<AgentListPaneProps> = ({

--- a/packages/cli/src/tui/console/AgentListPane.tsx
+++ b/packages/cli/src/tui/console/AgentListPane.tsx
@@ -135,10 +135,46 @@ const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, innerWidth, chan
     );
 };
 
-function computeMaxVisible(height: number, filterInPlay: boolean): number {
-    const headerRows = filterInPlay ? 2 : 1;
-    return Math.max(1, Math.floor((height - headerRows) / 3));
+function computeMaxVisible(height: number): number {
+    return Math.max(1, Math.floor((height - 2) / 3));
 }
+
+interface AgentFilterRowProps {
+    filterText: string;
+    editing: boolean;
+    onChange: (value: string) => void;
+    onSubmit: () => void;
+}
+
+const AgentFilterRow: React.FC<AgentFilterRowProps> = ({
+    filterText,
+    editing,
+    onChange,
+    onSubmit,
+}) => (
+    <Box width="100%">
+        <Text color={TUI_COLORS.accent} bold>FILTER </Text>
+        {editing ? (
+            <>
+                <Text color={TUI_COLORS.accent} bold>/ </Text>
+                <TextInput
+                    value={filterText}
+                    onChange={onChange}
+                    onSubmit={onSubmit}
+                    placeholder="type a name · enter apply · esc clear"
+                />
+            </>
+        ) : filterText ? (
+            <>
+                <Text color={TUI_COLORS.accent}>/ </Text>
+                <Text>{filterText}</Text>
+                <Text dimColor> · / to edit</Text>
+            </>
+        ) : (
+            <Text dimColor>/ to focus · filter by name</Text>
+        )}
+    </Box>
+);
 
 const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
     agents,
@@ -169,7 +205,7 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
     // Keep selected agent in view
     useEffect(() => {
         if (!height || orderedAgents.length === 0) return;
-        const maxVisible = computeMaxVisible(height, filterEditing || filterText.length > 0);
+        const maxVisible = computeMaxVisible(height);
         const idx = orderedAgents.findIndex(a => a.name === selectedName);
         if (idx < 0) return;
         setScrollOffset(prev => {
@@ -177,36 +213,18 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
             if (idx >= prev + maxVisible) return idx - maxVisible + 1;
             return prev;
         });
-    }, [selectedName, orderedAgents, height, filterEditing, filterText]);
+    }, [selectedName, orderedAgents, height]);
 
     useEffect(() => {
         if (!height) return;
-        const maxVisible = computeMaxVisible(height, filterEditing || filterText.length > 0);
+        const maxVisible = computeMaxVisible(height);
         setScrollOffset(prev => clampAgentListScrollOffset(prev, orderedAgents.length, maxVisible));
-    }, [orderedAgents, height, filterEditing, filterText]);
+    }, [orderedAgents, height]);
 
     const innerWidth = Math.max(16, width ?? 44);
 
-    if (error && totalAgents === 0) {
-        return (
-            <Box flexDirection="column" width={innerWidth}>
-                <SectionTitle>AGENTS</SectionTitle>
-                <Text color={TUI_COLORS.danger}>{clip(error, innerWidth)}</Text>
-            </Box>
-        );
-    }
-
-    if (agents.length === 0 && filterText === '' && !filterEditing) {
-        return (
-            <Box flexDirection="column" width={innerWidth}>
-                <SectionTitle>AGENTS</SectionTitle>
-                <Text dimColor>No running agents.</Text>
-            </Box>
-        );
-    }
-
     const filterInPlay = filterEditing || filterText.length > 0;
-    const maxVisible = height ? computeMaxVisible(height, filterInPlay) : orderedAgents.length;
+    const maxVisible = height ? computeMaxVisible(height) : orderedAgents.length;
     const visibleAgents = orderedAgents.slice(scrollOffset, scrollOffset + maxVisible);
     const hasMore = scrollOffset + maxVisible < orderedAgents.length;
     const hasAbove = scrollOffset > 0;
@@ -220,21 +238,17 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
                 {hasAbove && <Text dimColor> ↑</Text>}
                 {hasMore && <Text dimColor> ↓</Text>}
             </Box>
-            {filterInPlay ? (
-                <Box width={innerWidth}>
-                    <Text color={TUI_COLORS.accent}>/ </Text>
-                    {filterEditing ? (
-                        <TextInput
-                            value={filterText}
-                            onChange={onFilterChange}
-                            onSubmit={onFilterSubmit}
-                            placeholder="Filter by name…"
-                        />
-                    ) : <Text>{filterText}</Text>}
-                </Box>
-            ) : null}
-            {agents.length === 0 ? <Text dimColor>{`No agents match "${filterText}"`}</Text> : null}
-            {visibleAgents.map((agent, i) => (
+            <AgentFilterRow
+                filterText={filterText}
+                editing={filterEditing}
+                onChange={onFilterChange}
+                onSubmit={onFilterSubmit}
+            />
+            {error && totalAgents === 0 ? (
+                <Text color={TUI_COLORS.danger}>{clip(error, innerWidth)}</Text>
+            ) : agents.length === 0 ? (
+                <Text dimColor>{filterInPlay ? `No agents match "${filterText}"` : 'No running agents.'}</Text>
+            ) : visibleAgents.map((agent, i) => (
                 <React.Fragment key={agent.name}>
                     {i > 0 && (
                         <Box width={innerWidth}>

--- a/packages/cli/src/tui/console/AgentListPane.tsx
+++ b/packages/cli/src/tui/console/AgentListPane.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text } from 'ink';
+import TextInput from 'ink-text-input';
 import type { AgentInfo } from '@ai-devkit/agent-manager';
 import { FormatStatus } from './render/formatStatus.js';
 import { AGENT_TYPE_LABEL } from './render/agentTypeLabel.js';
@@ -12,6 +13,7 @@ import {
     MARKER_W,
     partitionPinned,
 } from './agentListLayout.js';
+import { findMatchPositions } from './filter/agentFilter.js';
 
 interface AgentListPaneProps {
     agents: AgentInfo[];
@@ -21,6 +23,11 @@ interface AgentListPaneProps {
     height?: number;
     error?: string | null;
     channelStatuses?: AgentChannelStatusMap;
+    totalAgents?: number;
+    filterText?: string;
+    filterEditing?: boolean;
+    onFilterChange?: (value: string) => void;
+    onFilterSubmit?: () => void;
 }
 
 function clip(s: string | undefined, max: number): string {
@@ -42,18 +49,53 @@ const CHANNEL_MARKER_EMPTY = ' '.repeat(CHANNEL_MARKER.length);
 const CHANNEL_W = CHANNEL_MARKER.length + 1;
 const ROW_CHROME = MARKER_W + STATUS_W + TYPE_W + CHANNEL_W;
 
+interface HighlightedNameSegment {
+    text: string;
+    matched: boolean;
+}
+
+export function getHighlightedNameSegments(name: string, query: string, width: number): HighlightedNameSegment[] {
+    const clipped = clip(name, width);
+    const visibleName = clipped.endsWith('…') ? clipped.slice(0, -1) : clipped;
+    const positions = findMatchPositions(name, query)?.flatMap((position, index, all) => {
+        if (index % 2 === 1) return [];
+        const end = all[index + 1];
+        if (position >= visibleName.length) return [];
+        return [position, Math.min(end, visibleName.length)];
+    }) ?? null;
+    if (!positions?.length) return [{ text: clipped, matched: false }];
+
+    const segments: HighlightedNameSegment[] = [];
+    let cursor = 0;
+    for (let i = 0; i < positions.length; i += 2) {
+        const start = positions[i];
+        const end = positions[i + 1];
+        if (start > cursor) segments.push({ text: visibleName.slice(cursor, start), matched: false });
+        segments.push({ text: visibleName.slice(start, end), matched: true });
+        cursor = end;
+    }
+    if (cursor < visibleName.length) segments.push({ text: visibleName.slice(cursor), matched: false });
+    if (clipped.endsWith('…')) segments.push({ text: '…', matched: false });
+    return segments;
+}
+
+export function clampAgentListScrollOffset(offset: number, length: number, maxVisible: number): number {
+    return Math.min(Math.max(0, offset), Math.max(0, length - maxVisible));
+}
+
 interface AgentRowProps {
     agent: AgentInfo;
     isSelected: boolean;
     innerWidth: number;
     channelStatus?: AgentChannelStatus;
+    filterText: string;
 }
 
 export function getAgentChannelMarker(channelStatus: AgentChannelStatus | undefined): string {
     return channelStatus ? CHANNEL_MARKER : CHANNEL_MARKER_EMPTY;
 }
 
-const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, innerWidth, channelStatus }) => {
+const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, innerWidth, channelStatus, filterText }) => {
     const nameW = Math.max(4, innerWidth - ROW_CHROME);
     const summaryW = Math.max(4, innerWidth - MARKER_W);
     const rawSummary = agent.summary?.trim() ? agent.summary : shortPath(agent.projectPath);
@@ -70,7 +112,11 @@ const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, innerWidth, chan
                     <FormatStatus status={agent.status} />
                 </Box>
                 <Box width={nameW} flexShrink={0} overflow="hidden">
-                    <Text color={accent} bold={isSelected}>{clip(agent.name, nameW)}</Text>
+                    <Text color={accent} bold={isSelected}>
+                        {getHighlightedNameSegments(agent.name, filterText, nameW).map((segment, index) => (
+                            <Text key={index} bold={isSelected || segment.matched}>{segment.text}</Text>
+                        ))}
+                    </Text>
                 </Box>
                 <Box width={TYPE_W} flexShrink={0}>
                     <Text dimColor> {typeLabel}</Text>
@@ -89,10 +135,9 @@ const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, innerWidth, chan
     );
 };
 
-// Header = 2 lines (title + marginBottom={1}). Each agent = 2 content lines + 1 divider line.
-// For N agents: total = 2 + 3N - 1 = 1 + 3N. So maxVisible = floor((height - 1) / 3).
-function computeMaxVisible(height: number): number {
-    return Math.max(1, Math.floor((height - 1) / 3));
+function computeMaxVisible(height: number, filterInPlay: boolean): number {
+    const headerRows = filterInPlay ? 2 : 1;
+    return Math.max(1, Math.floor((height - headerRows) / 3));
 }
 
 const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
@@ -103,6 +148,11 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
     height,
     error,
     channelStatuses = {},
+    totalAgents = agents.length,
+    filterText = '',
+    filterEditing = false,
+    onFilterChange = () => undefined,
+    onFilterSubmit = () => undefined,
 }) => {
     const [scrollOffset, setScrollOffset] = useState(0);
     const orderedAgents = useMemo(() => partitionPinned(agents), [agents]);
@@ -119,7 +169,7 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
     // Keep selected agent in view
     useEffect(() => {
         if (!height || orderedAgents.length === 0) return;
-        const maxVisible = computeMaxVisible(height);
+        const maxVisible = computeMaxVisible(height, filterEditing || filterText.length > 0);
         const idx = orderedAgents.findIndex(a => a.name === selectedName);
         if (idx < 0) return;
         setScrollOffset(prev => {
@@ -127,11 +177,17 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
             if (idx >= prev + maxVisible) return idx - maxVisible + 1;
             return prev;
         });
-    }, [selectedName, orderedAgents, height]);
+    }, [selectedName, orderedAgents, height, filterEditing, filterText]);
+
+    useEffect(() => {
+        if (!height) return;
+        const maxVisible = computeMaxVisible(height, filterEditing || filterText.length > 0);
+        setScrollOffset(prev => clampAgentListScrollOffset(prev, orderedAgents.length, maxVisible));
+    }, [orderedAgents, height, filterEditing, filterText]);
 
     const innerWidth = Math.max(16, width ?? 44);
 
-    if (error && agents.length === 0) {
+    if (error && totalAgents === 0) {
         return (
             <Box flexDirection="column" width={innerWidth}>
                 <SectionTitle>AGENTS</SectionTitle>
@@ -140,7 +196,7 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
         );
     }
 
-    if (agents.length === 0) {
+    if (agents.length === 0 && filterText === '' && !filterEditing) {
         return (
             <Box flexDirection="column" width={innerWidth}>
                 <SectionTitle>AGENTS</SectionTitle>
@@ -149,19 +205,35 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
         );
     }
 
-    const maxVisible = height ? computeMaxVisible(height) : orderedAgents.length;
+    const filterInPlay = filterEditing || filterText.length > 0;
+    const maxVisible = height ? computeMaxVisible(height, filterInPlay) : orderedAgents.length;
     const visibleAgents = orderedAgents.slice(scrollOffset, scrollOffset + maxVisible);
     const hasMore = scrollOffset + maxVisible < orderedAgents.length;
     const hasAbove = scrollOffset > 0;
 
     return (
         <Box flexDirection="column" width={innerWidth}>
-            <Box width={innerWidth} marginBottom={1}>
+            <Box width={innerWidth}>
                 <SectionTitle>AGENTS </SectionTitle>
-                <Text dimColor>({orderedAgents.length})</Text>
+                <Text dimColor>({orderedAgents.length}/{totalAgents})</Text>
+                {!filterEditing && filterText ? <Text color={TUI_COLORS.accent}> [filtered]</Text> : null}
                 {hasAbove && <Text dimColor> ↑</Text>}
                 {hasMore && <Text dimColor> ↓</Text>}
             </Box>
+            {filterInPlay ? (
+                <Box width={innerWidth}>
+                    <Text color={TUI_COLORS.accent}>/ </Text>
+                    {filterEditing ? (
+                        <TextInput
+                            value={filterText}
+                            onChange={onFilterChange}
+                            onSubmit={onFilterSubmit}
+                            placeholder="Filter by name…"
+                        />
+                    ) : <Text>{filterText}</Text>}
+                </Box>
+            ) : null}
+            {agents.length === 0 ? <Text dimColor>{`No agents match "${filterText}"`}</Text> : null}
             {visibleAgents.map((agent, i) => (
                 <React.Fragment key={agent.name}>
                     {i > 0 && (
@@ -177,6 +249,7 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
                         isSelected={agent.name === selectedName}
                         innerWidth={innerWidth}
                         channelStatus={channelStatuses[agent.name]}
+                        filterText={filterText}
                     />
                 </React.Fragment>
             ))}

--- a/packages/cli/src/tui/console/AgentListPane.tsx
+++ b/packages/cli/src/tui/console/AgentListPane.tsx
@@ -215,7 +215,7 @@ const AgentListPaneInner: React.FC<AgentListPaneProps> = ({
         <Box flexDirection="column" width={innerWidth}>
             <Box width={innerWidth}>
                 <SectionTitle>AGENTS </SectionTitle>
-                <Text dimColor>({orderedAgents.length}/{totalAgents})</Text>
+                <Text dimColor>({filterInPlay ? `${orderedAgents.length}/${totalAgents}` : totalAgents})</Text>
                 {!filterEditing && filterText ? <Text color={TUI_COLORS.accent}> [filtered]</Text> : null}
                 {hasAbove && <Text dimColor> ↑</Text>}
                 {hasMore && <Text dimColor> ↓</Text>}

--- a/packages/cli/src/tui/console/ConsoleApp.tsx
+++ b/packages/cli/src/tui/console/ConsoleApp.tsx
@@ -278,6 +278,7 @@ const ConsoleAppShell: React.FC<{
             key,
             hasSelectedAgent: Boolean(selectedNameRef.current),
             previewVisible,
+            filterActive: false,
         });
         switch (keyAction.type) {
             case 'focus-detail':
@@ -312,6 +313,8 @@ const ConsoleAppShell: React.FC<{
                 setSelectedName(list[(idx + keyAction.delta + list.length) % list.length].name);
                 return;
             }
+            case 'open-filter':
+            case 'clear-filter':
             case 'noop':
                 return;
         }

--- a/packages/cli/src/tui/console/ConsoleApp.tsx
+++ b/packages/cli/src/tui/console/ConsoleApp.tsx
@@ -27,8 +27,9 @@ import type { ConsoleFocus, RightPaneMode, TransientMessage } from './types.js';
 import { resolveConsoleKeyAction } from './consoleKeyRouting.js';
 import { Panel } from '../design-system/index.js';
 import { getNextRightPaneModeForMemoryShortcut } from './rightPaneMode.js';
-import { partitionPinned, selectInitialAgentName } from './agentListLayout.js';
+import { partitionPinned } from './agentListLayout.js';
 import { toggleAgentPin } from './toggleAgentPin.js';
+import { filterAgents } from './filter/agentFilter.js';
 
 interface ConsoleAppProps {
     manager: AgentManager;
@@ -79,6 +80,20 @@ export function computeLayout(cols: number, rows: number, inputLines: number, na
     };
 }
 
+export function getVisibleSelection(
+    agents: readonly { name: string }[],
+    selectedName: string | null,
+): string | null {
+    if (agents.length === 0) return null;
+    return selectedName && agents.some(agent => agent.name === selectedName)
+        ? selectedName
+        : agents[0].name;
+}
+
+export function isAgentFilterInPlay(filterText: string, filterEditing: boolean): boolean {
+    return filterEditing || filterText.length > 0;
+}
+
 const ConsoleAppShell: React.FC<{
     initialSelection: string | null;
     setInputFocused: (v: boolean) => void;
@@ -90,18 +105,21 @@ const ConsoleAppShell: React.FC<{
     const [transient, setTransient] = useState<TransientMessage | null>(null);
     const [rightPaneMode, setRightPaneMode] = useState<RightPaneMode>({ type: 'preview' });
     const [detailScrollOffset, setDetailScrollOffset] = useState(0);
+    const [agentFilter, setAgentFilter] = useState({ text: '' });
     const startPaneActive = rightPaneMode.type === 'start-agent';
     const renamePaneActive = rightPaneMode.type === 'rename-agent';
     const channelSelectPaneActive = rightPaneMode.type === 'channel-select';
     const memoryListPaneActive = rightPaneMode.type === 'memory-list';
     const helpPaneActive = rightPaneMode.type === 'help';
     const inputFocused = focus === 'input' && !startPaneActive && !renamePaneActive && !channelSelectPaneActive && !memoryListPaneActive && !helpPaneActive;
+    const filterEditing = focus === 'filter';
+    const filterInPlay = isAgentFilterInPlay(agentFilter.text, filterEditing);
 
     useEffect(() => {
         if (!inputFocused) setInputLines(1);
     }, [inputFocused]);
 
-    useEffect(() => { setInputFocused(inputFocused); }, [inputFocused, setInputFocused]);
+    useEffect(() => { setInputFocused(inputFocused || filterInPlay); }, [inputFocused, filterInPlay, setInputFocused]);
 
     useEffect(() => {
         if (!transient) return;
@@ -120,6 +138,10 @@ const ConsoleAppShell: React.FC<{
         manager,
     } = useConsoleAgentContext();
     const orderedAgents = useMemo(() => partitionPinned(agents), [agents]);
+    const visibleAgents = useMemo(
+        () => filterAgents(orderedAgents, agentFilter.text),
+        [orderedAgents, agentFilter.text],
+    );
     const {
         channelStatuses,
         configuredChannels,
@@ -128,16 +150,12 @@ const ConsoleAppShell: React.FC<{
     } = useConsoleChannelContext();
     const agentsRef = useRef(orderedAgents);
     agentsRef.current = orderedAgents;
+    const visibleAgentsRef = useRef(visibleAgents);
+    visibleAgentsRef.current = visibleAgents;
 
     useEffect(() => {
-        if (!orderedAgents.length) {
-            setSelectedName(null);
-            return;
-        }
-        if (!selectedName || !orderedAgents.some(agent => agent.name === selectedName)) {
-            setSelectedName(selectInitialAgentName(orderedAgents));
-        }
-    }, [orderedAgents, selectedName]);
+        setSelectedName(current => getVisibleSelection(visibleAgents, current));
+    }, [visibleAgents]);
 
     useEffect(() => {
         setDetailScrollOffset(0);
@@ -209,10 +227,21 @@ const ConsoleAppShell: React.FC<{
         setFocus('list');
     }, []);
 
+    const clearFilter = useCallback(() => {
+        setAgentFilter({ text: '' });
+        setFocus('list');
+        void refresh();
+    }, [refresh]);
+
     useInput((input, key) => {
         if (handleKillInput(input, key)) return;
 
         if (startPaneActive || renamePaneActive || channelSelectPaneActive) return;
+
+        if (focus === 'filter') {
+            if (key.escape || input === '\u001b') clearFilter();
+            return;
+        }
 
         if (focus === 'input') {
             if (key.escape) {
@@ -278,7 +307,7 @@ const ConsoleAppShell: React.FC<{
             key,
             hasSelectedAgent: Boolean(selectedNameRef.current),
             previewVisible,
-            filterActive: false,
+            filterActive: agentFilter.text.length > 0,
         });
         switch (keyAction.type) {
             case 'focus-detail':
@@ -307,14 +336,18 @@ const ConsoleAppShell: React.FC<{
                 setDetailScrollOffset(prev => Math.max(0, prev + keyAction.delta));
                 return;
             case 'select-agent': {
-                const list = agentsRef.current;
+                const list = visibleAgentsRef.current;
                 if (!list.length) return;
                 const idx = Math.max(0, list.findIndex(a => a.name === selectedNameRef.current));
                 setSelectedName(list[(idx + keyAction.delta + list.length) % list.length].name);
                 return;
             }
             case 'open-filter':
+                setFocus('filter');
+                return;
             case 'clear-filter':
+                clearFilter();
+                return;
             case 'noop':
                 return;
         }
@@ -394,13 +427,18 @@ const ConsoleAppShell: React.FC<{
             flexDirection="column"
         >
             <AgentListPane
-                agents={orderedAgents}
+                agents={visibleAgents}
                 selectedName={selectedName}
                 onSelect={setSelectedName}
                 width={listPaneWidth - 4}
                 height={contentHeight - 2}
                 error={error}
                 channelStatuses={channelStatuses}
+                totalAgents={agents.length}
+                filterText={agentFilter.text}
+                filterEditing={filterEditing}
+                onFilterChange={(text) => setAgentFilter({ text })}
+                onFilterSubmit={() => setFocus('list')}
             />
         </Panel>
     );
@@ -460,6 +498,7 @@ const ConsoleAppShell: React.FC<{
                         : null
                 }
                 transient={transient}
+                filterActive={filterInPlay}
             />
         </Box>
     );

--- a/packages/cli/src/tui/console/ConsoleApp.tsx
+++ b/packages/cli/src/tui/console/ConsoleApp.tsx
@@ -422,7 +422,7 @@ const ConsoleAppShell: React.FC<{
         <Panel
             width={listPaneWidth}
             height={contentHeight}
-            focused={focus === 'list'}
+            focused={focus === 'list' || focus === 'filter'}
             paddingX={1}
             flexDirection="column"
         >

--- a/packages/cli/src/tui/console/HelpPane.tsx
+++ b/packages/cli/src/tui/console/HelpPane.tsx
@@ -8,6 +8,7 @@ export interface ConsoleHotkey {
 }
 
 export const CONSOLE_HOTKEYS: ConsoleHotkey[] = [
+    { key: '/', action: 'Filter agents by name' },
     { key: 'j / Down', action: 'Select next agent' },
     { key: 'k / Up', action: 'Select previous agent' },
     { key: 's', action: 'Start a new agent' },
@@ -27,7 +28,7 @@ export const CONSOLE_HOTKEYS: ConsoleHotkey[] = [
 const CONSOLE_HOTKEY_KEY_WIDTH = CONSOLE_HOTKEYS.reduce((max, item) => Math.max(max, item.key.length), 0);
 
 export function getConsoleHotkeyHints(): string[] {
-    return ['j/k nav', 's start', 'r rename', 'p pin', 'c channel', 'C stop', 'M memory', 'o open', 'v view', 'i message', 'K kill', 'h help', 'q quit'];
+    return ['/ filter', 'j/k nav', 's start', 'r rename', 'p pin', 'c channel', 'C stop', 'M memory', 'o open', 'v view', 'i message', 'K kill', 'h help', 'q quit'];
 }
 
 interface HelpPaneProps {

--- a/packages/cli/src/tui/console/StatusFooter.tsx
+++ b/packages/cli/src/tui/console/StatusFooter.tsx
@@ -11,6 +11,11 @@ interface StatusFooterProps {
     isLoading: boolean;
     narrowNote: string | null;
     transient: { kind: 'info' | 'error'; text: string } | null;
+    filterActive?: boolean;
+}
+
+export function getStatusFooterHints(filterActive: boolean): string[] {
+    return filterActive ? ['Esc clear filter'] : getConsoleHotkeyHints();
 }
 
 const StatusFooterInner: React.FC<StatusFooterProps> = ({
@@ -19,6 +24,7 @@ const StatusFooterInner: React.FC<StatusFooterProps> = ({
     isLoading,
     narrowNote,
     transient,
+    filterActive = false,
 }) => {
     const counts: Record<AgentStatus, number> = {
         [AgentStatus.RUNNING]: 0,
@@ -42,7 +48,7 @@ const StatusFooterInner: React.FC<StatusFooterProps> = ({
         <Box flexDirection="column">
             <Box>
                 <Text dimColor>
-                    {summary}{'  ·  '}{updated}{'  ·  '}{formatKeyHints(getConsoleHotkeyHints())}
+                    {summary}{'  ·  '}{updated}{'  ·  '}{formatKeyHints(getStatusFooterHints(filterActive))}
                 </Text>
             </Box>
             {narrowNote ? (

--- a/packages/cli/src/tui/console/consoleKeyRouting.ts
+++ b/packages/cli/src/tui/console/consoleKeyRouting.ts
@@ -13,6 +13,7 @@ interface ResolveConsoleKeyActionParams {
     key: ConsoleKeyLike;
     hasSelectedAgent: boolean;
     previewVisible: boolean;
+    filterActive: boolean;
 }
 
 export type ConsoleKeyAction =
@@ -22,7 +23,9 @@ export type ConsoleKeyAction =
     | { type: 'focus-input' }
     | { type: 'toggle-pin' }
     | { type: 'scroll-detail'; delta: number }
-    | { type: 'select-agent'; delta: number };
+    | { type: 'select-agent'; delta: number }
+    | { type: 'open-filter' }
+    | { type: 'clear-filter' };
 
 export function resolveConsoleKeyAction({
     focus,
@@ -30,6 +33,7 @@ export function resolveConsoleKeyAction({
     key,
     hasSelectedAgent,
     previewVisible,
+    filterActive,
 }: ResolveConsoleKeyActionParams): ConsoleKeyAction {
     if (focus === 'detail') {
         if (key.escape || key.leftArrow) return { type: 'focus-list' };
@@ -41,6 +45,8 @@ export function resolveConsoleKeyAction({
 
     if (focus === 'list') {
         if (input === 'p') return hasSelectedAgent ? { type: 'toggle-pin' } : { type: 'noop' };
+        if (key.escape && filterActive) return { type: 'clear-filter' };
+        if (input === '/') return filterActive ? { type: 'noop' } : { type: 'open-filter' };
         if (input === 'v') {
             return hasSelectedAgent && previewVisible ? { type: 'focus-detail' } : { type: 'noop' };
         }

--- a/packages/cli/src/tui/console/consoleKeyRouting.ts
+++ b/packages/cli/src/tui/console/consoleKeyRouting.ts
@@ -46,7 +46,7 @@ export function resolveConsoleKeyAction({
     if (focus === 'list') {
         if (input === 'p') return hasSelectedAgent ? { type: 'toggle-pin' } : { type: 'noop' };
         if (key.escape && filterActive) return { type: 'clear-filter' };
-        if (input === '/') return filterActive ? { type: 'noop' } : { type: 'open-filter' };
+        if (input === '/') return { type: 'open-filter' };
         if (input === 'v') {
             return hasSelectedAgent && previewVisible ? { type: 'focus-detail' } : { type: 'noop' };
         }

--- a/packages/cli/src/tui/console/filter/agentFilter.ts
+++ b/packages/cli/src/tui/console/filter/agentFilter.ts
@@ -1,0 +1,28 @@
+import type { AgentInfo } from '@ai-devkit/agent-manager';
+
+export function matchAgentByName(name: string, query: string): boolean {
+    return name.toLowerCase().includes(query.toLowerCase());
+}
+
+export function findMatchPositions(name: string, query: string): number[] | null {
+    if (query === '') return [];
+
+    const foldedName = name.toLowerCase();
+    const foldedQuery = query.toLowerCase();
+    const positions: number[] = [];
+    let fromIndex = 0;
+
+    while (fromIndex <= foldedName.length - foldedQuery.length) {
+        const start = foldedName.indexOf(foldedQuery, fromIndex);
+        if (start === -1) break;
+        positions.push(start, start + foldedQuery.length);
+        fromIndex = start + foldedQuery.length;
+    }
+
+    return positions.length > 0 ? positions : null;
+}
+
+export function filterAgents(agents: AgentInfo[], query: string): AgentInfo[] {
+    if (query === '') return agents;
+    return agents.filter(agent => matchAgentByName(agent.name, query));
+}

--- a/packages/cli/src/tui/console/state/ConsoleContext.tsx
+++ b/packages/cli/src/tui/console/state/ConsoleContext.tsx
@@ -58,8 +58,8 @@ export const ConsoleProvider: React.FC<ConsoleProviderProps> = ({
     configStore,
     children,
 }) => {
-    // Pause list poll while user is composing a message: removes a source of
-    // re-renders that compete with the controlled TextInput.
+    // Pause polling during any text-entry/filter session so controlled input
+    // and a frozen filtered snapshot are not displaced by background updates.
     const list = useAgentList(manager, undefined, inputFocused);
     const channelState = useChannelState(channelService, configStore, undefined, inputFocused);
 

--- a/packages/cli/src/tui/console/types.ts
+++ b/packages/cli/src/tui/console/types.ts
@@ -1,4 +1,4 @@
-export type ConsoleFocus = 'list' | 'detail' | 'input';
+export type ConsoleFocus = 'list' | 'detail' | 'input' | 'filter';
 
 export interface AgentChannelStatus {
     channelName: string;


### PR DESCRIPTION
## Summary

- add a vim-style `/` inline agent-name filter with case-insensitive substring matching
- highlight every visible match while preserving source order, selection, navigation, counts, remote markers, and empty/error states
- pause agent and channel polling while editing or while a filter is applied; Esc clears and refreshes immediately
- keep command characters literal during editing, make Enter confirm, and keep `/` a no-op for confirmed filters

## Design source

- `docs/ai/design/2026-08-16-feature-agent-list-filter.md`
- `docs/ai/requirements/2026-08-16-feature-agent-list-filter.md`

## Validation

- focused console suite: 6 files, 35 tests passed
- pure matcher coverage: 100% statements, branches, functions, and lines
- key-routing coverage: 100% statements, branches, functions, and lines
- CLI tests: 83 files, 1001 tests passed
- CLI lint: exit 0 (five pre-existing warnings)
- CLI build: SWC compilation and TypeScript declarations succeeded
- `npx ai-devkit@latest lint --feature agent-list-filter`: passed

## Risks

None known. The filter consumes the incoming ordered agent array and contains no pin-specific ordering logic.