### PR TITLE
feat(agent): add pi print mode

### DIFF
--- a/docs/ai/design/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/design/2026-08-17-feature-pi-print-mode.md
@@ -45,7 +45,7 @@ Pi follows the merged Claude and Codex durable service/runner boundary and provi
 
 - `DurableAgent.ts`: provider union and Pi errors.
 - `DurableAgentRepository.ts`: SQLite persistence, provider creation, and CAS run ownership.
-- `durable/run.ts`: provider-neutral resolve, validation, ownership, execution, and completion sequencing.
+- `durable/run.ts`: provider-neutral resolve, validation, ownership, execution, completion sequencing, summary sanitization, and session-health result mapping.
 - `providers/pi/durable/PiCliProbe.ts`: sanitized capability validation.
 - `providers/pi/durable/PiPrintRunner.ts`: bounded JSONL parser, identity validation, lifecycle/result extraction, subprocess safety.
 - `providers/pi/durable/PiStreamParser.ts`: provider-local bounded JSONL state and final-result validation.

--- a/docs/ai/design/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/design/2026-08-17-feature-pi-print-mode.md
@@ -12,9 +12,11 @@ description: Architecture for durable Pi JSON-mode agents
 flowchart LR
   CLI[agent start/send/list/detail] --> Dispatch[provider dispatch]
   Dispatch --> Service[PiPrintAgentService]
+  Service --> Lifecycle[shared durable run lifecycle]
   Service --> Probe[PiCliProbe]
-  Service --> Repository[DurableAgentRepository]
-  Service --> Runner[PiPrintRunner]
+  Lifecycle --> Repository[DurableAgentRepository]
+  Lifecycle --> Runner[PiPrintRunner]
+  Runner --> Parser[PiStreamParser]
   Runner -->|pi --mode json --session-id/--session UUID| Pi[Pi CLI]
   Pi -->|session header + events| Runner
   Repository --> Registry[(agents.db durable_agents)]
@@ -36,14 +38,17 @@ Pi follows the merged Claude and Codex durable service/runner boundary and provi
 - `onSpawn(ProcessIdentity)` persists process ownership; the emitted session UUID must match the repository-assigned UUID.
 - `PiPrintAgentService.create()` probes then creates with provider `pi`.
 - `PiPrintAgentService.send()` resolves, locks, checks provider, runs, records success/failure, and always releases through `completeRun`.
+- The shared durable run lifecycle rejects the wrong provider before ownership acquisition and keeps successful completion writes outside the execution-failure handler.
 - CLI creates and dispatches services by stored provider rather than assuming Claude.
 
 ## Component Breakdown
 
 - `DurableAgent.ts`: provider union and Pi errors.
 - `DurableAgentRepository.ts`: SQLite persistence, provider creation, and CAS run ownership.
+- `durable/run.ts`: provider-neutral resolve, validation, ownership, execution, and completion sequencing.
 - `providers/pi/durable/PiCliProbe.ts`: sanitized capability validation.
 - `providers/pi/durable/PiPrintRunner.ts`: bounded JSONL parser, identity validation, lifecycle/result extraction, subprocess safety.
+- `providers/pi/durable/PiStreamParser.ts`: provider-local bounded JSONL state and final-result validation.
 - `providers/pi/durable/PiPrintAgentService.ts`: orchestration and state transitions.
 - `agent.ts`: start validation, provider-aware send, labels, and detail output.
 - Tests mock process and store boundaries following Claude print patterns.

--- a/docs/ai/design/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/design/2026-08-17-feature-pi-print-mode.md
@@ -1,0 +1,75 @@
+---
+phase: design
+title: Pi Print Mode Design
+description: Architecture for durable Pi JSON-mode agents
+---
+
+# Pi Print Mode Design
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+  CLI[agent start/send/list/detail] --> Dispatch[provider dispatch]
+  Dispatch --> Service[PiPrintAgentService]
+  Service --> Probe[PiCliProbe]
+  Service --> Store[PrintAgentStore v2]
+  Service --> Runner[PiPrintRunner]
+  Runner -->|pi --mode json [--session id]| Pi[Pi CLI]
+  Pi -->|session header + events| Runner
+  Runner -->|onSession UUID| Store
+  Store --> Registry[(print-agents.json + run locks)]
+  Registry --> Console[agent list / console]
+```
+
+Pi follows the merged Claude service/runner boundary. The open Codex design is used only as a read-only consistency reference for provider-discriminated agents and late provider-session binding.
+
+## Data Models
+
+- `PrintProvider`: `claude | pi` on this main-based branch.
+- `PrintAgentBase`: shared AI DevKit identity, cwd binding, state, timestamps, active-run identity, and last result.
+- `ClaudePrintAgent`: provider `claude`, provider session UUID assigned at creation.
+- `PiPrintAgent`: provider `pi`, provider session UUID initially `null`, bound from Pi's session header during its first run.
+- Store schema version 2 reads legacy version 1 Claude records and writes version 2. Non-null provider session IDs are unique per provider.
+
+## API Design
+
+- `PiCliProbe.validate()` runs `pi --version` and `pi --help`, requiring `--mode`, `json`, and `--session`.
+- `PiPrintRunner.run(request)` spawns Pi with `['--mode', 'json']` for a first run or `['--mode', 'json', '--session', id]` for resume; prompt is sent on stdin.
+- Runner callbacks: `onSpawn(ProcessIdentity)` persists process ownership; `onSession(uuid)` atomically binds/verifies provider identity.
+- `PiPrintAgentService.create()` probes then creates with provider `pi`.
+- `PiPrintAgentService.send()` resolves, locks, checks provider, runs, records success/failure, and always releases through `completeRun`.
+- CLI creates and dispatches services by stored provider rather than assuming Claude.
+
+## Component Breakdown
+
+- `PrintAgent.ts`: discriminated provider types and Pi errors.
+- `PrintAgentStore.ts`: schema migration, provider creation, UUID validation, unique late binding.
+- `PiCliProbe.ts`: sanitized capability validation.
+- `PiPrintRunner.ts`: bounded JSONL parser, identity validation, lifecycle/result extraction, subprocess safety.
+- `PiPrintAgentService.ts`: orchestration and state transitions.
+- `agent.ts`: start validation, provider-aware send, labels, and detail output.
+- Tests mock process and store boundaries following Claude print patterns.
+
+## Protocol Rules
+
+- Accept exactly one valid leading/session identity event; duplicate or invalid session identity is a protocol error.
+- Verify resumed runs emit the stored UUID before binding callback succeeds.
+- Collect non-empty assistant text from completed assistant messages; return the last complete assistant text.
+- Require clean line-delimited JSON, a zero exit code, a session identity, `agent_end`, and at least one assistant result.
+- Reject oversized lines and incomplete trailing JSON; drain stderr without echoing potentially sensitive provider content.
+
+## Design Decisions
+
+- Selected JSON mode over plain print mode for durable session identity.
+- Selected late binding because Pi owns session UUID creation.
+- Generalize the shared store now, but add only Pi on main; future Codex integration can extend the union consistently.
+- Keep synchronous send behavior and existing run locks; no daemon or streaming transport.
+- Preserve version 1 reads and write version 2 to avoid breaking merged Claude installations.
+
+## Non-Functional Requirements
+
+- Security: `shell: false`, stdin prompts, canonical non-symlink cwd, bounded JSON lines, sanitized summaries, no stderr reflection.
+- Reliability: atomic store mutations, provider/session uniqueness, ownership-checked binding, mismatch degradation, stale-run reconciliation.
+- Performance: streaming JSONL parsing with a 1 MiB default line bound; no whole-output buffering.
+- Compatibility: no dependencies and no behavioral changes to interactive Pi or Claude print invocations.

--- a/docs/ai/design/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/design/2026-08-17-feature-pi-print-mode.md
@@ -21,13 +21,13 @@ flowchart LR
   Registry --> Console[agent list / detail]
 ```
 
-Pi follows the merged Claude durable service/runner boundary. The open Codex design is used only as a read-only consistency reference.
+Pi follows the merged Claude and Codex durable service/runner boundary and provider-directory structure.
 
 ## Data Models
 
-- `DurableProvider`: `claude | pi`.
+- `DurableProvider`: `claude | codex | pi`.
 - `DurableAgent`: shared identity, durable mode, cwd binding, state, timestamps, active-run identity, and last result.
-- `DurableAgentRepository` assigns a provider session UUID at creation and persists rows in SQLite migration 003.
+- `DurableAgentRepository` assigns Claude and Pi provider session UUIDs at creation, while Codex remains null until its first run; migration 004 permits the shared nullable column.
 
 ## API Design
 
@@ -42,9 +42,9 @@ Pi follows the merged Claude durable service/runner boundary. The open Codex des
 
 - `DurableAgent.ts`: provider union and Pi errors.
 - `DurableAgentRepository.ts`: SQLite persistence, provider creation, and CAS run ownership.
-- `PiCliProbe.ts`: sanitized capability validation.
-- `PiPrintRunner.ts`: bounded JSONL parser, identity validation, lifecycle/result extraction, subprocess safety.
-- `PiPrintAgentService.ts`: orchestration and state transitions.
+- `providers/pi/durable/PiCliProbe.ts`: sanitized capability validation.
+- `providers/pi/durable/PiPrintRunner.ts`: bounded JSONL parser, identity validation, lifecycle/result extraction, subprocess safety.
+- `providers/pi/durable/PiPrintAgentService.ts`: orchestration and state transitions.
 - `agent.ts`: start validation, provider-aware send, labels, and detail output.
 - Tests mock process and store boundaries following Claude print patterns.
 

--- a/docs/ai/design/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/design/2026-08-17-feature-pi-print-mode.md
@@ -13,38 +13,35 @@ flowchart LR
   CLI[agent start/send/list/detail] --> Dispatch[provider dispatch]
   Dispatch --> Service[PiPrintAgentService]
   Service --> Probe[PiCliProbe]
-  Service --> Store[PrintAgentStore v2]
+  Service --> Repository[DurableAgentRepository]
   Service --> Runner[PiPrintRunner]
-  Runner -->|pi --mode json [--session id]| Pi[Pi CLI]
+  Runner -->|pi --mode json --session-id/--session UUID| Pi[Pi CLI]
   Pi -->|session header + events| Runner
-  Runner -->|onSession UUID| Store
-  Store --> Registry[(print-agents.json + run locks)]
-  Registry --> Console[agent list / console]
+  Repository --> Registry[(agents.db durable_agents)]
+  Registry --> Console[agent list / detail]
 ```
 
-Pi follows the merged Claude service/runner boundary. The open Codex design is used only as a read-only consistency reference for provider-discriminated agents and late provider-session binding.
+Pi follows the merged Claude durable service/runner boundary. The open Codex design is used only as a read-only consistency reference.
 
 ## Data Models
 
-- `PrintProvider`: `claude | pi` on this main-based branch.
-- `PrintAgentBase`: shared AI DevKit identity, cwd binding, state, timestamps, active-run identity, and last result.
-- `ClaudePrintAgent`: provider `claude`, provider session UUID assigned at creation.
-- `PiPrintAgent`: provider `pi`, provider session UUID initially `null`, bound from Pi's session header during its first run.
-- Store schema version 2 reads legacy version 1 Claude records and writes version 2. Non-null provider session IDs are unique per provider.
+- `DurableProvider`: `claude | pi`.
+- `DurableAgent`: shared identity, durable mode, cwd binding, state, timestamps, active-run identity, and last result.
+- `DurableAgentRepository` assigns a provider session UUID at creation and persists rows in SQLite migration 003.
 
 ## API Design
 
-- `PiCliProbe.validate()` runs `pi --version` and `pi --help`, requiring `--mode`, `json`, and `--session`.
-- `PiPrintRunner.run(request)` spawns Pi with `['--mode', 'json']` for a first run or `['--mode', 'json', '--session', id]` for resume; prompt is sent on stdin.
-- Runner callbacks: `onSpawn(ProcessIdentity)` persists process ownership; `onSession(uuid)` atomically binds/verifies provider identity.
+- `PiCliProbe.validate()` runs `pi --version` and `pi --help`, requiring `--mode`, `json`, `--session-id`, and `--session`.
+- `PiPrintRunner.run(request)` uses `--session-id <uuid>` for a first run and `--session <uuid>` for resume; prompt is sent on stdin.
+- `onSpawn(ProcessIdentity)` persists process ownership; the emitted session UUID must match the repository-assigned UUID.
 - `PiPrintAgentService.create()` probes then creates with provider `pi`.
 - `PiPrintAgentService.send()` resolves, locks, checks provider, runs, records success/failure, and always releases through `completeRun`.
 - CLI creates and dispatches services by stored provider rather than assuming Claude.
 
 ## Component Breakdown
 
-- `PrintAgent.ts`: discriminated provider types and Pi errors.
-- `PrintAgentStore.ts`: schema migration, provider creation, UUID validation, unique late binding.
+- `DurableAgent.ts`: provider union and Pi errors.
+- `DurableAgentRepository.ts`: SQLite persistence, provider creation, and CAS run ownership.
 - `PiCliProbe.ts`: sanitized capability validation.
 - `PiPrintRunner.ts`: bounded JSONL parser, identity validation, lifecycle/result extraction, subprocess safety.
 - `PiPrintAgentService.ts`: orchestration and state transitions.
@@ -54,7 +51,7 @@ Pi follows the merged Claude service/runner boundary. The open Codex design is u
 ## Protocol Rules
 
 - Accept exactly one valid leading/session identity event; duplicate or invalid session identity is a protocol error.
-- Verify resumed runs emit the stored UUID before binding callback succeeds.
+- Verify every run emits the stored UUID.
 - Collect non-empty assistant text from completed assistant messages; return the last complete assistant text.
 - Require clean line-delimited JSON, a zero exit code, a session identity, `agent_end`, and at least one assistant result.
 - Reject oversized lines and incomplete trailing JSON; drain stderr without echoing potentially sensitive provider content.
@@ -62,14 +59,13 @@ Pi follows the merged Claude service/runner boundary. The open Codex design is u
 ## Design Decisions
 
 - Selected JSON mode over plain print mode for durable session identity.
-- Selected late binding because Pi owns session UUID creation.
-- Generalize the shared store now, but add only Pi on main; future Codex integration can extend the union consistently.
-- Keep synchronous send behavior and existing run locks; no daemon or streaming transport.
-- Preserve version 1 reads and write version 2 to avoid breaking merged Claude installations.
+- Use Pi's `--session-id` support so the durable repository remains the UUID authority.
+- Extend only the shared provider union and create input; no migration or legacy import is needed.
+- Keep synchronous send behavior and SQLite CAS ownership; no daemon or streaming transport.
 
 ## Non-Functional Requirements
 
 - Security: `shell: false`, stdin prompts, canonical non-symlink cwd, bounded JSON lines, sanitized summaries, no stderr reflection.
-- Reliability: atomic store mutations, provider/session uniqueness, ownership-checked binding, mismatch degradation, stale-run reconciliation.
+- Reliability: atomic SQLite mutations, provider/session uniqueness, CAS ownership, mismatch degradation, stale-run reconciliation.
 - Performance: streaming JSONL parsing with a 1 MiB default line bound; no whole-output buffering.
 - Compatibility: no dependencies and no behavioral changes to interactive Pi or Claude print invocations.

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -27,8 +27,10 @@ Pi provider modules mirror Claude under `src/providers/pi/durable/`. Shared dura
 - Complete: user-facing creation uses `--mode durable`; the retired `--mode print` spelling is rejected consistently.
 - Complete: pure `PiPrintProtocol` helpers make argument, session-identity, and assistant-text mapping independently testable at 100% coverage.
 - Complete: shared `durable/run.ts` now owns durable resolve, provider validation, run acquisition, execution, and completion ordering for Pi, Claude, and Codex services.
+- Complete: the shared lifecycle also owns sanitized 4 KiB success/failure summaries and healthy/mismatch/unknown completion mapping; providers supply only their mismatch predicate.
 - Complete: wrong-provider service calls fail before acquiring or mutating the target, and a failed successful-completion write is attempted only once.
 - Complete: `PiStreamParser` owns bounded JSONL state while the runner focuses on safe process orchestration.
+- Complete: Pi probe, service, and runner declarations and control flow now follow the expanded Claude/Codex formatting style.
 
 ### Patterns & Best Practices
 

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -1,0 +1,52 @@
+---
+phase: implementation
+title: Pi Print Mode Implementation
+description: Living implementation record for durable Pi print agents
+---
+
+# Pi Print Mode Implementation
+
+## Development Setup
+
+- Worktree: `feature-pi-print-mode` from `origin/main` at `a643f4a`.
+- References: merged Claude implementation under `packages/agent-manager/src/print/`; read-only Codex worktree at `../feature-codex-print-mode`.
+- Pi ground truth: installed package README, `docs/json.md`, and CLI capability probe.
+- Tests run with repository Vitest/Nx scripts; no new dependencies.
+
+## Code Structure
+
+Planned additions are `PiCliProbe.ts`, `PiPrintRunner.ts`, and `PiPrintAgentService.ts` beside the Claude modules. Shared store/types and agent CLI wiring are generalized minimally.
+
+## Implementation Notes
+
+### Core Features
+
+- Pending: provider-discriminated schema-v2 store with legacy reads.
+- Pending: strict Pi JSONL runner with late UUID binding and resume args.
+- Pending: provider-aware CLI creation/send/list/detail/console wiring.
+
+### Patterns & Best Practices
+
+- Red-green-refactor for each planning task.
+- Mock child processes and store boundaries; validate public behavior.
+- Preserve Claude defaults for callers that omit provider.
+
+## Integration Points
+
+`agent start` creates through the provider service; `agent send` resolves the persisted record then dispatches by provider; list/detail/console use the shared store union.
+
+## Error Handling
+
+Provider-specific probe/protocol/process errors are sanitized. The service maps identity mismatches to `sessionHealth: mismatch` and other failures to `unknown`, then records completion to release ownership.
+
+## Performance Considerations
+
+Parse stdout incrementally with a 1 MiB line limit. Store only the final bounded result summary.
+
+## Security Notes
+
+No shell, prompt via stdin, canonical cwd, no stderr reflection, UUID validation, ownership-checked session binding, and existing safe-file/run-lock protections.
+
+## Deviations and Follow-ups
+
+None at design completion. This document will be updated after each task with files, evidence, and deviations.

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -23,7 +23,7 @@ Pi provider modules live beside the Claude modules under `src/durable/`. Shared 
 
 - Complete: Pi support in the shared SQLite `DurableAgentRepository`; no legacy import or Pi-specific migration is needed.
 - Complete: Pi capability probe, bounded JSONL runner, repository-assigned session UUID via `--session-id`, exact resume args, and service state orchestration.
-- Pending: provider-aware CLI creation/send/list/detail/console wiring.
+- Complete: provider-aware CLI creation/send dispatch, Pi labels, and shared durable list/detail integration.
 
 ### Patterns & Best Practices
 

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -9,21 +9,22 @@ description: Living implementation record for durable Pi print agents
 ## Development Setup
 
 - Worktree: `feature-pi-print-mode`, rebased onto the durable-agents architecture on `origin/main`.
-- References: merged Claude implementation under `packages/agent-manager/src/durable/`; read-only Codex worktree at `../feature-codex-print-mode`.
+- References: merged shared durability implementation under `packages/agent-manager/src/durable/` and provider implementations under `packages/agent-manager/src/providers/{claude,codex}/`.
 - Pi ground truth: installed package README, `docs/json.md`, and CLI capability probe.
 - Tests run with repository Vitest/Nx scripts; no new dependencies.
 
 ## Code Structure
 
-Pi provider modules live beside the Claude modules under `src/durable/`. Shared changes are limited to the provider union, repository create input, exports, and CLI dispatch.
+Pi provider modules mirror Claude under `src/providers/pi/durable/`. Shared durability models and SQLite persistence remain under `src/durable/`; shared changes are limited to the provider union, repository create input, exports, and CLI dispatch.
 
 ## Implementation Notes
 
 ### Core Features
 
-- Complete: Pi support in the shared SQLite `DurableAgentRepository`; no legacy import or Pi-specific migration is needed.
+- Complete: Pi support in the shared SQLite `DurableAgentRepository`; migration 004 permits Codex's deferred session binding, while Pi retains a non-null repository-assigned session UUID.
 - Complete: Pi capability probe, bounded JSONL runner, repository-assigned session UUID via `--session-id`, exact resume args, and service state orchestration.
 - Complete: provider-aware CLI creation/send dispatch, Pi labels, and shared durable list/detail integration.
+- Complete: user-facing creation uses `--mode durable`; the retired `--mode print` spelling is rejected consistently.
 - Complete: pure `PiPrintProtocol` helpers make argument, session-identity, and assistant-text mapping independently testable at 100% coverage.
 
 ### Patterns & Best Practices
@@ -50,4 +51,4 @@ No shell, prompt via stdin, canonical cwd, no stderr reflection, UUID validation
 
 ## Deviations and Follow-ups
 
-The original file-store generalization was dropped because main now supplies SQLite persistence and CAS concurrency. Pi uses the repository-assigned UUID directly, avoiding late session binding. Provider files are isolated under `src/durable/`; shared edits remain additive.
+The original file-store generalization was dropped because main supplies SQLite persistence and CAS concurrency. Unlike Codex, Pi accepts `--session-id`, so it uses a repository-assigned non-null UUID and does not call the Codex-only late-binding method. Pi already exposes the landed repository/probe/runner injection seams. Provider files are isolated under `src/providers/pi/durable/`; shared edits remain additive.

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -24,6 +24,7 @@ Pi provider modules live beside the Claude modules under `src/durable/`. Shared 
 - Complete: Pi support in the shared SQLite `DurableAgentRepository`; no legacy import or Pi-specific migration is needed.
 - Complete: Pi capability probe, bounded JSONL runner, repository-assigned session UUID via `--session-id`, exact resume args, and service state orchestration.
 - Complete: provider-aware CLI creation/send dispatch, Pi labels, and shared durable list/detail integration.
+- Complete: pure `PiPrintProtocol` helpers make argument, session-identity, and assistant-text mapping independently testable at 100% coverage.
 
 ### Patterns & Best Practices
 
@@ -49,4 +50,4 @@ No shell, prompt via stdin, canonical cwd, no stderr reflection, UUID validation
 
 ## Deviations and Follow-ups
 
-The original file-store generalization was dropped because main now supplies SQLite persistence and CAS concurrency. Pi uses the repository-assigned UUID directly, avoiding late session binding.
+The original file-store generalization was dropped because main now supplies SQLite persistence and CAS concurrency. Pi uses the repository-assigned UUID directly, avoiding late session binding. Provider files are isolated under `src/durable/`; shared edits remain additive.

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -8,21 +8,21 @@ description: Living implementation record for durable Pi print agents
 
 ## Development Setup
 
-- Worktree: `feature-pi-print-mode` from `origin/main` at `a643f4a`.
-- References: merged Claude implementation under `packages/agent-manager/src/print/`; read-only Codex worktree at `../feature-codex-print-mode`.
+- Worktree: `feature-pi-print-mode`, rebased onto the durable-agents architecture on `origin/main`.
+- References: merged Claude implementation under `packages/agent-manager/src/durable/`; read-only Codex worktree at `../feature-codex-print-mode`.
 - Pi ground truth: installed package README, `docs/json.md`, and CLI capability probe.
 - Tests run with repository Vitest/Nx scripts; no new dependencies.
 
 ## Code Structure
 
-Planned additions are `PiCliProbe.ts`, `PiPrintRunner.ts`, and `PiPrintAgentService.ts` beside the Claude modules. Shared store/types and agent CLI wiring are generalized minimally.
+Pi provider modules live beside the Claude modules under `src/durable/`. Shared changes are limited to the provider union, repository create input, exports, and CLI dispatch.
 
 ## Implementation Notes
 
 ### Core Features
 
-- Pending: provider-discriminated schema-v2 store with legacy reads.
-- Pending: strict Pi JSONL runner with late UUID binding and resume args.
+- Complete: Pi support in the shared SQLite `DurableAgentRepository`; no legacy import or Pi-specific migration is needed.
+- Complete: Pi capability probe, bounded JSONL runner, repository-assigned session UUID via `--session-id`, exact resume args, and service state orchestration.
 - Pending: provider-aware CLI creation/send/list/detail/console wiring.
 
 ### Patterns & Best Practices
@@ -33,7 +33,7 @@ Planned additions are `PiCliProbe.ts`, `PiPrintRunner.ts`, and `PiPrintAgentServ
 
 ## Integration Points
 
-`agent start` creates through the provider service; `agent send` resolves the persisted record then dispatches by provider; list/detail/console use the shared store union.
+`agent start` creates through the provider service; `agent send` resolves the persisted record then dispatches by provider; list/detail/console use the shared durable repository.
 
 ## Error Handling
 
@@ -45,8 +45,8 @@ Parse stdout incrementally with a 1 MiB line limit. Store only the final bounded
 
 ## Security Notes
 
-No shell, prompt via stdin, canonical cwd, no stderr reflection, UUID validation, ownership-checked session binding, and existing safe-file/run-lock protections.
+No shell, prompt via stdin, canonical cwd, no stderr reflection, UUID validation, and SQLite CAS run ownership.
 
 ## Deviations and Follow-ups
 
-None at design completion. This document will be updated after each task with files, evidence, and deviations.
+The original file-store generalization was dropped because main now supplies SQLite persistence and CAS concurrency. Pi uses the repository-assigned UUID directly, avoiding late session binding.

--- a/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/implementation/2026-08-17-feature-pi-print-mode.md
@@ -26,12 +26,16 @@ Pi provider modules mirror Claude under `src/providers/pi/durable/`. Shared dura
 - Complete: provider-aware CLI creation/send dispatch, Pi labels, and shared durable list/detail integration.
 - Complete: user-facing creation uses `--mode durable`; the retired `--mode print` spelling is rejected consistently.
 - Complete: pure `PiPrintProtocol` helpers make argument, session-identity, and assistant-text mapping independently testable at 100% coverage.
+- Complete: shared `durable/run.ts` now owns durable resolve, provider validation, run acquisition, execution, and completion ordering for Pi, Claude, and Codex services.
+- Complete: wrong-provider service calls fail before acquiring or mutating the target, and a failed successful-completion write is attempted only once.
+- Complete: `PiStreamParser` owns bounded JSONL state while the runner focuses on safe process orchestration.
 
 ### Patterns & Best Practices
 
 - Red-green-refactor for each planning task.
 - Mock child processes and store boundaries; validate public behavior.
 - Preserve Claude defaults for callers that omit provider.
+- Reuse shared durable sanitization, UUID validation, line buffering, process inspection, and child-close helpers instead of Pi-local copies.
 
 ## Integration Points
 
@@ -40,6 +44,8 @@ Pi provider modules mirror Claude under `src/providers/pi/durable/`. Shared dura
 ## Error Handling
 
 Provider-specific probe/protocol/process errors are sanitized. The service maps identity mismatches to `sessionHealth: mismatch` and other failures to `unknown`, then records completion to release ownership.
+
+Successful completion persistence is outside the runner failure handler, so repository completion errors are not reclassified or retried as provider failures.
 
 ## Performance Considerations
 
@@ -52,3 +58,5 @@ No shell, prompt via stdin, canonical cwd, no stderr reflection, UUID validation
 ## Deviations and Follow-ups
 
 The original file-store generalization was dropped because main supplies SQLite persistence and CAS concurrency. Unlike Codex, Pi accepts `--session-id`, so it uses a repository-assigned non-null UUID and does not call the Codex-only late-binding method. Pi already exposes the landed repository/probe/runner injection seams. Provider files are isolated under `src/providers/pi/durable/`; shared edits remain additive.
+
+The 2026-08-27 simplification introduced one provider-neutral lifecycle function after three providers demonstrated the same sequence. Protocol parsing, error classification, session binding, and runner construction remain provider-local; no base class or provider plugin framework was added.

--- a/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
@@ -12,7 +12,7 @@ description: TDD implementation plan for durable Pi print agents
 - [x] Architecture and test strategy
 - [x] Provider-aware durable storage
 - [x] Pi probe, runner, and service
-- [ ] CLI integration and lifecycle verification
+- [x] CLI integration and lifecycle verification
 
 ## Task Breakdown
 
@@ -30,7 +30,7 @@ description: TDD implementation plan for durable Pi print agents
 ### Phase 3: CLI Integration
 
 - [x] T6: Add failing CLI tests for Pi print start, provider-aware send/list/detail/console representation, validation, and Claude regression; implement dispatch wiring and exports. Depends on T5. Evidence: CLI targeted suite. Scenarios: S25-S30.
-- [ ] T7: Update implementation/testing docs, run full relevant tests, coverage, lint, typecheck/build, and lifecycle review. Depends on all tasks. Evidence: fresh command outputs and feature lint.
+- [x] T7: Update implementation/testing docs, run full relevant tests, coverage, lint, typecheck/build, and lifecycle review. Depends on all tasks. Evidence: fresh command outputs and feature lint.
 
 ## Dependencies
 
@@ -46,4 +46,4 @@ Storage generalization precedes provider code; runner and probe precede service;
 
 ## Progress Summary
 
-The obsolete file-store generalization commit was dropped during rebase. Pi provider and CLI adaptation now target `DurableAgentRepository`; full validation remains.
+The obsolete file-store generalization commit was dropped during rebase. Pi provider and CLI adaptation now target `DurableAgentRepository`; fresh post-rebase validation is required before completion.

--- a/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
@@ -32,6 +32,11 @@ description: TDD implementation plan for durable Pi print agents
 - [x] T6: Add failing CLI tests for Pi print start, provider-aware send/list/detail/console representation, validation, and Claude regression; implement dispatch wiring and exports. Depends on T5. Evidence: CLI targeted suite. Scenarios: S25-S30.
 - [x] T7: Update implementation/testing docs, run full relevant tests, coverage, lint, typecheck/build, and lifecycle review. Depends on all tasks. Evidence: fresh command outputs and feature lint.
 
+### Phase 4: Durable Lifecycle Simplification
+
+- [x] T8: Add regressions and correct provider validation/completion sequencing across Pi, Claude, and Codex durable services.
+- [x] T9: Extract the shared durable-run lifecycle, move Pi stream state into a provider-local parser, and reuse shared sanitization, UUID, buffering, process, and child-close utilities.
+
 ## Dependencies
 
 Storage generalization precedes provider code; runner and probe precede service; service precedes CLI. No new external dependencies. The Codex worktree is read-only reference material, never a branch dependency.

--- a/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
@@ -10,22 +10,22 @@ description: TDD implementation plan for durable Pi print agents
 
 - [x] Requirements and Pi CLI investigation
 - [x] Architecture and test strategy
-- [ ] Provider-aware durable storage
-- [ ] Pi probe, runner, and service
+- [x] Provider-aware durable storage
+- [x] Pi probe, runner, and service
 - [ ] CLI integration and lifecycle verification
 
 ## Task Breakdown
 
 ### Phase 1: Storage Foundation
 
-- [ ] T1: Add failing store/type tests for Pi creation, legacy migration, safe late session binding, uniqueness, and invalid records. Depends on none. Evidence: targeted store suite and 100% new pure-logic coverage. Scenarios: S1-S5.
-- [ ] T2: Implement provider-discriminated agents and schema-v2 store behavior while retaining Claude compatibility. Depends on T1. Evidence: store and Claude suites green.
+- [x] T1: Rebase onto the SQLite durable-agent repository and add a failing test for Pi creation/provider validation. No legacy import is required.
+- [x] T2: Extend the provider union and repository create input additively while retaining Claude defaults and CAS behavior.
 
 ### Phase 2: Pi Provider
 
-- [ ] T3: Add failing probe tests for supported, missing, unsupported, and sanitized failure cases; implement `PiCliProbe`. Depends on T2. Evidence: probe suite and coverage. Scenarios: S6-S8.
-- [ ] T4: Add failing runner tests for first/resume args, stdin, event parsing, identity mismatch, malformed/oversized/incomplete output, process failures, and callbacks; implement `PiPrintRunner`. Depends on T2. Evidence: runner suite and coverage. Scenarios: S9-S18.
-- [ ] T5: Add failing mocked-service integration tests for create/send success, resume, ambiguity/provider mismatch, binding failure, and state recording; implement `PiPrintAgentService`. Depends on T3-T4. Evidence: service suite. Scenarios: S19-S24.
+- [x] T3: Add failing probe tests for supported, missing, unsupported, and sanitized failure cases; implement `PiCliProbe`. Depends on T2. Evidence: probe suite and coverage. Scenarios: S6-S8.
+- [x] T4: Add failing runner tests for first/resume args, stdin, event parsing, identity mismatch, malformed/oversized/incomplete output, process failures, and callbacks; implement `PiPrintRunner`. Depends on T2. Evidence: runner suite and coverage. Scenarios: S9-S18.
+- [x] T5: Add failing mocked-service integration tests for create/send success, resume, ambiguity/provider mismatch, binding failure, and state recording; implement `PiPrintAgentService`. Depends on T3-T4. Evidence: service suite. Scenarios: S19-S24.
 
 ### Phase 3: CLI Integration
 
@@ -46,4 +46,4 @@ Storage generalization precedes provider code; runner and probe precede service;
 
 ## Progress Summary
 
-Research and design are complete. Implementation begins with storage tests, then moves through one red-green-refactor cycle per task. Optional task tracing is unavailable, so this checklist and phase commits are the durable progress record.
+The obsolete file-store generalization commit was dropped during rebase. Pi provider adaptation now targets `DurableAgentRepository`, with CLI integration and full verification remaining.

--- a/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
@@ -36,6 +36,7 @@ description: TDD implementation plan for durable Pi print agents
 
 - [x] T8: Add regressions and correct provider validation/completion sequencing across Pi, Claude, and Codex durable services.
 - [x] T9: Extract the shared durable-run lifecycle, move Pi stream state into a provider-local parser, and reuse shared sanitization, UUID, buffering, process, and child-close utilities.
+- [x] T10: Consolidate identical success/failure completion construction in the durable-run lifecycle and expand dense Pi provider code for linear readability.
 
 ## Dependencies
 

--- a/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
@@ -1,0 +1,49 @@
+---
+phase: planning
+title: Pi Print Mode Plan
+description: TDD implementation plan for durable Pi print agents
+---
+
+# Pi Print Mode Plan
+
+## Milestones
+
+- [x] Requirements and Pi CLI investigation
+- [x] Architecture and test strategy
+- [ ] Provider-aware durable storage
+- [ ] Pi probe, runner, and service
+- [ ] CLI integration and lifecycle verification
+
+## Task Breakdown
+
+### Phase 1: Storage Foundation
+
+- [ ] T1: Add failing store/type tests for Pi creation, legacy migration, safe late session binding, uniqueness, and invalid records. Depends on none. Evidence: targeted store suite and 100% new pure-logic coverage. Scenarios: S1-S5.
+- [ ] T2: Implement provider-discriminated agents and schema-v2 store behavior while retaining Claude compatibility. Depends on T1. Evidence: store and Claude suites green.
+
+### Phase 2: Pi Provider
+
+- [ ] T3: Add failing probe tests for supported, missing, unsupported, and sanitized failure cases; implement `PiCliProbe`. Depends on T2. Evidence: probe suite and coverage. Scenarios: S6-S8.
+- [ ] T4: Add failing runner tests for first/resume args, stdin, event parsing, identity mismatch, malformed/oversized/incomplete output, process failures, and callbacks; implement `PiPrintRunner`. Depends on T2. Evidence: runner suite and coverage. Scenarios: S9-S18.
+- [ ] T5: Add failing mocked-service integration tests for create/send success, resume, ambiguity/provider mismatch, binding failure, and state recording; implement `PiPrintAgentService`. Depends on T3-T4. Evidence: service suite. Scenarios: S19-S24.
+
+### Phase 3: CLI Integration
+
+- [ ] T6: Add failing CLI tests for Pi print start, provider-aware send/list/detail/console representation, validation, and Claude regression; implement dispatch wiring and exports. Depends on T5. Evidence: CLI targeted suite. Scenarios: S25-S30.
+- [ ] T7: Update implementation/testing docs, run full relevant tests, coverage, lint, typecheck/build, and lifecycle review. Depends on all tasks. Evidence: fresh command outputs and feature lint.
+
+## Dependencies
+
+Storage generalization precedes provider code; runner and probe precede service; service precedes CLI. No new external dependencies. The Codex worktree is read-only reference material, never a branch dependency.
+
+## Risks & Mitigation
+
+- Pi protocol drift: capability probe plus strict protocol tests and explicit errors.
+- Store migration regression: version-1 fixtures and full Claude print regression suite.
+- Session cross-binding: ownership checks and per-provider uniqueness.
+- Sensitive output leakage: stderr drain and bounded sanitized summaries.
+- CLI ambiguity: dispatch from persisted provider and preserve existing exact-ID rules.
+
+## Progress Summary
+
+Research and design are complete. Implementation begins with storage tests, then moves through one red-green-refactor cycle per task. Optional task tracing is unavailable, so this checklist and phase commits are the durable progress record.

--- a/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/planning/2026-08-17-feature-pi-print-mode.md
@@ -29,7 +29,7 @@ description: TDD implementation plan for durable Pi print agents
 
 ### Phase 3: CLI Integration
 
-- [ ] T6: Add failing CLI tests for Pi print start, provider-aware send/list/detail/console representation, validation, and Claude regression; implement dispatch wiring and exports. Depends on T5. Evidence: CLI targeted suite. Scenarios: S25-S30.
+- [x] T6: Add failing CLI tests for Pi print start, provider-aware send/list/detail/console representation, validation, and Claude regression; implement dispatch wiring and exports. Depends on T5. Evidence: CLI targeted suite. Scenarios: S25-S30.
 - [ ] T7: Update implementation/testing docs, run full relevant tests, coverage, lint, typecheck/build, and lifecycle review. Depends on all tasks. Evidence: fresh command outputs and feature lint.
 
 ## Dependencies
@@ -46,4 +46,4 @@ Storage generalization precedes provider code; runner and probe precede service;
 
 ## Progress Summary
 
-The obsolete file-store generalization commit was dropped during rebase. Pi provider adaptation now targets `DurableAgentRepository`, with CLI integration and full verification remaining.
+The obsolete file-store generalization commit was dropped during rebase. Pi provider and CLI adaptation now target `DurableAgentRepository`; full validation remains.

--- a/docs/ai/requirements/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/requirements/2026-08-17-feature-pi-print-mode.md
@@ -36,7 +36,7 @@ Non-goals:
 
 ## Success Criteria
 
-- `--type pi --mode print` creates a persisted `provider: "pi"` print agent with an initially unbound provider session.
+- `--type pi --mode print` creates a persisted durable `provider: "pi"` agent with a repository-assigned provider session UUID.
 - First send invokes `pi --mode json`, extracts and stores the session header UUID, and returns the final assistant text.
 - Later sends invoke `pi --mode json --session <uuid>` and reject a different emitted UUID.
 - Pi agents participate in existing list/detail/send/console flows and provider-specific dispatch.
@@ -58,7 +58,7 @@ Non-goals:
 - `pi -p`: simple text output but does not expose the new session UUID reliably; rejected.
 - Discover the session file after execution: races with other Pi processes and couples to filesystem layout; rejected.
 - `pi --mode rpc`: designed for a long-lived controller and adds unnecessary lifecycle complexity; rejected.
-- `pi --mode json` with late binding: deterministic structured identity and events using the documented CLI; selected.
+- `pi --mode json --session-id <uuid>`: deterministic structured identity using the repository-assigned UUID; selected.
 
 ## Questions & Open Items
 

--- a/docs/ai/requirements/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/requirements/2026-08-17-feature-pi-print-mode.md
@@ -12,7 +12,7 @@ AI DevKit can start Pi only as an interactive terminal process. Automation needs
 
 ## Goals & Objectives
 
-- Support `ai-devkit agent start --type pi --mode print --name <name> --cwd <dir>`.
+- Support `ai-devkit agent start --type pi --mode durable --name <name> --cwd <dir>`.
 - Run Pi non-interactively through its structured JSON event mode.
 - Persist the Pi session UUID after the first run and resume it with `--session <id>`.
 - Reuse Claude print-agent identity, locking, lifecycle, listing, detail, and pruning semantics.
@@ -36,8 +36,8 @@ Non-goals:
 
 ## Success Criteria
 
-- `--type pi --mode print` creates a persisted durable `provider: "pi"` agent with a repository-assigned provider session UUID.
-- First send invokes `pi --mode json`, extracts and stores the session header UUID, and returns the final assistant text.
+- `--type pi --mode durable` creates a persisted `provider: "pi"` agent with a repository-assigned provider session UUID.
+- First send invokes `pi --mode json --session-id <uuid>`, verifies the session header UUID, and returns the final assistant text.
 - Later sends invoke `pi --mode json --session <uuid>` and reject a different emitted UUID.
 - Pi agents participate in existing list/detail/send/console flows and provider-specific dispatch.
 - Claude store data remains readable and Claude tests remain green.
@@ -47,7 +47,7 @@ Non-goals:
 ## Constraints & Assumptions
 
 - Ground truth is the installed `@earendil-works/pi-coding-agent`: `--mode json` is non-interactive, emits a leading `{type:"session", id}` JSON line, auto-saves sessions, and accepts `--session <path|id>`.
-- Pi has no Claude-style caller-assigned session ID; the store must bind the provider-emitted UUID during the first run.
+- Pi supports a Claude-style caller-assigned session ID through `--session-id`; the repository assigns it at creation and every run verifies the provider-emitted UUID.
 - Pi JSON mode emits lifecycle events rather than one terminal result object; the runner derives the result from completed assistant messages and requires `agent_end`.
 - Prompts are written to stdin to avoid shell interpolation and command-line disclosure; subprocesses use `shell: false`.
 - Existing print-agent storage must migrate safely without losing Claude agents.

--- a/docs/ai/requirements/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/requirements/2026-08-17-feature-pi-print-mode.md
@@ -1,0 +1,65 @@
+---
+phase: requirements
+title: Pi Print Mode Requirements
+description: Durable non-interactive Pi coding agents managed by AI DevKit
+---
+
+# Pi Print Mode Requirements
+
+## Problem Statement
+
+AI DevKit can start Pi only as an interactive terminal process. Automation needs a durable, non-interactive Pi agent that can be registered once, addressed by AI DevKit ID or name, resumed across invocations, inspected alongside other agents, and reconciled after an interrupted run.
+
+## Goals & Objectives
+
+- Support `ai-devkit agent start --type pi --mode print --name <name> --cwd <dir>`.
+- Run Pi non-interactively through its structured JSON event mode.
+- Persist the Pi session UUID after the first run and resume it with `--session <id>`.
+- Reuse Claude print-agent identity, locking, lifecycle, listing, detail, and pruning semantics.
+- Keep Claude print agents backward compatible and align storage with the Codex print-mode generalization in PR #148.
+- Add no runtime dependencies.
+
+Non-goals:
+
+- Changing existing interactive Pi behavior.
+- Streaming partial Pi output or live heartbeats to the console.
+- Supporting Pi's interactive session picker (`--resume`) or forking.
+- Merging or depending on the open Codex print branch.
+
+## User Stories & Use Cases
+
+- As an automation user, I can register a named Pi print agent without opening a terminal UI.
+- As a user, I can send multiple prompts to that agent and retain Pi conversation context.
+- As a user, I can see Pi print agents in `agent list` and `agent console`, and inspect their provider session ID.
+- As a user, I receive a clear failure when Pi is missing, lacks required flags, emits invalid JSON, changes session identity, or exits unsuccessfully.
+- As a user, an interrupted provider process is reconciled using existing print-agent run-lock behavior.
+
+## Success Criteria
+
+- `--type pi --mode print` creates a persisted `provider: "pi"` print agent with an initially unbound provider session.
+- First send invokes `pi --mode json`, extracts and stores the session header UUID, and returns the final assistant text.
+- Later sends invoke `pi --mode json --session <uuid>` and reject a different emitted UUID.
+- Pi agents participate in existing list/detail/send/console flows and provider-specific dispatch.
+- Claude store data remains readable and Claude tests remain green.
+- New probe, protocol parsing, and argument mapping branches have 100% statement, branch, function, and line coverage.
+- Agent-manager and CLI tests, typechecks/builds, and feature-doc lint pass.
+
+## Constraints & Assumptions
+
+- Ground truth is the installed `@earendil-works/pi-coding-agent`: `--mode json` is non-interactive, emits a leading `{type:"session", id}` JSON line, auto-saves sessions, and accepts `--session <path|id>`.
+- Pi has no Claude-style caller-assigned session ID; the store must bind the provider-emitted UUID during the first run.
+- Pi JSON mode emits lifecycle events rather than one terminal result object; the runner derives the result from completed assistant messages and requires `agent_end`.
+- Prompts are written to stdin to avoid shell interpolation and command-line disclosure; subprocesses use `shell: false`.
+- Existing print-agent storage must migrate safely without losing Claude agents.
+- The globally installed lifecycle skills satisfy execution even though project-local built-in installation fails at `.agents/skills`; optional task tracing is unavailable (`unknown command 'task'`).
+
+## Alternatives Considered
+
+- `pi -p`: simple text output but does not expose the new session UUID reliably; rejected.
+- Discover the session file after execution: races with other Pi processes and couples to filesystem layout; rejected.
+- `pi --mode rpc`: designed for a long-lived controller and adds unnecessary lifecycle complexity; rejected.
+- `pi --mode json` with late binding: deterministic structured identity and events using the documented CLI; selected.
+
+## Questions & Open Items
+
+No material open items. Pi's documented session identity and resume surface resolves the durability question.

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -1,0 +1,85 @@
+---
+phase: testing
+title: Pi Print Mode Testing Strategy
+description: Unit, integration, CLI, and regression coverage for Pi print agents
+---
+
+# Pi Print Mode Testing Strategy
+
+## Test Coverage Goals
+
+- 100% statements, branches, functions, and lines for new pure probe/protocol/argument-mapping logic.
+- Mocked subprocess tests; no model credentials or network calls.
+- Mocked-store service integration tests for every state transition.
+- CLI command tests for critical creation and dispatch flows.
+- Full Claude print regression coverage and package typecheck/build.
+
+## Unit Tests
+
+### Store and Types
+
+- [ ] S1 Pi agents start with a null provider session while Claude retains an assigned UUID.
+- [ ] S2 version-1 Claude stores load and migrate to version 2 on mutation.
+- [ ] S3 an owned Pi run binds one valid UUID idempotently.
+- [ ] S4 binding rejects invalid UUIDs, ownership changes, non-Pi agents, mismatches, and duplicate provider bindings.
+- [ ] S5 malformed provider-discriminated records are rejected.
+
+### Pi CLI Probe
+
+- [ ] S6 supported Pi help/version returns sanitized metadata.
+- [ ] S7 missing flags produce an unsupported-capability error.
+- [ ] S8 execution failures produce a sanitized unavailable error.
+
+### Pi JSON Runner
+
+- [ ] S9 first-run args are `--mode json`; resume adds `--session <uuid>`; prompt uses stdin and shell is disabled.
+- [ ] S10 provider process identity and session callbacks run.
+- [ ] S11 the session header and completed assistant message yield the final result.
+- [ ] S12 multiple assistant completions return the last complete message.
+- [ ] S13 missing/invalid/duplicate/mismatched session identity is rejected.
+- [ ] S14 malformed, non-object, oversized, or incomplete JSON is rejected.
+- [ ] S15 missing `agent_end` or assistant output is rejected.
+- [ ] S16 spawn identity/start errors and callback failures terminate safely.
+- [ ] S17 non-zero/signal exits become process errors.
+- [ ] S18 stderr is drained without inclusion in results.
+
+## Integration Tests
+
+- [ ] S19 service create probes and persists provider `pi`.
+- [ ] S20 first send records process/session, success, health, and sanitized summary.
+- [ ] S21 resumed send preserves the bound session.
+- [ ] S22 missing/ambiguous/wrong-provider references fail clearly.
+- [ ] S23 protocol/store session mismatches record mismatch health.
+- [ ] S24 other failures record unknown health and release the run.
+
+## CLI and End-to-End Tests
+
+- [ ] S25 `agent start --type pi --mode print` creates without interactive launch.
+- [ ] S26 unsupported print providers and modes remain rejected.
+- [ ] S27 `agent send` dispatches Pi records to the Pi service and reports provider `pi`.
+- [ ] S28 list/detail output identifies Pi print agents and nullable pre-first-run sessions safely.
+- [ ] S29 console receives the combined interactive/print registry.
+- [ ] S30 Claude print start/send/list/detail behavior remains green.
+
+## Test Data
+
+Use temporary store/cwd fixtures, deterministic clocks/process identities, valid UUID fixtures, mocked child-process streams, and mocked probe/runner/store boundaries. Never invoke a live model.
+
+## Test Reporting & Coverage
+
+- Targeted: `npx vitest run <changed test files>` in relevant packages.
+- Coverage: package Vitest coverage scoped to Pi pure-logic files with 100% thresholds.
+- Regression: `npm test --workspace @ai-devkit/agent-manager` and CLI equivalent.
+- Static: package lint/typecheck/build and `npx ai-devkit@latest lint --feature pi-print-mode`.
+
+## Manual Testing
+
+No credentialed Pi model run is required. `pi --help` and installed docs provide CLI-surface evidence; subprocess behavior is deterministic under mocks.
+
+## Performance and Security Testing
+
+Oversized-line tests exercise the memory bound. Spawn assertions cover `shell: false`, cwd binding, stdin prompt delivery, stderr draining, and provider-output sanitization.
+
+## Bug Tracking
+
+Any failing scenario returns to its implementation task, is added as a regression test first, and is documented in implementation notes.

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -72,6 +72,15 @@ Use temporary store/cwd fixtures, deterministic clocks/process identities, valid
 - Regression: `npm test --workspace @ai-devkit/agent-manager` and CLI equivalent.
 - Static: package lint/typecheck/build and `npx ai-devkit@latest lint --feature pi-print-mode`.
 
+Final evidence (2026-08-17):
+
+- Agent manager: 28 files, 552 tests passed.
+- CLI: 82 files, 986 tests passed.
+- Pi focused suites: 4 files, 23 tests passed.
+- Pure Pi protocol: 100% statements (26/26), branches (38/38), functions (4/4), and lines (20/20), enforced with `--coverage.thresholds.100=true`.
+- Agent-manager and CLI package builds passed; package lints passed (CLI retains five unrelated baseline warnings and zero errors).
+- Feature-doc lint passed all base, feature, branch, and worktree checks.
+
 ## Manual Testing
 
 No credentialed Pi model run is required. `pi --help` and installed docs provide CLI-surface evidence; subprocess behavior is deterministic under mocks.

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -26,31 +26,31 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 
 ### Pi CLI Probe
 
-- [ ] S6 supported Pi help/version returns sanitized metadata.
-- [ ] S7 missing flags produce an unsupported-capability error.
-- [ ] S8 execution failures produce a sanitized unavailable error.
+- [x] S6 supported Pi help/version returns sanitized metadata.
+- [x] S7 missing flags produce an unsupported-capability error.
+- [x] S8 execution failures produce a sanitized unavailable error.
 
 ### Pi JSON Runner
 
-- [ ] S9 first-run args are `--mode json`; resume adds `--session <uuid>`; prompt uses stdin and shell is disabled.
-- [ ] S10 provider process identity and session callbacks run.
-- [ ] S11 the session header and completed assistant message yield the final result.
-- [ ] S12 multiple assistant completions return the last complete message.
-- [ ] S13 missing/invalid/duplicate/mismatched session identity is rejected.
-- [ ] S14 malformed, non-object, oversized, or incomplete JSON is rejected.
-- [ ] S15 missing `agent_end` or assistant output is rejected.
-- [ ] S16 spawn identity/start errors and callback failures terminate safely.
-- [ ] S17 non-zero/signal exits become process errors.
-- [ ] S18 stderr is drained without inclusion in results.
+- [x] S9 first-run args are `--mode json`; resume adds `--session <uuid>`; prompt uses stdin and shell is disabled.
+- [x] S10 provider process identity and session callbacks run.
+- [x] S11 the session header and completed assistant message yield the final result.
+- [x] S12 multiple assistant completions return the last complete message.
+- [x] S13 missing/invalid/duplicate/mismatched session identity is rejected.
+- [x] S14 malformed, non-object, oversized, or incomplete JSON is rejected.
+- [x] S15 missing `agent_end` or assistant output is rejected.
+- [x] S16 spawn identity/start errors and callback failures terminate safely.
+- [x] S17 non-zero/signal exits become process errors.
+- [x] S18 stderr is drained without inclusion in results.
 
 ## Integration Tests
 
-- [ ] S19 service create probes and persists provider `pi`.
-- [ ] S20 first send records process/session, success, health, and sanitized summary.
-- [ ] S21 resumed send preserves the bound session.
-- [ ] S22 missing/ambiguous/wrong-provider references fail clearly.
-- [ ] S23 protocol/store session mismatches record mismatch health.
-- [ ] S24 other failures record unknown health and release the run.
+- [x] S19 service create probes and persists provider `pi`.
+- [x] S20 first send records process/session, success, health, and sanitized summary.
+- [x] S21 resumed send preserves the bound session.
+- [x] S22 missing/ambiguous/wrong-provider references fail clearly.
+- [x] S23 protocol/store session mismatches record mismatch health.
+- [x] S24 other failures record unknown health and release the run.
 
 ## CLI and End-to-End Tests
 

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -54,12 +54,12 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 
 ## CLI and End-to-End Tests
 
-- [ ] S25 `agent start --type pi --mode print` creates without interactive launch.
-- [ ] S26 unsupported print providers and modes remain rejected.
-- [ ] S27 `agent send` dispatches Pi records to the Pi service and reports provider `pi`.
-- [ ] S28 list/detail output identifies Pi print agents and nullable pre-first-run sessions safely.
-- [ ] S29 console receives the combined interactive/print registry.
-- [ ] S30 Claude print start/send/list/detail behavior remains green.
+- [x] S25 `agent start --type pi --mode print` creates without interactive launch.
+- [x] S26 unsupported print providers and modes remain rejected.
+- [x] S27 `agent send` dispatches Pi records to the Pi service and reports provider `pi`.
+- [x] S28 list/detail output identifies Pi print agents and nullable pre-first-run sessions safely.
+- [x] S29 console receives the combined interactive/print registry.
+- [x] S30 Claude print start/send/list/detail behavior remains green.
 
 ## Test Data
 

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -18,11 +18,11 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 
 ### Store and Types
 
-- [ ] S1 Pi agents start with a null provider session while Claude retains an assigned UUID.
-- [ ] S2 version-1 Claude stores load and migrate to version 2 on mutation.
-- [ ] S3 an owned Pi run binds one valid UUID idempotently.
-- [ ] S4 binding rejects invalid UUIDs, ownership changes, non-Pi agents, mismatches, and duplicate provider bindings.
-- [ ] S5 malformed provider-discriminated records are rejected.
+- [x] S1 Pi and Claude agents receive non-null provider sessions at creation while Codex starts null.
+- [x] S2 migration 004 preserves existing Claude rows while permitting deferred Codex sessions.
+- [x] S3 Pi first-run arguments use the repository-assigned UUID and verify the emitted session identity.
+- [x] S4 Codex-only session binding remains unavailable to Pi; Pi identity mismatches fail in the runner.
+- [x] S5 malformed provider-discriminated records, including null Pi sessions, are rejected.
 
 ### Pi CLI Probe
 
@@ -54,11 +54,11 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 
 ## CLI and End-to-End Tests
 
-- [x] S25 `agent start --type pi --mode print` creates without interactive launch.
-- [x] S26 unsupported print providers and modes remain rejected.
+- [x] S25 `agent start --type pi --mode durable` creates without interactive launch.
+- [x] S26 unsupported durable providers and the retired `print` mode name remain rejected.
 - [x] S27 `agent send` dispatches Pi records to the Pi service and reports provider `pi`.
 - [x] S28 list/detail output identifies durable Pi agents and their repository-assigned sessions.
-- [x] S29 console receives the combined interactive/print registry.
+- [x] S29 console receives the combined interactive/durable registry.
 - [x] S30 Claude print start/send/list/detail behavior remains green.
 
 ## Test Data

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -42,6 +42,8 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 - [x] S16 spawn identity/start errors and callback failures terminate safely.
 - [x] S17 non-zero/signal exits become process errors.
 - [x] S18 stderr is drained without inclusion in results.
+- [x] S31 session identities must be UUID strings; values that merely stringify as UUIDs are protocol errors.
+- [x] S34 parser blank-line handling, generic failure normalization, and signal-bearing process failures are covered directly.
 
 ## Integration Tests
 
@@ -51,6 +53,8 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 - [x] S22 missing/ambiguous/wrong-provider references fail clearly.
 - [x] S23 protocol/store session mismatches record mismatch health.
 - [x] S24 other failures record unknown health and release the run.
+- [x] S32 wrong-provider calls are rejected before acquiring or mutating durable run ownership for Pi, Claude, and Codex.
+- [x] S33 a failed successful-completion write is attempted once and is not reclassified as a provider execution failure.
 
 ## CLI and End-to-End Tests
 
@@ -80,6 +84,13 @@ Final evidence (2026-08-17):
 - Pure Pi protocol: 100% statements (26/26), branches (38/38), functions (4/4), and lines (20/20), enforced with `--coverage.thresholds.100=true`.
 - Agent-manager and CLI package builds passed; package lints passed (CLI retains five unrelated baseline warnings and zero errors).
 - Feature-doc lint passed all base, feature, branch, and worktree checks.
+
+Simplification verification (2026-08-27):
+
+- Agent manager: 41 files, 631 tests passed.
+- CLI durable-command regression: 1 file, 79 tests passed.
+- Pure Pi protocol/parser coverage: 100% statements (66/66), branches (62/62), functions (12/12), and lines (56/56).
+- Agent-manager lint, typecheck, and build passed; feature-doc lint passed.
 
 ## Manual Testing
 

--- a/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
+++ b/docs/ai/testing/2026-08-17-feature-pi-print-mode.md
@@ -57,7 +57,7 @@ description: Unit, integration, CLI, and regression coverage for Pi print agents
 - [x] S25 `agent start --type pi --mode print` creates without interactive launch.
 - [x] S26 unsupported print providers and modes remain rejected.
 - [x] S27 `agent send` dispatches Pi records to the Pi service and reports provider `pi`.
-- [x] S28 list/detail output identifies Pi print agents and nullable pre-first-run sessions safely.
+- [x] S28 list/detail output identifies durable Pi agents and their repository-assigned sessions.
 - [x] S29 console receives the combined interactive/print registry.
 - [x] S30 Claude print start/send/list/detail behavior remains green.
 

--- a/packages/agent-manager/src/__tests__/durable/CodexPrintAgentService.test.ts
+++ b/packages/agent-manager/src/__tests__/durable/CodexPrintAgentService.test.ts
@@ -52,7 +52,7 @@ describe('CodexPrintAgentService', () => {
         }));
     });
 
-    it('records mismatch separately from unknown failures and rejects non-Codex targets', async () => {
+    it('records mismatch separately from unknown failures', async () => {
         const api = await import('../../index.js') as Record<string, unknown>;
         const ErrorType = api.CodexPrintError as new (message: string, code: string) => Error;
         const completeRun = vi.fn();
@@ -67,10 +67,39 @@ describe('CodexPrintAgentService', () => {
         } });
         await expect(service.send('reviewer', 'x')).rejects.toMatchObject({ code: 'CODEX_SESSION_MISMATCH' });
         expect(completeRun).toHaveBeenCalledWith('id', 'one', expect.objectContaining({ sessionHealth: 'mismatch' }));
+    });
 
-        repository.acquireRun.mockResolvedValueOnce({ agent: { ...base, provider: 'claude' }, token: 'two' });
-        await expect(service.send('reviewer', 'x')).rejects.toMatchObject({ code: 'CODEX_UNSUPPORTED' });
-        expect(completeRun).toHaveBeenLastCalledWith('id', 'two', expect.objectContaining({ sessionHealth: 'unknown' }));
+    it('rejects a non-Codex target without acquiring or mutating it', async () => {
+        const api = await import('../../index.js') as Record<string, unknown>;
+        const Service = api.CodexPrintAgentService as new (options: unknown) => any;
+        const repository = {
+            resolve: vi.fn().mockResolvedValue({ ...base, provider: 'claude' }),
+            acquireRun: vi.fn(), recordProviderProcess: vi.fn(), bindProviderSession: vi.fn(), completeRun: vi.fn(),
+        };
+
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } })
+            .send('reviewer', 'x')).rejects.toMatchObject({ code: 'CODEX_UNSUPPORTED' });
+        expect(repository.acquireRun).not.toHaveBeenCalled();
+        expect(repository.completeRun).not.toHaveBeenCalled();
+    });
+
+    it('does not turn a successful completion write failure into a second completion', async () => {
+        const api = await import('../../index.js') as Record<string, unknown>;
+        const Service = api.CodexPrintAgentService as new (options: unknown) => any;
+        const completionFailure = new Error('completion failed');
+        const repository = {
+            resolve: vi.fn().mockResolvedValue(base),
+            acquireRun: vi.fn().mockResolvedValue({ agent: base, token: 'one' }),
+            recordProviderProcess: vi.fn(), bindProviderSession: vi.fn(),
+            completeRun: vi.fn().mockRejectedValue(completionFailure),
+        };
+        const runner = { run: vi.fn().mockResolvedValue({
+            sessionId: SESSION, result: 'answer', messages: ['answer'], exitCode: 0,
+        }) };
+
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner })
+            .send('reviewer', 'x')).rejects.toBe(completionFailure);
+        expect(repository.completeRun).toHaveBeenCalledOnce();
     });
 
     it('records a repository binding conflict as a session mismatch', async () => {

--- a/packages/agent-manager/src/__tests__/print/ClaudePrintAgentService.test.ts
+++ b/packages/agent-manager/src/__tests__/print/ClaudePrintAgentService.test.ts
@@ -43,4 +43,36 @@ describe('ClaudePrintAgentService', () => {
             status: 'succeeded', exitCode: 0, sessionHealth: 'healthy',
         }));
     });
+
+    it('rejects a non-Claude target without acquiring or mutating it', async () => {
+        const api = await import('../../index.js') as Record<string, unknown>;
+        const Service = api.ClaudePrintAgentService as new (options: unknown) => any;
+        const target = { id: 'id', name: 'reviewer', provider: 'pi' };
+        const repository = {
+            resolve: vi.fn().mockResolvedValue(target),
+            acquireRun: vi.fn(), recordProviderProcess: vi.fn(), completeRun: vi.fn(),
+        };
+
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } })
+            .send('reviewer', 'x')).rejects.toMatchObject({ code: 'CLAUDE_PRINT_UNSUPPORTED' });
+        expect(repository.acquireRun).not.toHaveBeenCalled();
+        expect(repository.completeRun).not.toHaveBeenCalled();
+    });
+
+    it('does not turn a successful completion write failure into a second completion', async () => {
+        const api = await import('../../index.js') as Record<string, unknown>;
+        const Service = api.ClaudePrintAgentService as new (options: unknown) => any;
+        const target = { id: 'id', name: 'reviewer', provider: 'claude', providerSessionId: 'session', sessionHealth: 'healthy' };
+        const completionFailure = new Error('completion failed');
+        const repository = {
+            resolve: vi.fn().mockResolvedValue(target),
+            acquireRun: vi.fn().mockResolvedValue({ agent: target, token: 'one' }),
+            recordProviderProcess: vi.fn(), completeRun: vi.fn().mockRejectedValue(completionFailure),
+        };
+        const runner = { run: vi.fn().mockResolvedValue({ sessionId: 'session', result: 'answer', exitCode: 0 }) };
+
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner })
+            .send('reviewer', 'x')).rejects.toBe(completionFailure);
+        expect(repository.completeRun).toHaveBeenCalledOnce();
+    });
 });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
@@ -29,7 +29,7 @@ describe('PiCliProbe', () => {
     });
 
     it('reports an empty version as unknown', async () => {
-        const api = await import('../../index.js') as Record<string, unknown>;
+        const api = await import('../../../../index.js') as Record<string, unknown>;
         const Probe = api.PiCliProbe as new (options: unknown) => any;
         const exec = vi.fn().mockResolvedValueOnce({ stdout: ' \n', stderr: '' })
             .mockResolvedValueOnce({ stdout: '--mode json --session-id --session', stderr: '' });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
@@ -32,7 +32,7 @@ describe('PiCliProbe', () => {
         const api = await import('../../index.js') as Record<string, unknown>;
         const Probe = api.PiCliProbe as new (options: unknown) => any;
         const exec = vi.fn().mockResolvedValueOnce({ stdout: ' \n', stderr: '' })
-            .mockResolvedValueOnce({ stdout: '--mode json --session', stderr: '' });
+            .mockResolvedValueOnce({ stdout: '--mode json --session-id --session', stderr: '' });
         await expect(new Probe({ exec }).validate()).resolves.toMatchObject({ version: 'unknown' });
     });
 });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('PiCliProbe', () => {
+    it('validates documented JSON mode and session capabilities', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>;
+        expect(api).toHaveProperty('PiCliProbe');
+        const exec = vi.fn()
+            .mockResolvedValueOnce({ stdout: 'pi 0.52.8', stderr: '' })
+            .mockResolvedValueOnce({ stdout: '--mode json\n--session-id <uuid>\n--session <path|id>', stderr: '' });
+        const Probe = api.PiCliProbe as new (options: unknown) => any;
+        await expect(new Probe({ executable: 'fake-pi', exec }).validate()).resolves.toEqual({
+            executable: 'fake-pi', version: 'pi 0.52.8',
+        });
+        expect(exec.mock.calls).toEqual([['fake-pi', ['--version']], ['fake-pi', ['--help']]]);
+    });
+
+    it('rejects unsupported and unavailable CLIs with sanitized errors', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>;
+        const Probe = api.PiCliProbe as new (options: unknown) => any;
+        await expect(new Probe({ exec: vi.fn()
+            .mockResolvedValueOnce({ stdout: '', stderr: '' })
+            .mockResolvedValueOnce({ stdout: '--print only', stderr: '' }) }).validate())
+            .rejects.toMatchObject({ code: 'PI_CLI_UNSUPPORTED' });
+        const unavailable = new Probe({ exec: vi.fn().mockRejectedValue(new Error(`bad\0${'x'.repeat(1000)}`)) });
+        const error = await unavailable.validate().catch((value: Error & { code: string }) => value);
+        expect(error.code).toBe('PI_CLI_UNAVAILABLE');
+        expect(error.message).not.toContain('\0');
+        expect(error.message.length).toBeLessThan(600);
+    });
+});

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiCliProbe.test.ts
@@ -27,4 +27,12 @@ describe('PiCliProbe', () => {
         expect(error.message).not.toContain('\0');
         expect(error.message.length).toBeLessThan(600);
     });
+
+    it('reports an empty version as unknown', async () => {
+        const api = await import('../../index.js') as Record<string, unknown>;
+        const Probe = api.PiCliProbe as new (options: unknown) => any;
+        const exec = vi.fn().mockResolvedValueOnce({ stdout: ' \n', stderr: '' })
+            .mockResolvedValueOnce({ stdout: '--mode json --session', stderr: '' });
+        await expect(new Probe({ exec }).validate()).resolves.toMatchObject({ version: 'unknown' });
+    });
 });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiDurableAgentRepository.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiDurableAgentRepository.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DurableAgentRepository } from '../../../../durable/DurableAgentRepository.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('Pi durable-agent repository sessions', () => {
+    it('assigns a non-null session at creation and rejects deferred binding', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-durable-repository-'));
+        roots.push(root);
+        const cwd = path.join(root, 'project');
+        fs.mkdirSync(cwd);
+        const repository = new DurableAgentRepository({
+            dbPath: path.join(root, 'agents.db'),
+            processInspector: { getIdentity: (pid) => ({ pid, startedAt: 'owner-start' }) },
+        });
+
+        const agent = await repository.create({ name: 'reviewer', cwd, provider: 'pi' });
+        expect(agent).toMatchObject({ provider: 'pi', sessionHealth: 'uninitialized' });
+        expect(agent.providerSessionId).toMatch(/^[0-9a-f-]{36}$/);
+
+        const run = await repository.acquireRun(agent.id);
+        await expect(repository.bindProviderSession(agent.id, run.token, crypto.randomUUID()))
+            .rejects.toThrow('Only Codex durable sessions can be bound after creation.');
+    });
+});

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintAgentService.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintAgentService.test.ts
@@ -5,7 +5,7 @@ const base = { id: 'id', name: 'reviewer', provider: 'pi', providerSessionId: SE
 describe('PiPrintAgentService', () => {
     it('probes before provider-aware create', async () => {
         const api = await import('../../../../index.js') as Record<string, unknown>; expect(api).toHaveProperty('PiPrintAgentService');
-        const probe = { validate: vi.fn() }; const repository = { create: vi.fn().mockResolvedValue(base) }; const runner = { run: vi.fn() };
+        const probe = { validate: vi.fn() }; const repository = { create: vi.fn().mockResolvedValue(base), list: vi.fn() }; const runner = { run: vi.fn() };
         const Service = api.PiPrintAgentService as new (options: unknown) => any;
         await new Service({ repository, probe, runner }).create({ name: 'reviewer', cwd: '/project' });
         expect(probe.validate).toHaveBeenCalledOnce(); expect(repository.create).toHaveBeenCalledWith({ name: 'reviewer', cwd: '/project', provider: 'pi' });
@@ -13,7 +13,7 @@ describe('PiPrintAgentService', () => {
 
     it('records successful first and resumed sends', async () => {
         const api = await import('../../../../index.js') as Record<string, unknown>;
-        const repository = { resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn()
+        const repository = { list: vi.fn(), resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn()
             .mockResolvedValueOnce({ agent: base, token: 'one' }).mockResolvedValueOnce({ agent: { ...base, sessionHealth: 'healthy' }, token: 'two' }),
             recordProviderProcess: vi.fn(), completeRun: vi.fn() };
         const runner = { run: vi.fn(async (request) => { await request.onSpawn({ pid: 42, startedAt: 'start' }); return { sessionId: SESSION, result: 'answer', messages: ['answer'], exitCode: 0 }; }) };
@@ -24,7 +24,7 @@ describe('PiPrintAgentService', () => {
 
     it('records mismatches, rejects wrong providers, missing and ambiguous records', async () => {
         const api = await import('../../../../index.js') as Record<string, unknown>; const ErrorType = api.PiPrintError as new (message: string, code: string) => Error;
-        const completeRun = vi.fn(); const repository = { resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn().mockResolvedValue({ agent: base, token: 'one' }), recordProviderProcess: vi.fn(), completeRun };
+        const completeRun = vi.fn(); const repository = { list: vi.fn(), resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn().mockResolvedValue({ agent: base, token: 'one' }), recordProviderProcess: vi.fn(), completeRun };
         const Service = api.PiPrintAgentService as new (options: unknown) => any;
         await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn().mockRejectedValue(new ErrorType('bad', 'PI_SESSION_MISMATCH')) } }).send('reviewer', 'x'))
             .rejects.toMatchObject({ code: 'PI_SESSION_MISMATCH' });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintAgentService.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintAgentService.test.ts
@@ -22,18 +22,48 @@ describe('PiPrintAgentService', () => {
         expect(repository.completeRun).toHaveBeenCalledWith('id', 'one', expect.objectContaining({ status: 'succeeded', sessionHealth: 'healthy' }));
     });
 
-    it('records mismatches, rejects wrong providers, missing and ambiguous records', async () => {
+    it('records mismatches and rejects missing and ambiguous records', async () => {
         const api = await import('../../../../index.js') as Record<string, unknown>; const ErrorType = api.PiPrintError as new (message: string, code: string) => Error;
         const completeRun = vi.fn(); const repository = { list: vi.fn(), resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn().mockResolvedValue({ agent: base, token: 'one' }), recordProviderProcess: vi.fn(), completeRun };
         const Service = api.PiPrintAgentService as new (options: unknown) => any;
         await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn().mockRejectedValue(new ErrorType('bad', 'PI_SESSION_MISMATCH')) } }).send('reviewer', 'x'))
             .rejects.toMatchObject({ code: 'PI_SESSION_MISMATCH' });
         expect(completeRun).toHaveBeenCalledWith('id', 'one', expect.objectContaining({ sessionHealth: 'mismatch' }));
-        repository.acquireRun.mockResolvedValueOnce({ agent: { ...base, provider: 'claude' }, token: 'two' });
-        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } }).send('reviewer', 'x')).rejects.toMatchObject({ code: 'PI_UNSUPPORTED' });
         const earlyRepository = { ...repository, resolve: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce([base, base]), acquireRun: vi.fn() };
         const early = new Service({ repository: earlyRepository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } });
         await expect(early.send('missing', 'x')).rejects.toMatchObject({ code: 'DURABLE_AGENT_NOT_FOUND' });
         await expect(early.send('many', 'x')).rejects.toMatchObject({ code: 'PI_UNSUPPORTED' });
+    });
+
+    it('rejects a non-Pi target without acquiring or mutating it', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>;
+        const Service = api.PiPrintAgentService as new (options: unknown) => any;
+        const repository = {
+            resolve: vi.fn().mockResolvedValue({ ...base, provider: 'claude' }),
+            acquireRun: vi.fn(), recordProviderProcess: vi.fn(), completeRun: vi.fn(),
+        };
+
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } })
+            .send('reviewer', 'x')).rejects.toMatchObject({ code: 'PI_UNSUPPORTED' });
+        expect(repository.acquireRun).not.toHaveBeenCalled();
+        expect(repository.completeRun).not.toHaveBeenCalled();
+    });
+
+    it('does not turn a successful completion write failure into a second completion', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>;
+        const Service = api.PiPrintAgentService as new (options: unknown) => any;
+        const completionFailure = new Error('completion failed');
+        const repository = {
+            resolve: vi.fn().mockResolvedValue(base),
+            acquireRun: vi.fn().mockResolvedValue({ agent: base, token: 'one' }),
+            recordProviderProcess: vi.fn(), completeRun: vi.fn().mockRejectedValue(completionFailure),
+        };
+        const runner = { run: vi.fn().mockResolvedValue({
+            sessionId: SESSION, result: 'answer', messages: ['answer'], exitCode: 0,
+        }) };
+
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner })
+            .send('reviewer', 'x')).rejects.toBe(completionFailure);
+        expect(repository.completeRun).toHaveBeenCalledOnce();
     });
 });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintAgentService.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintAgentService.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+const SESSION = '22222222-2222-4222-8222-222222222222';
+const base = { id: 'id', name: 'reviewer', provider: 'pi', providerSessionId: SESSION, sessionHealth: 'uninitialized' };
+
+describe('PiPrintAgentService', () => {
+    it('probes before provider-aware create', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>; expect(api).toHaveProperty('PiPrintAgentService');
+        const probe = { validate: vi.fn() }; const repository = { create: vi.fn().mockResolvedValue(base) }; const runner = { run: vi.fn() };
+        const Service = api.PiPrintAgentService as new (options: unknown) => any;
+        await new Service({ repository, probe, runner }).create({ name: 'reviewer', cwd: '/project' });
+        expect(probe.validate).toHaveBeenCalledOnce(); expect(repository.create).toHaveBeenCalledWith({ name: 'reviewer', cwd: '/project', provider: 'pi' });
+    });
+
+    it('records successful first and resumed sends', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>;
+        const repository = { resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn()
+            .mockResolvedValueOnce({ agent: base, token: 'one' }).mockResolvedValueOnce({ agent: { ...base, sessionHealth: 'healthy' }, token: 'two' }),
+            recordProviderProcess: vi.fn(), completeRun: vi.fn() };
+        const runner = { run: vi.fn(async (request) => { await request.onSpawn({ pid: 42, startedAt: 'start' }); return { sessionId: SESSION, result: 'answer', messages: ['answer'], exitCode: 0 }; }) };
+        const Service = api.PiPrintAgentService as new (options: unknown) => any; const service = new Service({ repository, probe: { validate: vi.fn() }, runner });
+        await service.send('reviewer', 'first'); await service.send('reviewer', 'later');
+        expect(repository.completeRun).toHaveBeenCalledWith('id', 'one', expect.objectContaining({ status: 'succeeded', sessionHealth: 'healthy' }));
+    });
+
+    it('records mismatches, rejects wrong providers, missing and ambiguous records', async () => {
+        const api = await import('../../../../index.js') as Record<string, unknown>; const ErrorType = api.PiPrintError as new (message: string, code: string) => Error;
+        const completeRun = vi.fn(); const repository = { resolve: vi.fn().mockResolvedValue(base), acquireRun: vi.fn().mockResolvedValue({ agent: base, token: 'one' }), recordProviderProcess: vi.fn(), completeRun };
+        const Service = api.PiPrintAgentService as new (options: unknown) => any;
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn().mockRejectedValue(new ErrorType('bad', 'PI_SESSION_MISMATCH')) } }).send('reviewer', 'x'))
+            .rejects.toMatchObject({ code: 'PI_SESSION_MISMATCH' });
+        expect(completeRun).toHaveBeenCalledWith('id', 'one', expect.objectContaining({ sessionHealth: 'mismatch' }));
+        repository.acquireRun.mockResolvedValueOnce({ agent: { ...base, provider: 'claude' }, token: 'two' });
+        await expect(new Service({ repository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } }).send('reviewer', 'x')).rejects.toMatchObject({ code: 'PI_UNSUPPORTED' });
+        const earlyRepository = { ...repository, resolve: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce([base, base]), acquireRun: vi.fn() };
+        const early = new Service({ repository: earlyRepository, probe: { validate: vi.fn() }, runner: { run: vi.fn() } });
+        await expect(early.send('missing', 'x')).rejects.toMatchObject({ code: 'DURABLE_AGENT_NOT_FOUND' });
+        await expect(early.send('many', 'x')).rejects.toMatchObject({ code: 'PI_UNSUPPORTED' });
+    });
+});

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintProtocol.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintProtocol.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildPiPrintArgs, readPiAssistantText, readPiSessionId } from '../../../../providers/pi/durable/PiPrintProtocol.js';
+
+const SESSION = '22222222-2222-4222-8222-222222222222';
+
+describe('Pi print pure protocol mapping', () => {
+    it('maps first and resumed runs to exact documented arguments', () => {
+        expect(buildPiPrintArgs(SESSION, true)).toEqual(['--mode', 'json', '--session-id', SESSION]);
+        expect(buildPiPrintArgs(SESSION, false)).toEqual(['--mode', 'json', '--session', SESSION]);
+    });
+
+    it('accepts one expected UUID and rejects invalid, duplicate, and mismatched identities', () => {
+        expect(readPiSessionId({ id: SESSION }, null, SESSION)).toBe(SESSION);
+        expect(() => readPiSessionId({}, null, SESSION)).toThrowError(expect.objectContaining({ code: 'PI_PROTOCOL' }));
+        expect(() => readPiSessionId({ id: SESSION }, SESSION, SESSION)).toThrowError(expect.objectContaining({ code: 'PI_PROTOCOL' }));
+        expect(() => readPiSessionId({ id: '33333333-3333-4333-8333-333333333333' }, null, SESSION))
+            .toThrowError(expect.objectContaining({ code: 'PI_SESSION_MISMATCH' }));
+    });
+
+    it('extracts only non-empty completed assistant text', () => {
+        expect(readPiAssistantText({ type: 'future' })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end' })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end', message: [] })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end', message: { role: 'user', content: 'no' } })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end', message: { role: 'assistant', content: ' ' } })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end', message: { role: 'assistant', content: 'answer' } })).toBe('answer');
+        expect(readPiAssistantText({ type: 'message_end', message: { role: 'assistant', content: null } })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end', message: { role: 'assistant', content: [null, [], { type: 'thinking' }] } })).toBeNull();
+        expect(readPiAssistantText({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'a' }, { type: 'text', text: 1 }, { type: 'text', text: 'b' }] } })).toBe('ab');
+    });
+});

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintProtocol.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintProtocol.test.ts
@@ -12,6 +12,8 @@ describe('Pi print pure protocol mapping', () => {
     it('accepts one expected UUID and rejects invalid, duplicate, and mismatched identities', () => {
         expect(readPiSessionId({ id: SESSION }, null, SESSION)).toBe(SESSION);
         expect(() => readPiSessionId({}, null, SESSION)).toThrowError(expect.objectContaining({ code: 'PI_PROTOCOL' }));
+        expect(() => readPiSessionId({ id: [SESSION] }, null, SESSION))
+            .toThrowError(expect.objectContaining({ code: 'PI_PROTOCOL' }));
         expect(() => readPiSessionId({ id: SESSION }, SESSION, SESSION)).toThrowError(expect.objectContaining({ code: 'PI_PROTOCOL' }));
         expect(() => readPiSessionId({ id: '33333333-3333-4333-8333-333333333333' }, null, SESSION))
             .toThrowError(expect.objectContaining({ code: 'PI_SESSION_MISMATCH' }));

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from 'node:events';
 import { PassThrough, Writable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
-import type { DurableAgent } from '../../../../index.js';
+import type { PiDurableAgent } from '../../../../index.js';
 
 const SESSION = '22222222-2222-4222-8222-222222222222';
-function agent(sessionHealth: DurableAgent['sessionHealth'] = 'uninitialized'): DurableAgent {
+function agent(sessionHealth: PiDurableAgent['sessionHealth'] = 'uninitialized'): PiDurableAgent {
     return { id: '11111111-1111-4111-8111-111111111111', name: 'reviewer', provider: 'pi', mode: 'durable',
         cwd: '/project', providerSessionId: SESSION, state: 'running', sessionHealth, createdAt: '',
         updatedAt: '', lastActiveAt: null, lastResult: null, activeRun: null };

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
@@ -71,4 +71,40 @@ describe('PiPrintRunner', () => {
             .rejects.toMatchObject({ code: 'PI_PROCESS' });
         expect(fixture.child.kill).toHaveBeenCalledOnce();
     });
+
+    it('rejects invalid and duplicate session identities', async () => {
+        for (const lines of [
+            [JSON.stringify({ type: 'session', id: 'bad' }), ''],
+            [JSON.stringify({ type: 'session', id: SESSION }), JSON.stringify({ type: 'session', id: SESSION }), ''],
+        ]) await expect((await runner(fakeSpawn(lines))).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn(), onSession: vi.fn() }))
+            .rejects.toMatchObject({ code: 'PI_PROTOCOL' });
+    });
+
+    it('kills on spawn persistence failure and classifies session callback failure', async () => {
+        const spawnFailure = fakeSpawn([]); const failure = new Error('cannot persist');
+        await expect((await runner(spawnFailure)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn().mockRejectedValue(failure), onSession: vi.fn() })).rejects.toBe(failure);
+        expect(spawnFailure.child.kill).toHaveBeenCalledOnce();
+        const callbackFailure = fakeSpawn(events());
+        await expect((await runner(callbackFailure)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn(), onSession: vi.fn().mockRejectedValue(new Error('store')) }))
+            .rejects.toMatchObject({ code: 'PI_PROTOCOL' });
+    });
+
+    it('classifies spawn errors and a missing PID as process failures', async () => {
+        const errored = fakeSpawn([]);
+        errored.child.stdin = new Writable({ write(_chunk, _encoding, callback) { callback(); }, final(callback) { queueMicrotask(() => errored.child.emit('error', new Error('spawn'))); callback(); } });
+        await expect((await runner(errored)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn(), onSession: vi.fn() })).rejects.toMatchObject({ code: 'PI_PROCESS' });
+        const missing = fakeSpawn([]); missing.child.pid = undefined;
+        await expect((await runner(missing)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn(), onSession: vi.fn() })).rejects.toMatchObject({ code: 'PI_PROCESS' });
+        expect(missing.child.kill).toHaveBeenCalledOnce();
+    });
+
+    it('accepts string assistant content and ignores empty or unrelated messages', async () => {
+        const lines = [JSON.stringify({ type: 'session', id: SESSION }), JSON.stringify({ type: 'future' }),
+            JSON.stringify({ type: 'message_end', message: { role: 'user', content: 'ignored' } }),
+            JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: ' ' } }),
+            JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: 'answer' } }),
+            JSON.stringify({ type: 'agent_end' }), ''];
+        await expect((await runner(fakeSpawn(lines))).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn(), onSession: vi.fn() }))
+            .resolves.toMatchObject({ result: 'answer' });
+    });
 });

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
@@ -80,13 +80,10 @@ describe('PiPrintRunner', () => {
             .rejects.toMatchObject({ code: 'PI_PROTOCOL' });
     });
 
-    it('kills on spawn persistence failure and classifies session callback failure', async () => {
+    it('kills on spawn persistence failure', async () => {
         const spawnFailure = fakeSpawn([]); const failure = new Error('cannot persist');
         await expect((await runner(spawnFailure)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn().mockRejectedValue(failure), onSession: vi.fn() })).rejects.toBe(failure);
         expect(spawnFailure.child.kill).toHaveBeenCalledOnce();
-        const callbackFailure = fakeSpawn(events());
-        await expect((await runner(callbackFailure)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn(), onSession: vi.fn().mockRejectedValue(new Error('store')) }))
-            .rejects.toMatchObject({ code: 'PI_PROTOCOL' });
     });
 
     it('classifies spawn errors and a missing PID as process failures', async () => {

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiPrintRunner.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough, Writable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { DurableAgent } from '../../../../index.js';
+
+const SESSION = '22222222-2222-4222-8222-222222222222';
+function agent(sessionHealth: DurableAgent['sessionHealth'] = 'uninitialized'): DurableAgent {
+    return { id: '11111111-1111-4111-8111-111111111111', name: 'reviewer', provider: 'pi', mode: 'durable',
+        cwd: '/project', providerSessionId: SESSION, state: 'running', sessionHealth, createdAt: '',
+        updatedAt: '', lastActiveAt: null, lastResult: null, activeRun: null };
+}
+function fakeSpawn(lines: string[], exitCode = 0) {
+    const promptChunks: Buffer[] = [];
+    const child = new EventEmitter() as any;
+    child.pid = 4242; child.stdout = new PassThrough(); child.stderr = new PassThrough(); child.kill = vi.fn();
+    child.stdin = new Writable({
+        write(chunk, _encoding, callback) { promptChunks.push(Buffer.from(chunk)); callback(); },
+        final(callback) { child.stdout.end(lines.join('\n')); queueMicrotask(() => child.emit('close', exitCode, null)); callback(); },
+    });
+    return { child, spawn: vi.fn(() => child), promptChunks };
+}
+function events(session = SESSION): string[] { return [
+    JSON.stringify({ type: 'session', version: 3, id: session, cwd: '/project' }),
+    JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'first' }] } }),
+    JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'thinking', thinking: 'hidden' }, { type: 'text', text: 'final' }] } }),
+    JSON.stringify({ type: 'agent_end', messages: [] }), '',
+]; }
+async function runner(fixture: ReturnType<typeof fakeSpawn>, maxLineBytes?: number) {
+    const api = await import('../../../../index.js') as Record<string, unknown>;
+    expect(api).toHaveProperty('PiPrintRunner');
+    const Runner = api.PiPrintRunner as new (options: unknown) => any;
+    return new Runner({ spawn: fixture.spawn, maxLineBytes, processInspector: { getIdentity: () => ({ pid: 4242, startedAt: 'start' }) } });
+}
+
+describe('PiPrintRunner', () => {
+    it('binds a first session and returns the last completed assistant text', async () => {
+        const fixture = fakeSpawn(events()); const instance = await runner(fixture); const order: string[] = [];
+        const result = await instance.run({ agent: agent(), prompt: 'secret', executable: 'fake-pi',
+            onSpawn: async () => { expect(fixture.promptChunks).toHaveLength(0); order.push('spawn'); } });
+        expect(order).toEqual(['spawn']);
+        expect(fixture.spawn).toHaveBeenCalledWith('fake-pi', ['--mode', 'json', '--session-id', SESSION], expect.objectContaining({ cwd: '/project', shell: false }));
+        expect(Buffer.concat(fixture.promptChunks).toString()).toBe('secret');
+        expect(result).toEqual({ sessionId: SESSION, result: 'final', messages: ['first', 'final'], exitCode: 0 });
+    });
+
+    it('resumes the exact stored session and rejects mismatch', async () => {
+        const fixture = fakeSpawn(events('33333333-3333-4333-8333-333333333333'));
+        await expect((await runner(fixture)).run({ agent: agent('healthy'), prompt: 'later', onSpawn: vi.fn() }))
+            .rejects.toMatchObject({ code: 'PI_SESSION_MISMATCH' });
+        expect(fixture.spawn.mock.calls[0]![1]).toEqual(['--mode', 'json', '--session', SESSION]);
+    });
+
+    it.each([
+        ['malformed', ['{bad\n'], 'PI_PROTOCOL'], ['non-object', ['[]\n'], 'PI_PROTOCOL'],
+        ['truncated', ['{}'], 'PI_PROTOCOL'], ['missing session', [JSON.stringify({ type: 'agent_end' }), ''], 'PI_PROTOCOL'],
+        ['missing result', [JSON.stringify({ type: 'session', id: SESSION }), JSON.stringify({ type: 'agent_end' }), ''], 'PI_RESULT_MISSING'],
+        ['missing end', [JSON.stringify({ type: 'session', id: SESSION }), JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'x' }] } }), ''], 'PI_PROTOCOL'],
+    ])('rejects %s output', async (_name, lines, code) => {
+        await expect((await runner(fakeSpawn(lines as string[]))).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn() }))
+            .rejects.toMatchObject({ code });
+    });
+
+    it('rejects oversized output, failed processes, and unverifiable identities', async () => {
+        await expect((await runner(fakeSpawn(['x'.repeat(20)]), 10)).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn() }))
+            .rejects.toMatchObject({ code: 'PI_PROTOCOL' });
+        await expect((await runner(fakeSpawn(events(), 1))).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn() }))
+            .rejects.toMatchObject({ code: 'PI_PROCESS' });
+        const fixture = fakeSpawn([]); const api = await import('../../../../index.js') as Record<string, unknown>;
+        const Runner = api.PiPrintRunner as new (options: unknown) => any;
+        await expect(new Runner({ spawn: fixture.spawn, processInspector: { getIdentity: () => null } }).run({ agent: agent(), prompt: 'x', onSpawn: vi.fn() }))
+            .rejects.toMatchObject({ code: 'PI_PROCESS' });
+        expect(fixture.child.kill).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/agent-manager/src/__tests__/providers/pi/durable/PiStreamParser.test.ts
+++ b/packages/agent-manager/src/__tests__/providers/pi/durable/PiStreamParser.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { PiStreamParser } from '../../../../providers/pi/durable/PiStreamParser.js';
+
+const SESSION = '22222222-2222-4222-8222-222222222222';
+
+describe('PiStreamParser', () => {
+    it('ignores blank lines and normalizes unexpected parser failures', () => {
+        const parser = new PiStreamParser(SESSION, 1024);
+        parser.accept('\n');
+        parser.fail(new Error('unexpected'));
+
+        expect(parser.hasFailed()).toBe(true);
+        expect(() => parser.result({ code: 0, signal: null }))
+            .toThrowError(expect.objectContaining({ code: 'PI_PROTOCOL', message: 'Pi stream processing failed.' }));
+    });
+
+    it('includes the terminating signal in process failures', () => {
+        const parser = new PiStreamParser(SESSION, 1024);
+        parser.accept(`${JSON.stringify({ type: 'session', id: SESSION })}\n`);
+
+        expect(() => parser.result({ code: null, signal: 'SIGTERM' }))
+            .toThrowError(expect.objectContaining({ code: 'PI_PROCESS', message: 'Pi print run failed (SIGTERM)' }));
+    });
+});

--- a/packages/agent-manager/src/durable/DurableAgent.ts
+++ b/packages/agent-manager/src/durable/DurableAgent.ts
@@ -1,6 +1,15 @@
 export type DurableAgentState = 'ready' | 'running' | 'degraded';
 export type DurableSessionHealth = 'uninitialized' | 'healthy' | 'unknown' | 'mismatch';
 export type DurableRunStatus = 'succeeded' | 'failed' | 'interrupted';
+export type DurableProvider = 'claude' | 'pi';
+export type PiPrintErrorCode =
+    | 'PI_CLI_UNAVAILABLE'
+    | 'PI_CLI_UNSUPPORTED'
+    | 'PI_PROCESS'
+    | 'PI_PROTOCOL'
+    | 'PI_RESULT_MISSING'
+    | 'PI_SESSION_MISMATCH'
+    | 'PI_UNSUPPORTED';
 
 export const AGENT_MODES = {
     INTERACTIVE: 'interactive',
@@ -26,7 +35,7 @@ export interface DurableLastResult {
     summary: string;
 }
 
-export type DurableProvider = 'claude' | 'codex';
+export type DurableProvider = 'claude' | 'codex' | 'pi';
 
 export interface DurableAgentBase {
     id: string;
@@ -52,7 +61,12 @@ export interface CodexDurableAgent extends DurableAgentBase {
     providerSessionId: string | null;
 }
 
-export type DurableAgent = ClaudeDurableAgent | CodexDurableAgent;
+export interface PiDurableAgent extends DurableAgentBase {
+    provider: 'pi';
+    providerSessionId: string;
+}
+
+export type DurableAgent = ClaudeDurableAgent | CodexDurableAgent | PiDurableAgent;
 
 export class DurableAgentError extends Error {
     constructor(
@@ -115,5 +129,12 @@ export class CodexPrintError extends DurableAgentError {
     constructor(message: string, code: CodexPrintErrorCode) {
         super(message, code);
         this.name = 'CodexPrintError';
+    }
+}
+
+export class PiPrintError extends DurableAgentError {
+    constructor(message: string, code: PiPrintErrorCode = 'PI_PROCESS') {
+        super(message, code);
+        this.name = 'PiPrintError';
     }
 }

--- a/packages/agent-manager/src/durable/DurableAgent.ts
+++ b/packages/agent-manager/src/durable/DurableAgent.ts
@@ -1,7 +1,6 @@
 export type DurableAgentState = 'ready' | 'running' | 'degraded';
 export type DurableSessionHealth = 'uninitialized' | 'healthy' | 'unknown' | 'mismatch';
 export type DurableRunStatus = 'succeeded' | 'failed' | 'interrupted';
-export type DurableProvider = 'claude' | 'pi';
 export type PiPrintErrorCode =
     | 'PI_CLI_UNAVAILABLE'
     | 'PI_CLI_UNSUPPORTED'

--- a/packages/agent-manager/src/durable/DurableAgentRepository.ts
+++ b/packages/agent-manager/src/durable/DurableAgentRepository.ts
@@ -67,7 +67,7 @@ export class DurableAgentRepository {
         const timestamp = this.now().toISOString();
         const id = randomUUID();
         const provider = input.provider ?? 'claude';
-        let providerSessionId = provider === 'claude' ? randomUUID() : null;
+        let providerSessionId = provider === 'codex' ? null : randomUUID();
         while (providerSessionId === id) providerSessionId = randomUUID();
         try {
             this.db.execute(`INSERT INTO durable_agents (
@@ -266,8 +266,8 @@ export class DurableAgentRepository {
     }
 
     private fromRow(row: DurableAgentRow): DurableAgent {
-        if (!['claude', 'codex'].includes(row.provider)
-            || (row.provider === 'claude' && row.provider_session_id === null)) {
+        if (!['claude', 'codex', 'pi'].includes(row.provider)
+            || (row.provider !== 'codex' && row.provider_session_id === null)) {
             throw new DurableAgentRepositoryError(`Invalid durable-agent provider record: ${row.id}`);
         }
         const activeRun: DurableActiveRun | null = row.active_run_token === null ? null : {
@@ -288,9 +288,13 @@ export class DurableAgentRepository {
             },
             activeRun,
         };
-        return row.provider === 'claude'
-            ? { ...base, provider: 'claude', providerSessionId: row.provider_session_id! }
-            : { ...base, provider: 'codex', providerSessionId: row.provider_session_id };
+        if (row.provider === 'claude') {
+            return { ...base, provider: 'claude', providerSessionId: row.provider_session_id! };
+        }
+        if (row.provider === 'pi') {
+            return { ...base, provider: 'pi', providerSessionId: row.provider_session_id! };
+        }
+        return { ...base, provider: 'codex', providerSessionId: row.provider_session_id };
     }
 
     private canonicalDirectory(input: string): string {

--- a/packages/agent-manager/src/durable/run.ts
+++ b/packages/agent-manager/src/durable/run.ts
@@ -1,0 +1,44 @@
+import type { DurableAgent, DurableProvider } from './DurableAgent.js';
+import { DurableAgentNotFoundError } from './DurableAgent.js';
+import type { DurableRunCompletion } from './DurableAgentRepository.js';
+
+export interface DurableRunRepository {
+    resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>;
+    acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>;
+    completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent>;
+}
+
+type ProviderAgent<Provider extends DurableProvider> = Extract<DurableAgent, { provider: Provider }>;
+
+interface DurableRunOptions<Provider extends DurableProvider, Result> {
+    reference: string;
+    provider: Provider;
+    repository: DurableRunRepository;
+    ambiguousError(): Error;
+    providerError(): Error;
+    execute(agent: ProviderAgent<Provider>, token: string): Promise<Result>;
+    succeeded(result: Result): DurableRunCompletion;
+    failed(error: unknown): DurableRunCompletion;
+}
+
+export async function runDurableAgent<Provider extends DurableProvider, Result>(
+    options: DurableRunOptions<Provider, Result>,
+): Promise<{ agent: ProviderAgent<Provider>; result: Result }> {
+    const resolved = await options.repository.resolve(options.reference);
+    if (!resolved) throw new DurableAgentNotFoundError(options.reference);
+    if (Array.isArray(resolved)) throw options.ambiguousError();
+    if (resolved.provider !== options.provider) throw options.providerError();
+
+    const target = resolved as ProviderAgent<Provider>;
+    const acquired = await options.repository.acquireRun(target.id);
+    let result: Result;
+    try {
+        result = await options.execute(acquired.agent as ProviderAgent<Provider>, acquired.token);
+    } catch (error) {
+        await options.repository.completeRun(target.id, acquired.token, options.failed(error));
+        throw error;
+    }
+
+    await options.repository.completeRun(target.id, acquired.token, options.succeeded(result));
+    return { agent: target, result };
+}

--- a/packages/agent-manager/src/durable/run.ts
+++ b/packages/agent-manager/src/durable/run.ts
@@ -1,6 +1,9 @@
 import type { DurableAgent, DurableProvider } from './DurableAgent.js';
 import { DurableAgentNotFoundError } from './DurableAgent.js';
 import type { DurableRunCompletion } from './DurableAgentRepository.js';
+import { sanitizeText } from './utils.js';
+
+const MAX_RESULT_SUMMARY_LENGTH = 4096;
 
 export interface DurableRunRepository {
     resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>;
@@ -10,18 +13,22 @@ export interface DurableRunRepository {
 
 type ProviderAgent<Provider extends DurableProvider> = Extract<DurableAgent, { provider: Provider }>;
 
-interface DurableRunOptions<Provider extends DurableProvider, Result> {
+interface DurableRunResult {
+    result: string;
+    exitCode: number;
+}
+
+interface DurableRunOptions<Provider extends DurableProvider, Result extends DurableRunResult> {
     reference: string;
     provider: Provider;
     repository: DurableRunRepository;
     ambiguousError(): Error;
     providerError(): Error;
     execute(agent: ProviderAgent<Provider>, token: string): Promise<Result>;
-    succeeded(result: Result): DurableRunCompletion;
-    failed(error: unknown): DurableRunCompletion;
+    isSessionMismatch(error: unknown): boolean;
 }
 
-export async function runDurableAgent<Provider extends DurableProvider, Result>(
+export async function runDurableAgent<Provider extends DurableProvider, Result extends DurableRunResult>(
     options: DurableRunOptions<Provider, Result>,
 ): Promise<{ agent: ProviderAgent<Provider>; result: Result }> {
     const resolved = await options.repository.resolve(options.reference);
@@ -35,10 +42,33 @@ export async function runDurableAgent<Provider extends DurableProvider, Result>(
     try {
         result = await options.execute(acquired.agent as ProviderAgent<Provider>, acquired.token);
     } catch (error) {
-        await options.repository.completeRun(target.id, acquired.token, options.failed(error));
+        await options.repository.completeRun(
+            target.id,
+            acquired.token,
+            createFailedCompletion(error, options.isSessionMismatch(error)),
+        );
         throw error;
     }
 
-    await options.repository.completeRun(target.id, acquired.token, options.succeeded(result));
+    await options.repository.completeRun(target.id, acquired.token, createSucceededCompletion(result));
     return { agent: target, result };
+}
+
+function createSucceededCompletion(result: DurableRunResult): DurableRunCompletion {
+    return {
+        status: 'succeeded',
+        exitCode: result.exitCode,
+        summary: sanitizeText(result.result, MAX_RESULT_SUMMARY_LENGTH, { preserveFormatting: true }),
+        sessionHealth: 'healthy',
+    };
+}
+
+function createFailedCompletion(error: unknown, sessionMismatch: boolean): DurableRunCompletion {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+        status: 'failed',
+        exitCode: null,
+        summary: sanitizeText(message, MAX_RESULT_SUMMARY_LENGTH, { preserveFormatting: true }),
+        sessionHealth: sessionMismatch ? 'mismatch' : 'unknown',
+    };
 }

--- a/packages/agent-manager/src/index.ts
+++ b/packages/agent-manager/src/index.ts
@@ -49,12 +49,14 @@ export {
     DurableAgentNameConflictError,
     ClaudePrintError,
     CodexPrintError,
+    PiPrintError,
 } from './durable/DurableAgent.js';
 export type {
     DurableAgent,
     DurableAgentBase,
     ClaudeDurableAgent,
     CodexDurableAgent,
+    PiDurableAgent,
     DurableProvider,
     CodexPrintErrorCode,
     DurableAgentState,
@@ -62,6 +64,7 @@ export type {
     DurableRunStatus,
     DurableActiveRun,
     DurableLastResult,
+    PiPrintErrorCode,
     ProcessIdentity,
 } from './durable/DurableAgent.js';
 export { DurableAgentRepository } from './durable/DurableAgentRepository.js';
@@ -89,3 +92,9 @@ export type {
     CodexPrintAgentServiceOptions,
     CodexPrintSendResult,
 } from './providers/codex/durable/CodexPrintAgentService.js';
+export { PiCliProbe } from './providers/pi/durable/PiCliProbe.js';
+export type { PiCliProbeOptions } from './providers/pi/durable/PiCliProbe.js';
+export { PiPrintRunner } from './providers/pi/durable/PiPrintRunner.js';
+export type { PiPrintRunnerOptions, PiPrintRunRequest, PiPrintRunResult } from './providers/pi/durable/PiPrintRunner.js';
+export { PiPrintAgentService } from './providers/pi/durable/PiPrintAgentService.js';
+export type { PiPrintAgentServiceOptions, PiPrintSendResult } from './providers/pi/durable/PiPrintAgentService.js';

--- a/packages/agent-manager/src/providers/claude/durable/ClaudePrintAgentService.ts
+++ b/packages/agent-manager/src/providers/claude/durable/ClaudePrintAgentService.ts
@@ -1,17 +1,15 @@
 import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
-import { ClaudePrintError, DurableAgentNotFoundError } from '../../../durable/DurableAgent.js';
+import { ClaudePrintError } from '../../../durable/DurableAgent.js';
 import { ClaudeCliProbe } from './ClaudeCliProbe.js';
 import { ClaudePrintRunner, type ClaudePrintRunResult } from './ClaudePrintRunner.js';
-import { DurableAgentRepository, type CreateDurableAgentInput, type DurableRunCompletion } from '../../../durable/DurableAgentRepository.js';
+import { DurableAgentRepository, type CreateDurableAgentInput } from '../../../durable/DurableAgentRepository.js';
 import { sanitizeText } from '../../../durable/utils.js';
+import { runDurableAgent, type DurableRunRepository } from '../../../durable/run.js';
 
-interface RepositoryLike {
+interface RepositoryLike extends DurableRunRepository {
     create(input: CreateDurableAgentInput): Promise<DurableAgent>;
     list(): Promise<DurableAgent[]>;
-    resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>;
-    acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>;
     recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>;
-    completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent>;
 }
 
 interface ProbeLike { validate(): Promise<{ executable: string; version: string }> }
@@ -48,42 +46,29 @@ export class ClaudePrintAgentService {
     }
 
     async send(reference: string, prompt: string): Promise<ClaudePrintSendResult> {
-        const resolved = await this.repository.resolve(reference);
-        if (!resolved) throw new DurableAgentNotFoundError(reference);
-        if (Array.isArray(resolved)) {
-            throw new ClaudePrintError(`Multiple durable agents match "${reference}".`, 'DURABLE_AGENT_AMBIGUOUS');
-        }
-        const acquired = await this.repository.acquireRun(resolved.id);
-        try {
-            if (acquired.agent.provider !== 'claude') {
-                throw new ClaudePrintError('Durable agent provider is not Claude.', 'CLAUDE_PRINT_UNSUPPORTED');
-            }
-            const result = await this.runner.run({
-                agent: acquired.agent,
+        const completed = await runDurableAgent({
+            reference, provider: 'claude', repository: this.repository,
+            ambiguousError: () => new ClaudePrintError(
+                `Multiple durable agents match "${reference}".`, 'DURABLE_AGENT_AMBIGUOUS'),
+            providerError: () => new ClaudePrintError(
+                'Durable agent provider is not Claude.', 'CLAUDE_PRINT_UNSUPPORTED'),
+            execute: (agent, token) => this.runner.run({
+                agent,
                 prompt,
                 executable: this.executable,
-                firstRun: acquired.agent.sessionHealth === 'uninitialized',
-                onSpawn: (identity) => this.repository.recordProviderProcess(resolved.id, acquired.token, identity),
-            });
-            await this.repository.completeRun(resolved.id, acquired.token, {
-                status: 'succeeded',
-                exitCode: result.exitCode,
-                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }),
-                sessionHealth: 'healthy',
-            });
-            return { ...result, agentId: resolved.id, agentName: resolved.name };
-        } catch (error) {
-            const failure = error instanceof Error ? error : new Error(String(error));
-            const sessionHealth = error instanceof ClaudePrintError && error.code === 'CLAUDE_SESSION_MISMATCH'
-                ? 'mismatch' as const
-                : 'unknown' as const;
-            await this.repository.completeRun(resolved.id, acquired.token, {
-                status: 'failed',
-                exitCode: null,
-                summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }),
-                sessionHealth,
-            });
-            throw error;
-        }
+                firstRun: agent.sessionHealth === 'uninitialized',
+                onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity),
+            }),
+            succeeded: (result) => ({ status: 'succeeded', exitCode: result.exitCode,
+                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy' }),
+            failed: (error) => {
+                const failure = error instanceof Error ? error : new Error(String(error));
+                const sessionHealth = error instanceof ClaudePrintError && error.code === 'CLAUDE_SESSION_MISMATCH'
+                    ? 'mismatch' as const : 'unknown' as const;
+                return { status: 'failed', exitCode: null,
+                    summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }), sessionHealth };
+            },
+        });
+        return { ...completed.result, agentId: completed.agent.id, agentName: completed.agent.name };
     }
 }

--- a/packages/agent-manager/src/providers/claude/durable/ClaudePrintAgentService.ts
+++ b/packages/agent-manager/src/providers/claude/durable/ClaudePrintAgentService.ts
@@ -3,7 +3,6 @@ import { ClaudePrintError } from '../../../durable/DurableAgent.js';
 import { ClaudeCliProbe } from './ClaudeCliProbe.js';
 import { ClaudePrintRunner, type ClaudePrintRunResult } from './ClaudePrintRunner.js';
 import { DurableAgentRepository, type CreateDurableAgentInput } from '../../../durable/DurableAgentRepository.js';
-import { sanitizeText } from '../../../durable/utils.js';
 import { runDurableAgent, type DurableRunRepository } from '../../../durable/run.js';
 
 interface RepositoryLike extends DurableRunRepository {
@@ -59,15 +58,8 @@ export class ClaudePrintAgentService {
                 firstRun: agent.sessionHealth === 'uninitialized',
                 onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity),
             }),
-            succeeded: (result) => ({ status: 'succeeded', exitCode: result.exitCode,
-                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy' }),
-            failed: (error) => {
-                const failure = error instanceof Error ? error : new Error(String(error));
-                const sessionHealth = error instanceof ClaudePrintError && error.code === 'CLAUDE_SESSION_MISMATCH'
-                    ? 'mismatch' as const : 'unknown' as const;
-                return { status: 'failed', exitCode: null,
-                    summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }), sessionHealth };
-            },
+            isSessionMismatch: (error) => error instanceof ClaudePrintError
+                && error.code === 'CLAUDE_SESSION_MISMATCH',
         });
         return { ...completed.result, agentId: completed.agent.id, agentName: completed.agent.name };
     }

--- a/packages/agent-manager/src/providers/codex/durable/CodexPrintAgentService.ts
+++ b/packages/agent-manager/src/providers/codex/durable/CodexPrintAgentService.ts
@@ -3,7 +3,6 @@ import { CodexPrintError } from '../../../durable/DurableAgent.js';
 import { CodexCliProbe } from './CodexCliProbe.js';
 import { CodexPrintRunner, type CodexPrintRunResult } from './CodexPrintRunner.js';
 import { DurableAgentRepository, type CreateDurableAgentInput } from '../../../durable/DurableAgentRepository.js';
-import { sanitizeText } from '../../../durable/utils.js';
 import { runDurableAgent, type DurableRunRepository } from '../../../durable/run.js';
 
 interface RepositoryLike extends DurableRunRepository {
@@ -58,15 +57,8 @@ export class CodexPrintAgentService {
                 onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity),
                 onSession: async (sessionId) => { await this.repository.bindProviderSession(agent.id, token, sessionId); },
             }),
-            succeeded: (result) => ({ status: 'succeeded', exitCode: result.exitCode,
-                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy' }),
-            failed: (error) => {
-                const failure = error instanceof Error ? error : new Error(String(error));
-                const sessionHealth = error instanceof CodexPrintError && error.code === 'CODEX_SESSION_MISMATCH'
-                    ? 'mismatch' as const : 'unknown' as const;
-                return { status: 'failed', exitCode: null,
-                    summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }), sessionHealth };
-            },
+            isSessionMismatch: (error) => error instanceof CodexPrintError
+                && error.code === 'CODEX_SESSION_MISMATCH',
         });
         return { ...completed.result, agentId: completed.agent.id, agentName: completed.agent.name };
     }

--- a/packages/agent-manager/src/providers/codex/durable/CodexPrintAgentService.ts
+++ b/packages/agent-manager/src/providers/codex/durable/CodexPrintAgentService.ts
@@ -1,18 +1,16 @@
-import type { CodexDurableAgent, DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
-import { CodexPrintError, DurableAgentNotFoundError } from '../../../durable/DurableAgent.js';
+import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
+import { CodexPrintError } from '../../../durable/DurableAgent.js';
 import { CodexCliProbe } from './CodexCliProbe.js';
 import { CodexPrintRunner, type CodexPrintRunResult } from './CodexPrintRunner.js';
-import { DurableAgentRepository, type CreateDurableAgentInput, type DurableRunCompletion } from '../../../durable/DurableAgentRepository.js';
+import { DurableAgentRepository, type CreateDurableAgentInput } from '../../../durable/DurableAgentRepository.js';
 import { sanitizeText } from '../../../durable/utils.js';
+import { runDurableAgent, type DurableRunRepository } from '../../../durable/run.js';
 
-interface RepositoryLike {
+interface RepositoryLike extends DurableRunRepository {
     create(input: CreateDurableAgentInput): Promise<DurableAgent>;
     list(): Promise<DurableAgent[]>;
-    resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>;
-    acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>;
     recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>;
     bindProviderSession(id: string, token: string, providerSessionId: string): Promise<DurableAgent>;
-    completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent>;
 }
 
 interface ProbeLike { validate(): Promise<{ executable: string; version: string }> }
@@ -49,35 +47,27 @@ export class CodexPrintAgentService {
     }
 
     async send(reference: string, prompt: string): Promise<CodexPrintSendResult> {
-        const resolved = await this.repository.resolve(reference);
-        if (!resolved) throw new DurableAgentNotFoundError(reference);
-        if (Array.isArray(resolved)) throw new CodexPrintError('Multiple print agents match.', 'CODEX_UNSUPPORTED');
-        const acquired = await this.repository.acquireRun(resolved.id);
-        try {
-            if (acquired.agent.provider !== 'codex') {
-                throw new CodexPrintError('Print agent provider is not Codex.', 'CODEX_UNSUPPORTED');
-            }
-            const result = await this.runner.run({
-                agent: acquired.agent as CodexDurableAgent,
+        const completed = await runDurableAgent({
+            reference, provider: 'codex', repository: this.repository,
+            ambiguousError: () => new CodexPrintError('Multiple print agents match.', 'CODEX_UNSUPPORTED'),
+            providerError: () => new CodexPrintError('Print agent provider is not Codex.', 'CODEX_UNSUPPORTED'),
+            execute: (agent, token) => this.runner.run({
+                agent,
                 prompt,
                 executable: this.executable,
-                onSpawn: (identity) => this.repository.recordProviderProcess(resolved.id, acquired.token, identity),
-                onSession: async (sessionId) => { await this.repository.bindProviderSession(resolved.id, acquired.token, sessionId); },
-            });
-            await this.repository.completeRun(resolved.id, acquired.token, {
-                status: 'succeeded', exitCode: result.exitCode,
-                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy',
-            });
-            return { ...result, agentId: resolved.id, agentName: resolved.name };
-        } catch (error) {
-            const failure = error instanceof Error ? error : new Error(String(error));
-            const sessionHealth = error instanceof CodexPrintError && error.code === 'CODEX_SESSION_MISMATCH'
-                ? 'mismatch' as const : 'unknown' as const;
-            await this.repository.completeRun(resolved.id, acquired.token, {
-                status: 'failed', exitCode: null,
-                summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }), sessionHealth,
-            });
-            throw error;
-        }
+                onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity),
+                onSession: async (sessionId) => { await this.repository.bindProviderSession(agent.id, token, sessionId); },
+            }),
+            succeeded: (result) => ({ status: 'succeeded', exitCode: result.exitCode,
+                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy' }),
+            failed: (error) => {
+                const failure = error instanceof Error ? error : new Error(String(error));
+                const sessionHealth = error instanceof CodexPrintError && error.code === 'CODEX_SESSION_MISMATCH'
+                    ? 'mismatch' as const : 'unknown' as const;
+                return { status: 'failed', exitCode: null,
+                    summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }), sessionHealth };
+            },
+        });
+        return { ...completed.result, agentId: completed.agent.id, agentName: completed.agent.name };
     }
 }

--- a/packages/agent-manager/src/providers/pi/durable/PiCliProbe.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiCliProbe.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { PiPrintError } from '../../../durable/DurableAgent.js';
+import { sanitizeText } from '../../../durable/utils.js';
 
 type ExecResult = { stdout: string; stderr: string };
 type Exec = (file: string, args: string[]) => Promise<ExecResult>;
@@ -26,17 +27,10 @@ export class PiCliProbe {
             const missing = REQUIRED.filter((capability) => !help.stdout.includes(capability));
             if (missing.length) throw new PiPrintError(
                 `Pi CLI does not support required print-mode capabilities: ${missing.join(', ')}.`, 'PI_CLI_UNSUPPORTED');
-            return { executable: this.executable, version: sanitize(version.stdout, 256) || 'unknown' };
+            return { executable: this.executable, version: sanitizeText(version.stdout, 256) || 'unknown' };
         } catch (error) {
             if (error instanceof PiPrintError) throw error;
-            throw new PiPrintError(`Pi CLI validation failed: ${sanitize((error as Error).message, 512)}`, 'PI_CLI_UNAVAILABLE');
+            throw new PiPrintError(`Pi CLI validation failed: ${sanitizeText((error as Error).message, 512)}`, 'PI_CLI_UNAVAILABLE');
         }
     }
-}
-
-function sanitize(value: string, max: number): string {
-    return Array.from(value, (character) => {
-        const code = character.charCodeAt(0);
-        return code <= 31 || code === 127 ? ' ' : character;
-    }).join('').trim().slice(0, max);
 }

--- a/packages/agent-manager/src/providers/pi/durable/PiCliProbe.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiCliProbe.ts
@@ -1,0 +1,42 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { PiPrintError } from '../../../durable/DurableAgent.js';
+
+type ExecResult = { stdout: string; stderr: string };
+type Exec = (file: string, args: string[]) => Promise<ExecResult>;
+const execFileAsync = promisify(execFile);
+const REQUIRED = ['--mode', 'json', '--session-id', '--session'];
+
+export interface PiCliProbeOptions { executable?: string; exec?: Exec }
+
+export class PiCliProbe {
+    private readonly executable: string;
+    private readonly exec: Exec;
+    constructor(options: PiCliProbeOptions = {}) {
+        this.executable = options.executable ?? 'pi';
+        this.exec = options.exec ?? (async (file, args) => {
+            const result = await execFileAsync(file, args, { encoding: 'utf8', maxBuffer: 1024 * 1024 });
+            return { stdout: result.stdout, stderr: result.stderr };
+        });
+    }
+    async validate(): Promise<{ executable: string; version: string }> {
+        try {
+            const version = await this.exec(this.executable, ['--version']);
+            const help = await this.exec(this.executable, ['--help']);
+            const missing = REQUIRED.filter((capability) => !help.stdout.includes(capability));
+            if (missing.length) throw new PiPrintError(
+                `Pi CLI does not support required print-mode capabilities: ${missing.join(', ')}.`, 'PI_CLI_UNSUPPORTED');
+            return { executable: this.executable, version: sanitize(version.stdout, 256) || 'unknown' };
+        } catch (error) {
+            if (error instanceof PiPrintError) throw error;
+            throw new PiPrintError(`Pi CLI validation failed: ${sanitize((error as Error).message, 512)}`, 'PI_CLI_UNAVAILABLE');
+        }
+    }
+}
+
+function sanitize(value: string, max: number): string {
+    return Array.from(value, (character) => {
+        const code = character.charCodeAt(0);
+        return code <= 31 || code === 127 ? ' ' : character;
+    }).join('').trim().slice(0, max);
+}

--- a/packages/agent-manager/src/providers/pi/durable/PiCliProbe.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiCliProbe.ts
@@ -8,11 +8,15 @@ type Exec = (file: string, args: string[]) => Promise<ExecResult>;
 const execFileAsync = promisify(execFile);
 const REQUIRED = ['--mode', 'json', '--session-id', '--session'];
 
-export interface PiCliProbeOptions { executable?: string; exec?: Exec }
+export interface PiCliProbeOptions {
+    executable?: string;
+    exec?: Exec;
+}
 
 export class PiCliProbe {
     private readonly executable: string;
     private readonly exec: Exec;
+
     constructor(options: PiCliProbeOptions = {}) {
         this.executable = options.executable ?? 'pi';
         this.exec = options.exec ?? (async (file, args) => {
@@ -20,17 +24,25 @@ export class PiCliProbe {
             return { stdout: result.stdout, stderr: result.stderr };
         });
     }
+
     async validate(): Promise<{ executable: string; version: string }> {
         try {
             const version = await this.exec(this.executable, ['--version']);
             const help = await this.exec(this.executable, ['--help']);
             const missing = REQUIRED.filter((capability) => !help.stdout.includes(capability));
-            if (missing.length) throw new PiPrintError(
-                `Pi CLI does not support required print-mode capabilities: ${missing.join(', ')}.`, 'PI_CLI_UNSUPPORTED');
+            if (missing.length > 0) {
+                throw new PiPrintError(
+                    `Pi CLI does not support required print-mode capabilities: ${missing.join(', ')}.`,
+                    'PI_CLI_UNSUPPORTED',
+                );
+            }
             return { executable: this.executable, version: sanitizeText(version.stdout, 256) || 'unknown' };
         } catch (error) {
             if (error instanceof PiPrintError) throw error;
-            throw new PiPrintError(`Pi CLI validation failed: ${sanitizeText((error as Error).message, 512)}`, 'PI_CLI_UNAVAILABLE');
+            throw new PiPrintError(
+                `Pi CLI validation failed: ${sanitizeText((error as Error).message, 512)}`,
+                'PI_CLI_UNAVAILABLE',
+            );
         }
     }
 }

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
@@ -4,7 +4,7 @@ import { PiCliProbe } from './PiCliProbe.js';
 import { PiPrintRunner, type PiPrintRunResult } from './PiPrintRunner.js';
 import { DurableAgentRepository, type CreateDurableAgentInput, type DurableRunCompletion } from '../../../durable/DurableAgentRepository.js';
 
-interface RepositoryLike { create(input: CreateDurableAgentInput): Promise<DurableAgent>; resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>; acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>; recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>; completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent> }
+interface RepositoryLike { create(input: CreateDurableAgentInput): Promise<DurableAgent>; list(): Promise<DurableAgent[]>; resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>; acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>; recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>; completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent> }
 interface ProbeLike { validate(): Promise<{ executable: string; version: string }> }
 interface RunnerLike { run(request: Parameters<PiPrintRunner['run']>[0]): Promise<PiPrintRunResult> }
 export interface PiPrintAgentServiceOptions { repository?: RepositoryLike; probe?: ProbeLike; runner?: RunnerLike; executable?: string }

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
@@ -4,40 +4,66 @@ import { PiCliProbe } from './PiCliProbe.js';
 import { PiPrintRunner, type PiPrintRunResult } from './PiPrintRunner.js';
 import { DurableAgentRepository, type CreateDurableAgentInput } from '../../../durable/DurableAgentRepository.js';
 import { runDurableAgent, type DurableRunRepository } from '../../../durable/run.js';
-import { sanitizeText } from '../../../durable/utils.js';
 
-interface RepositoryLike extends DurableRunRepository { create(input: CreateDurableAgentInput): Promise<DurableAgent>; list(): Promise<DurableAgent[]>; recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void> }
+interface RepositoryLike extends DurableRunRepository {
+    create(input: CreateDurableAgentInput): Promise<DurableAgent>;
+    list(): Promise<DurableAgent[]>;
+    recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>;
+}
+
 interface ProbeLike { validate(): Promise<{ executable: string; version: string }> }
 interface RunnerLike { run(request: Parameters<PiPrintRunner['run']>[0]): Promise<PiPrintRunResult> }
-export interface PiPrintAgentServiceOptions { repository?: RepositoryLike; probe?: ProbeLike; runner?: RunnerLike; executable?: string }
-export interface PiPrintSendResult extends PiPrintRunResult { agentId: string; agentName: string }
+
+export interface PiPrintAgentServiceOptions {
+    repository?: RepositoryLike;
+    probe?: ProbeLike;
+    runner?: RunnerLike;
+    executable?: string;
+}
+
+export interface PiPrintSendResult extends PiPrintRunResult {
+    agentId: string;
+    agentName: string;
+}
 
 export class PiPrintAgentService {
-    readonly repository: RepositoryLike; private readonly probe: ProbeLike; private readonly runner: RunnerLike; private readonly executable?: string;
+    readonly repository: RepositoryLike;
+    private readonly probe: ProbeLike;
+    private readonly runner: RunnerLike;
+    private readonly executable?: string;
+
     constructor(options: PiPrintAgentServiceOptions = {}) {
-        this.repository = options.repository ?? new DurableAgentRepository(); this.probe = options.probe ?? new PiCliProbe();
-        this.runner = options.runner ?? new PiPrintRunner(); this.executable = options.executable;
+        this.repository = options.repository ?? new DurableAgentRepository();
+        this.probe = options.probe ?? new PiCliProbe();
+        this.runner = options.runner ?? new PiPrintRunner();
+        this.executable = options.executable;
     }
+
     async create(input: Omit<CreateDurableAgentInput, 'provider'>): Promise<DurableAgent> {
-        await this.probe.validate(); return this.repository.create({ ...input, provider: 'pi' });
+        await this.probe.validate();
+        return this.repository.create({ ...input, provider: 'pi' });
     }
+
     async send(reference: string, prompt: string): Promise<PiPrintSendResult> {
         const completed = await runDurableAgent({
-            reference, provider: 'pi', repository: this.repository,
+            reference,
+            provider: 'pi',
+            repository: this.repository,
             ambiguousError: () => new PiPrintError('Multiple print agents match.', 'PI_UNSUPPORTED'),
             providerError: () => new PiPrintError('Print agent provider is not Pi.', 'PI_UNSUPPORTED'),
-            execute: (agent, token) => this.runner.run({ agent, prompt, executable: this.executable,
-                onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity) }),
-            succeeded: (result) => ({ status: 'succeeded', exitCode: result.exitCode,
-                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy' }),
-            failed: (error) => {
-                const failure = error instanceof Error ? error : new Error(String(error));
-                const mismatch = error instanceof PiPrintError && error.code === 'PI_SESSION_MISMATCH';
-                return { status: 'failed', exitCode: null,
-                    summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }),
-                    sessionHealth: mismatch ? 'mismatch' : 'unknown' };
-            },
+            execute: (agent, token) => this.runner.run({
+                agent,
+                prompt,
+                executable: this.executable,
+                onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity),
+            }),
+            isSessionMismatch: (error) => error instanceof PiPrintError
+                && error.code === 'PI_SESSION_MISMATCH',
         });
-        return { ...completed.result, agentId: completed.agent.id, agentName: completed.agent.name };
+        return {
+            ...completed.result,
+            agentId: completed.agent.id,
+            agentName: completed.agent.name,
+        };
     }
 }

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
@@ -1,10 +1,12 @@
 import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
-import { DurableAgentNotFoundError, PiPrintError } from '../../../durable/DurableAgent.js';
+import { PiPrintError } from '../../../durable/DurableAgent.js';
 import { PiCliProbe } from './PiCliProbe.js';
 import { PiPrintRunner, type PiPrintRunResult } from './PiPrintRunner.js';
-import { DurableAgentRepository, type CreateDurableAgentInput, type DurableRunCompletion } from '../../../durable/DurableAgentRepository.js';
+import { DurableAgentRepository, type CreateDurableAgentInput } from '../../../durable/DurableAgentRepository.js';
+import { runDurableAgent, type DurableRunRepository } from '../../../durable/run.js';
+import { sanitizeText } from '../../../durable/utils.js';
 
-interface RepositoryLike { create(input: CreateDurableAgentInput): Promise<DurableAgent>; list(): Promise<DurableAgent[]>; resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>; acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>; recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>; completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent> }
+interface RepositoryLike extends DurableRunRepository { create(input: CreateDurableAgentInput): Promise<DurableAgent>; list(): Promise<DurableAgent[]>; recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void> }
 interface ProbeLike { validate(): Promise<{ executable: string; version: string }> }
 interface RunnerLike { run(request: Parameters<PiPrintRunner['run']>[0]): Promise<PiPrintRunResult> }
 export interface PiPrintAgentServiceOptions { repository?: RepositoryLike; probe?: ProbeLike; runner?: RunnerLike; executable?: string }
@@ -20,27 +22,22 @@ export class PiPrintAgentService {
         await this.probe.validate(); return this.repository.create({ ...input, provider: 'pi' });
     }
     async send(reference: string, prompt: string): Promise<PiPrintSendResult> {
-        const resolved = await this.repository.resolve(reference);
-        if (!resolved) throw new DurableAgentNotFoundError(reference);
-        if (Array.isArray(resolved)) throw new PiPrintError('Multiple print agents match.', 'PI_UNSUPPORTED');
-        const acquired = await this.repository.acquireRun(resolved.id);
-        try {
-            if (acquired.agent.provider !== 'pi') throw new PiPrintError('Print agent provider is not Pi.', 'PI_UNSUPPORTED');
-            const result = await this.runner.run({ agent: acquired.agent, prompt, executable: this.executable,
-                onSpawn: (identity) => this.repository.recordProviderProcess(resolved.id, acquired.token, identity) });
-            await this.repository.completeRun(resolved.id, acquired.token, { status: 'succeeded', exitCode: result.exitCode,
-                summary: sanitize(result.result, 4096), sessionHealth: 'healthy' });
-            return { ...result, agentId: resolved.id, agentName: resolved.name };
-        } catch (error) {
-            const failure = error instanceof Error ? error : new Error(String(error));
-            const mismatch = error instanceof PiPrintError && error.code === 'PI_SESSION_MISMATCH';
-            await this.repository.completeRun(resolved.id, acquired.token, { status: 'failed', exitCode: null,
-                summary: sanitize(failure.message, 4096), sessionHealth: mismatch ? 'mismatch' : 'unknown' });
-            throw error;
-        }
+        const completed = await runDurableAgent({
+            reference, provider: 'pi', repository: this.repository,
+            ambiguousError: () => new PiPrintError('Multiple print agents match.', 'PI_UNSUPPORTED'),
+            providerError: () => new PiPrintError('Print agent provider is not Pi.', 'PI_UNSUPPORTED'),
+            execute: (agent, token) => this.runner.run({ agent, prompt, executable: this.executable,
+                onSpawn: (identity) => this.repository.recordProviderProcess(agent.id, token, identity) }),
+            succeeded: (result) => ({ status: 'succeeded', exitCode: result.exitCode,
+                summary: sanitizeText(result.result, 4096, { preserveFormatting: true }), sessionHealth: 'healthy' }),
+            failed: (error) => {
+                const failure = error instanceof Error ? error : new Error(String(error));
+                const mismatch = error instanceof PiPrintError && error.code === 'PI_SESSION_MISMATCH';
+                return { status: 'failed', exitCode: null,
+                    summary: sanitizeText(failure.message, 4096, { preserveFormatting: true }),
+                    sessionHealth: mismatch ? 'mismatch' : 'unknown' };
+            },
+        });
+        return { ...completed.result, agentId: completed.agent.id, agentName: completed.agent.name };
     }
-}
-
-function sanitize(value: string, max: number): string {
-    return Array.from(value, (character) => { const code = character.charCodeAt(0); return (code <= 8 || code === 11 || code === 12 || (code >= 14 && code <= 31) || code === 127) ? ' ' : character; }).join('').trim().slice(0, max);
 }

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintAgentService.ts
@@ -1,0 +1,46 @@
+import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
+import { DurableAgentNotFoundError, PiPrintError } from '../../../durable/DurableAgent.js';
+import { PiCliProbe } from './PiCliProbe.js';
+import { PiPrintRunner, type PiPrintRunResult } from './PiPrintRunner.js';
+import { DurableAgentRepository, type CreateDurableAgentInput, type DurableRunCompletion } from '../../../durable/DurableAgentRepository.js';
+
+interface RepositoryLike { create(input: CreateDurableAgentInput): Promise<DurableAgent>; resolve(reference: string): Promise<DurableAgent | DurableAgent[] | null>; acquireRun(id: string): Promise<{ agent: DurableAgent; token: string }>; recordProviderProcess(id: string, token: string, identity: ProcessIdentity): Promise<void>; completeRun(id: string, token: string, result: DurableRunCompletion): Promise<DurableAgent> }
+interface ProbeLike { validate(): Promise<{ executable: string; version: string }> }
+interface RunnerLike { run(request: Parameters<PiPrintRunner['run']>[0]): Promise<PiPrintRunResult> }
+export interface PiPrintAgentServiceOptions { repository?: RepositoryLike; probe?: ProbeLike; runner?: RunnerLike; executable?: string }
+export interface PiPrintSendResult extends PiPrintRunResult { agentId: string; agentName: string }
+
+export class PiPrintAgentService {
+    readonly repository: RepositoryLike; private readonly probe: ProbeLike; private readonly runner: RunnerLike; private readonly executable?: string;
+    constructor(options: PiPrintAgentServiceOptions = {}) {
+        this.repository = options.repository ?? new DurableAgentRepository(); this.probe = options.probe ?? new PiCliProbe();
+        this.runner = options.runner ?? new PiPrintRunner(); this.executable = options.executable;
+    }
+    async create(input: Omit<CreateDurableAgentInput, 'provider'>): Promise<DurableAgent> {
+        await this.probe.validate(); return this.repository.create({ ...input, provider: 'pi' });
+    }
+    async send(reference: string, prompt: string): Promise<PiPrintSendResult> {
+        const resolved = await this.repository.resolve(reference);
+        if (!resolved) throw new DurableAgentNotFoundError(reference);
+        if (Array.isArray(resolved)) throw new PiPrintError('Multiple print agents match.', 'PI_UNSUPPORTED');
+        const acquired = await this.repository.acquireRun(resolved.id);
+        try {
+            if (acquired.agent.provider !== 'pi') throw new PiPrintError('Print agent provider is not Pi.', 'PI_UNSUPPORTED');
+            const result = await this.runner.run({ agent: acquired.agent, prompt, executable: this.executable,
+                onSpawn: (identity) => this.repository.recordProviderProcess(resolved.id, acquired.token, identity) });
+            await this.repository.completeRun(resolved.id, acquired.token, { status: 'succeeded', exitCode: result.exitCode,
+                summary: sanitize(result.result, 4096), sessionHealth: 'healthy' });
+            return { ...result, agentId: resolved.id, agentName: resolved.name };
+        } catch (error) {
+            const failure = error instanceof Error ? error : new Error(String(error));
+            const mismatch = error instanceof PiPrintError && error.code === 'PI_SESSION_MISMATCH';
+            await this.repository.completeRun(resolved.id, acquired.token, { status: 'failed', exitCode: null,
+                summary: sanitize(failure.message, 4096), sessionHealth: mismatch ? 'mismatch' : 'unknown' });
+            throw error;
+        }
+    }
+}
+
+function sanitize(value: string, max: number): string {
+    return Array.from(value, (character) => { const code = character.charCodeAt(0); return (code <= 8 || code === 11 || code === 12 || (code >= 14 && code <= 31) || code === 127) ? ' ' : character; }).join('').trim().slice(0, max);
+}

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintProtocol.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintProtocol.ts
@@ -1,6 +1,5 @@
 import { PiPrintError } from '../../../durable/DurableAgent.js';
-
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import { isUuid } from '../../../durable/utils.js';
 
 export function buildPiPrintArgs(providerSessionId: string, firstRun: boolean): string[] {
     return firstRun
@@ -13,10 +12,10 @@ export function readPiSessionId(
     currentSessionId: string | null,
     expectedSessionId: string,
 ): string {
-    if (currentSessionId !== null || !UUID_PATTERN.test(String(event.id ?? ''))) {
+    if (currentSessionId !== null || typeof event.id !== 'string' || !isUuid(event.id)) {
         throw new PiPrintError('Pi emitted an invalid session identity.', 'PI_PROTOCOL');
     }
-    const sessionId = event.id as string;
+    const sessionId = event.id;
     if (expectedSessionId !== sessionId) {
         throw new PiPrintError('Pi returned a different session identity.', 'PI_SESSION_MISMATCH');
     }

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintProtocol.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintProtocol.ts
@@ -1,0 +1,40 @@
+import { PiPrintError } from './DurableAgent.js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function buildPiPrintArgs(providerSessionId: string, firstRun: boolean): string[] {
+    return firstRun
+        ? ['--mode', 'json', '--session-id', providerSessionId]
+        : ['--mode', 'json', '--session', providerSessionId];
+}
+
+export function readPiSessionId(
+    event: Record<string, unknown>,
+    currentSessionId: string | null,
+    expectedSessionId: string,
+): string {
+    if (currentSessionId !== null || !UUID_PATTERN.test(String(event.id ?? ''))) {
+        throw new PiPrintError('Pi emitted an invalid session identity.', 'PI_PROTOCOL');
+    }
+    const sessionId = event.id as string;
+    if (expectedSessionId !== sessionId) {
+        throw new PiPrintError('Pi returned a different session identity.', 'PI_SESSION_MISMATCH');
+    }
+    return sessionId;
+}
+
+export function readPiAssistantText(event: Record<string, unknown>): string | null {
+    if (event.type !== 'message_end') return null;
+    const message = event.message;
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+    const record = message as Record<string, unknown>;
+    if (record.role !== 'assistant') return null;
+    if (typeof record.content === 'string') return record.content.trim() ? record.content : null;
+    if (!Array.isArray(record.content)) return null;
+    const text = record.content.flatMap((part) => {
+        if (!part || typeof part !== 'object' || Array.isArray(part)) return [];
+        const block = part as Record<string, unknown>;
+        return block.type === 'text' && typeof block.text === 'string' ? [block.text] : [];
+    }).join('');
+    return text.trim() ? text : null;
+}

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintProtocol.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintProtocol.ts
@@ -1,4 +1,4 @@
-import { PiPrintError } from './DurableAgent.js';
+import { PiPrintError } from '../../../durable/DurableAgent.js';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
@@ -1,11 +1,11 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from 'child_process';
-import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
+import type { PiDurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
 import { PiPrintError } from '../../../durable/DurableAgent.js';
 import { LocalProcessInspector, type ProcessInspector } from '../../../durable/DurableAgentRepository.js';
 import { buildPiPrintArgs, readPiAssistantText, readPiSessionId } from './PiPrintProtocol.js';
 
 type Spawn = (command: string, args: readonly string[], options: SpawnOptionsWithoutStdio & { stdio: ['pipe', 'pipe', 'pipe'] }) => ChildProcessWithoutNullStreams;
-export interface PiPrintRunRequest { agent: DurableAgent; prompt: string; executable?: string; onSpawn(identity: ProcessIdentity): Promise<void> }
+export interface PiPrintRunRequest { agent: PiDurableAgent; prompt: string; executable?: string; onSpawn(identity: ProcessIdentity): Promise<void> }
 export interface PiPrintRunResult { sessionId: string; result: string; messages: string[]; exitCode: number }
 export interface PiPrintRunnerOptions { spawn?: Spawn; processInspector?: ProcessInspector; maxLineBytes?: number }
 

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
@@ -2,12 +2,12 @@ import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams, type SpawnOpti
 import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
 import { PiPrintError } from '../../../durable/DurableAgent.js';
 import { LocalProcessInspector, type ProcessInspector } from '../../../durable/DurableAgentRepository.js';
+import { buildPiPrintArgs, readPiAssistantText, readPiSessionId } from './PiPrintProtocol.js';
 
 type Spawn = (command: string, args: readonly string[], options: SpawnOptionsWithoutStdio & { stdio: ['pipe', 'pipe', 'pipe'] }) => ChildProcessWithoutNullStreams;
 export interface PiPrintRunRequest { agent: DurableAgent; prompt: string; executable?: string; onSpawn(identity: ProcessIdentity): Promise<void> }
 export interface PiPrintRunResult { sessionId: string; result: string; messages: string[]; exitCode: number }
 export interface PiPrintRunnerOptions { spawn?: Spawn; processInspector?: ProcessInspector; maxLineBytes?: number }
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export class PiPrintRunner {
     private readonly spawn: Spawn; private readonly processInspector: ProcessInspector; private readonly maxLineBytes: number;
@@ -16,9 +16,7 @@ export class PiPrintRunner {
         this.maxLineBytes = options.maxLineBytes ?? 1024 * 1024;
     }
     async run(request: PiPrintRunRequest): Promise<PiPrintRunResult> {
-        const args = request.agent.sessionHealth === 'uninitialized'
-            ? ['--mode', 'json', '--session-id', request.agent.providerSessionId]
-            : ['--mode', 'json', '--session', request.agent.providerSessionId];
+        const args = buildPiPrintArgs(request.agent.providerSessionId, request.agent.sessionHealth === 'uninitialized');
         const child = this.spawn(request.executable ?? 'pi', args, { cwd: request.agent.cwd, shell: false, stdio: ['pipe', 'pipe', 'pipe'] });
         if (!child.pid) { child.kill(); throw new PiPrintError('Pi process did not provide a PID.', 'PI_PROCESS'); }
         const identity = this.processInspector.getIdentity(child.pid);
@@ -33,21 +31,12 @@ export class PiPrintRunner {
             if (!value || typeof value !== 'object' || Array.isArray(value)) throw new PiPrintError('Pi emitted a non-object stream message.', 'PI_PROTOCOL');
             const event = value as Record<string, unknown>;
             if (event.type === 'session') {
-                if (sessionId !== null || !UUID_PATTERN.test(String(event.id ?? ''))) throw new PiPrintError('Pi emitted an invalid session identity.', 'PI_PROTOCOL');
-                sessionId = event.id as string;
-                if (request.agent.providerSessionId !== sessionId) {
-                    throw new PiPrintError('Pi returned a different session identity.', 'PI_SESSION_MISMATCH');
-                }
-            } else if (event.type === 'message_end') {
-                const message = event.message as Record<string, unknown> | undefined;
-                if (message?.role === 'assistant') {
-                    const content = message.content;
-                    const text = typeof content === 'string' ? content : Array.isArray(content)
-                        ? content.filter((part): part is Record<string, unknown> => !!part && typeof part === 'object' && !Array.isArray(part))
-                            .filter((part) => part.type === 'text' && typeof part.text === 'string').map((part) => part.text).join('') : '';
-                    if (text.trim()) messages.push(text);
-                }
+                sessionId = readPiSessionId(event, sessionId, request.agent.providerSessionId);
             } else if (event.type === 'agent_end') ended = true;
+            else {
+                const text = readPiAssistantText(event);
+                if (text !== null) messages.push(text);
+            }
         };
         child.stdout.on('data', (chunk: Buffer | string) => {
             if (protocolError) return;

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
@@ -1,8 +1,10 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from 'child_process';
 import type { PiDurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
 import { PiPrintError } from '../../../durable/DurableAgent.js';
-import { LocalProcessInspector, type ProcessInspector } from '../../../durable/DurableAgentRepository.js';
-import { buildPiPrintArgs, readPiAssistantText, readPiSessionId } from './PiPrintProtocol.js';
+import { LocalProcessInspector, type ProcessInspector } from '../../../durable/process.js';
+import { waitForChildClose } from '../../../durable/utils.js';
+import { buildPiPrintArgs } from './PiPrintProtocol.js';
+import { PiStreamParser } from './PiStreamParser.js';
 
 type Spawn = (command: string, args: readonly string[], options: SpawnOptionsWithoutStdio & { stdio: ['pipe', 'pipe', 'pipe'] }) => ChildProcessWithoutNullStreams;
 export interface PiPrintRunRequest { agent: PiDurableAgent; prompt: string; executable?: string; onSpawn(identity: ProcessIdentity): Promise<void> }
@@ -21,47 +23,18 @@ export class PiPrintRunner {
         if (!child.pid) { child.kill(); throw new PiPrintError('Pi process did not provide a PID.', 'PI_PROCESS'); }
         const identity = this.processInspector.getIdentity(child.pid);
         if (!identity) { child.kill(); throw new PiPrintError('Cannot verify Pi process identity.', 'PI_PROCESS'); }
-        let buffer = Buffer.alloc(0); let sessionId: string | null = null; let ended = false; const messages: string[] = [];
-        let protocolError: PiPrintError | null = null; let processing = Promise.resolve();
-        const processLine = async (line: Buffer) => {
-            if (!line.length) return;
-            if (line.length > this.maxLineBytes) throw new PiPrintError('Pi stream line exceeded the safety limit.', 'PI_PROTOCOL');
-            let value: unknown;
-            try { value = JSON.parse(line.toString('utf8')); } catch { throw new PiPrintError('Pi emitted malformed stream JSON.', 'PI_PROTOCOL'); }
-            if (!value || typeof value !== 'object' || Array.isArray(value)) throw new PiPrintError('Pi emitted a non-object stream message.', 'PI_PROTOCOL');
-            const event = value as Record<string, unknown>;
-            if (event.type === 'session') {
-                sessionId = readPiSessionId(event, sessionId, request.agent.providerSessionId);
-            } else if (event.type === 'agent_end') ended = true;
-            else {
-                const text = readPiAssistantText(event);
-                if (text !== null) messages.push(text);
-            }
-        };
+        const parser = new PiStreamParser(request.agent.providerSessionId, this.maxLineBytes);
         child.stdout.on('data', (chunk: Buffer | string) => {
-            if (protocolError) return;
-            buffer = Buffer.concat([buffer, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
-            if (buffer.length > this.maxLineBytes && buffer.indexOf(0x0a) < 0) { protocolError = new PiPrintError('Pi stream line exceeded the safety limit.', 'PI_PROTOCOL'); return; }
-            let newline: number;
-            while ((newline = buffer.indexOf(0x0a)) >= 0) {
-                const line = buffer.subarray(0, newline); buffer = buffer.subarray(newline + 1);
-                processing = processing.then(() => processLine(line)).catch((error) => { protocolError = error instanceof PiPrintError ? error : new PiPrintError('Pi stream processing failed.', 'PI_PROTOCOL'); });
-            }
+            if (parser.hasFailed()) return;
+            try { parser.accept(chunk); } catch (error) { parser.fail(error); }
         });
         child.stderr.resume();
-        const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-            child.once('error', reject); child.once('close', (code, signal) => resolve({ code, signal }));
-        });
+        const closed = waitForChildClose(child);
         try { await request.onSpawn(identity); } catch (error) { child.kill(); throw error; }
         child.stdin.end(request.prompt);
-        const { code, signal } = await closed.catch(() => { throw new PiPrintError('Pi process failed to start or communicate.', 'PI_PROCESS'); });
-        await processing;
-        if (protocolError) throw protocolError;
-        if (buffer.length) throw new PiPrintError('Pi stream ended with incomplete JSON.', 'PI_PROTOCOL');
-        if (code !== 0) throw new PiPrintError(`Pi print run failed${signal ? ` (${signal})` : '.'}`, 'PI_PROCESS');
-        if (sessionId === null) throw new PiPrintError('Pi stream ended without a session identity.', 'PI_PROTOCOL');
-        if (!ended) throw new PiPrintError('Pi stream ended before agent completion.', 'PI_PROTOCOL');
-        if (!messages.length) throw new PiPrintError('Pi stream ended without an assistant result.', 'PI_RESULT_MISSING');
-        return { sessionId, result: messages.at(-1)!, messages, exitCode: code };
+        const close = await closed.catch(() => {
+            throw new PiPrintError('Pi process failed to start or communicate.', 'PI_PROCESS');
+        });
+        return parser.result(close);
     }
 }

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
@@ -1,0 +1,78 @@
+import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from 'child_process';
+import type { DurableAgent, ProcessIdentity } from '../../../durable/DurableAgent.js';
+import { PiPrintError } from '../../../durable/DurableAgent.js';
+import { LocalProcessInspector, type ProcessInspector } from '../../../durable/DurableAgentRepository.js';
+
+type Spawn = (command: string, args: readonly string[], options: SpawnOptionsWithoutStdio & { stdio: ['pipe', 'pipe', 'pipe'] }) => ChildProcessWithoutNullStreams;
+export interface PiPrintRunRequest { agent: DurableAgent; prompt: string; executable?: string; onSpawn(identity: ProcessIdentity): Promise<void> }
+export interface PiPrintRunResult { sessionId: string; result: string; messages: string[]; exitCode: number }
+export interface PiPrintRunnerOptions { spawn?: Spawn; processInspector?: ProcessInspector; maxLineBytes?: number }
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export class PiPrintRunner {
+    private readonly spawn: Spawn; private readonly processInspector: ProcessInspector; private readonly maxLineBytes: number;
+    constructor(options: PiPrintRunnerOptions = {}) {
+        this.spawn = options.spawn ?? (nodeSpawn as Spawn); this.processInspector = options.processInspector ?? new LocalProcessInspector();
+        this.maxLineBytes = options.maxLineBytes ?? 1024 * 1024;
+    }
+    async run(request: PiPrintRunRequest): Promise<PiPrintRunResult> {
+        const args = request.agent.sessionHealth === 'uninitialized'
+            ? ['--mode', 'json', '--session-id', request.agent.providerSessionId]
+            : ['--mode', 'json', '--session', request.agent.providerSessionId];
+        const child = this.spawn(request.executable ?? 'pi', args, { cwd: request.agent.cwd, shell: false, stdio: ['pipe', 'pipe', 'pipe'] });
+        if (!child.pid) { child.kill(); throw new PiPrintError('Pi process did not provide a PID.', 'PI_PROCESS'); }
+        const identity = this.processInspector.getIdentity(child.pid);
+        if (!identity) { child.kill(); throw new PiPrintError('Cannot verify Pi process identity.', 'PI_PROCESS'); }
+        let buffer = Buffer.alloc(0); let sessionId: string | null = null; let ended = false; const messages: string[] = [];
+        let protocolError: PiPrintError | null = null; let processing = Promise.resolve();
+        const processLine = async (line: Buffer) => {
+            if (!line.length) return;
+            if (line.length > this.maxLineBytes) throw new PiPrintError('Pi stream line exceeded the safety limit.', 'PI_PROTOCOL');
+            let value: unknown;
+            try { value = JSON.parse(line.toString('utf8')); } catch { throw new PiPrintError('Pi emitted malformed stream JSON.', 'PI_PROTOCOL'); }
+            if (!value || typeof value !== 'object' || Array.isArray(value)) throw new PiPrintError('Pi emitted a non-object stream message.', 'PI_PROTOCOL');
+            const event = value as Record<string, unknown>;
+            if (event.type === 'session') {
+                if (sessionId !== null || !UUID_PATTERN.test(String(event.id ?? ''))) throw new PiPrintError('Pi emitted an invalid session identity.', 'PI_PROTOCOL');
+                sessionId = event.id as string;
+                if (request.agent.providerSessionId !== sessionId) {
+                    throw new PiPrintError('Pi returned a different session identity.', 'PI_SESSION_MISMATCH');
+                }
+            } else if (event.type === 'message_end') {
+                const message = event.message as Record<string, unknown> | undefined;
+                if (message?.role === 'assistant') {
+                    const content = message.content;
+                    const text = typeof content === 'string' ? content : Array.isArray(content)
+                        ? content.filter((part): part is Record<string, unknown> => !!part && typeof part === 'object' && !Array.isArray(part))
+                            .filter((part) => part.type === 'text' && typeof part.text === 'string').map((part) => part.text).join('') : '';
+                    if (text.trim()) messages.push(text);
+                }
+            } else if (event.type === 'agent_end') ended = true;
+        };
+        child.stdout.on('data', (chunk: Buffer | string) => {
+            if (protocolError) return;
+            buffer = Buffer.concat([buffer, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
+            if (buffer.length > this.maxLineBytes && buffer.indexOf(0x0a) < 0) { protocolError = new PiPrintError('Pi stream line exceeded the safety limit.', 'PI_PROTOCOL'); return; }
+            let newline: number;
+            while ((newline = buffer.indexOf(0x0a)) >= 0) {
+                const line = buffer.subarray(0, newline); buffer = buffer.subarray(newline + 1);
+                processing = processing.then(() => processLine(line)).catch((error) => { protocolError = error instanceof PiPrintError ? error : new PiPrintError('Pi stream processing failed.', 'PI_PROTOCOL'); });
+            }
+        });
+        child.stderr.resume();
+        const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+            child.once('error', reject); child.once('close', (code, signal) => resolve({ code, signal }));
+        });
+        try { await request.onSpawn(identity); } catch (error) { child.kill(); throw error; }
+        child.stdin.end(request.prompt);
+        const { code, signal } = await closed.catch(() => { throw new PiPrintError('Pi process failed to start or communicate.', 'PI_PROCESS'); });
+        await processing;
+        if (protocolError) throw protocolError;
+        if (buffer.length) throw new PiPrintError('Pi stream ended with incomplete JSON.', 'PI_PROTOCOL');
+        if (code !== 0) throw new PiPrintError(`Pi print run failed${signal ? ` (${signal})` : '.'}`, 'PI_PROCESS');
+        if (sessionId === null) throw new PiPrintError('Pi stream ended without a session identity.', 'PI_PROTOCOL');
+        if (!ended) throw new PiPrintError('Pi stream ended before agent completion.', 'PI_PROTOCOL');
+        if (!messages.length) throw new PiPrintError('Pi stream ended without an assistant result.', 'PI_RESULT_MISSING');
+        return { sessionId, result: messages.at(-1)!, messages, exitCode: code };
+    }
+}

--- a/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiPrintRunner.ts
@@ -6,31 +6,79 @@ import { waitForChildClose } from '../../../durable/utils.js';
 import { buildPiPrintArgs } from './PiPrintProtocol.js';
 import { PiStreamParser } from './PiStreamParser.js';
 
-type Spawn = (command: string, args: readonly string[], options: SpawnOptionsWithoutStdio & { stdio: ['pipe', 'pipe', 'pipe'] }) => ChildProcessWithoutNullStreams;
-export interface PiPrintRunRequest { agent: PiDurableAgent; prompt: string; executable?: string; onSpawn(identity: ProcessIdentity): Promise<void> }
-export interface PiPrintRunResult { sessionId: string; result: string; messages: string[]; exitCode: number }
-export interface PiPrintRunnerOptions { spawn?: Spawn; processInspector?: ProcessInspector; maxLineBytes?: number }
+type Spawn = (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptionsWithoutStdio & { stdio: ['pipe', 'pipe', 'pipe'] },
+) => ChildProcessWithoutNullStreams;
+
+export interface PiPrintRunRequest {
+    agent: PiDurableAgent;
+    prompt: string;
+    executable?: string;
+    onSpawn(identity: ProcessIdentity): Promise<void>;
+}
+
+export interface PiPrintRunResult {
+    sessionId: string;
+    result: string;
+    messages: string[];
+    exitCode: number;
+}
+
+export interface PiPrintRunnerOptions {
+    spawn?: Spawn;
+    processInspector?: ProcessInspector;
+    maxLineBytes?: number;
+}
 
 export class PiPrintRunner {
-    private readonly spawn: Spawn; private readonly processInspector: ProcessInspector; private readonly maxLineBytes: number;
+    private readonly spawn: Spawn;
+    private readonly processInspector: ProcessInspector;
+    private readonly maxLineBytes: number;
+
     constructor(options: PiPrintRunnerOptions = {}) {
-        this.spawn = options.spawn ?? (nodeSpawn as Spawn); this.processInspector = options.processInspector ?? new LocalProcessInspector();
+        this.spawn = options.spawn ?? (nodeSpawn as Spawn);
+        this.processInspector = options.processInspector ?? new LocalProcessInspector();
         this.maxLineBytes = options.maxLineBytes ?? 1024 * 1024;
     }
+
     async run(request: PiPrintRunRequest): Promise<PiPrintRunResult> {
         const args = buildPiPrintArgs(request.agent.providerSessionId, request.agent.sessionHealth === 'uninitialized');
-        const child = this.spawn(request.executable ?? 'pi', args, { cwd: request.agent.cwd, shell: false, stdio: ['pipe', 'pipe', 'pipe'] });
-        if (!child.pid) { child.kill(); throw new PiPrintError('Pi process did not provide a PID.', 'PI_PROCESS'); }
+        const child = this.spawn(request.executable ?? 'pi', args, {
+            cwd: request.agent.cwd,
+            shell: false,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        if (!child.pid) {
+            child.kill();
+            throw new PiPrintError('Pi process did not provide a PID.', 'PI_PROCESS');
+        }
         const identity = this.processInspector.getIdentity(child.pid);
-        if (!identity) { child.kill(); throw new PiPrintError('Cannot verify Pi process identity.', 'PI_PROCESS'); }
+        if (!identity) {
+            child.kill();
+            throw new PiPrintError('Cannot verify Pi process identity.', 'PI_PROCESS');
+        }
+
         const parser = new PiStreamParser(request.agent.providerSessionId, this.maxLineBytes);
         child.stdout.on('data', (chunk: Buffer | string) => {
             if (parser.hasFailed()) return;
-            try { parser.accept(chunk); } catch (error) { parser.fail(error); }
+            try {
+                parser.accept(chunk);
+            } catch (error) {
+                parser.fail(error);
+            }
         });
         child.stderr.resume();
+
         const closed = waitForChildClose(child);
-        try { await request.onSpawn(identity); } catch (error) { child.kill(); throw error; }
+        try {
+            await request.onSpawn(identity);
+        } catch (error) {
+            child.kill();
+            throw error;
+        }
+
         child.stdin.end(request.prompt);
         const close = await closed.catch(() => {
             throw new PiPrintError('Pi process failed to start or communicate.', 'PI_PROCESS');

--- a/packages/agent-manager/src/providers/pi/durable/PiStreamParser.ts
+++ b/packages/agent-manager/src/providers/pi/durable/PiStreamParser.ts
@@ -1,0 +1,84 @@
+import { PiPrintError } from '../../../durable/DurableAgent.js';
+import { LineBuffer, type ChildCloseResult } from '../../../durable/utils.js';
+import { readPiAssistantText, readPiSessionId } from './PiPrintProtocol.js';
+
+export class PiStreamParser {
+    private readonly lines: LineBuffer;
+    private sessionId: string | null = null;
+    private ended = false;
+    private readonly messages: string[] = [];
+    private failure: PiPrintError | null = null;
+
+    constructor(
+        private readonly expectedSessionId: string,
+        maxLineBytes: number,
+    ) {
+        this.lines = new LineBuffer(
+            maxLineBytes,
+            () => new PiPrintError('Pi stream line exceeded the safety limit.', 'PI_PROTOCOL'),
+        );
+    }
+
+    hasFailed(): boolean {
+        return this.failure !== null;
+    }
+
+    accept(chunk: Buffer | string): void {
+        for (const line of this.lines.accept(chunk)) {
+            if (line.length === 0) continue;
+            this.acceptLine(line);
+        }
+    }
+
+    fail(error: unknown): void {
+        this.failure = error instanceof PiPrintError
+            ? error
+            : new PiPrintError('Pi stream processing failed.', 'PI_PROTOCOL');
+    }
+
+    result(close: ChildCloseResult): { sessionId: string; result: string; messages: string[]; exitCode: number } {
+        if (this.failure) throw this.failure;
+        this.lines.assertComplete(
+            () => new PiPrintError('Pi stream ended with incomplete JSON.', 'PI_PROTOCOL'),
+        );
+        if (close.code !== 0) {
+            throw new PiPrintError(`Pi print run failed${close.signal ? ` (${close.signal})` : '.'}`, 'PI_PROCESS');
+        }
+        if (this.sessionId === null) {
+            throw new PiPrintError('Pi stream ended without a session identity.', 'PI_PROTOCOL');
+        }
+        if (!this.ended) throw new PiPrintError('Pi stream ended before agent completion.', 'PI_PROTOCOL');
+        if (this.messages.length === 0) {
+            throw new PiPrintError('Pi stream ended without an assistant result.', 'PI_RESULT_MISSING');
+        }
+        return {
+            sessionId: this.sessionId,
+            result: this.messages.at(-1)!,
+            messages: this.messages,
+            exitCode: close.code,
+        };
+    }
+
+    private acceptLine(line: Buffer): void {
+        let value: unknown;
+        try {
+            value = JSON.parse(line.toString('utf8'));
+        } catch {
+            throw new PiPrintError('Pi emitted malformed stream JSON.', 'PI_PROTOCOL');
+        }
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            throw new PiPrintError('Pi emitted a non-object stream message.', 'PI_PROTOCOL');
+        }
+        const event = value as Record<string, unknown>;
+        if (event.type === 'session') {
+            this.sessionId = readPiSessionId(event, this.sessionId, this.expectedSessionId);
+            return;
+        }
+        if (event.type === 'agent_end') {
+            this.ended = true;
+            return;
+        }
+        const text = readPiAssistantText(event);
+        if (text !== null) this.messages.push(text);
+    }
+}

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -32,6 +32,12 @@ const mockCodexPrintService: any = {
   send: vi.fn(),
 };
 
+const mockPiPrintService: any = {
+  repository: mockDurableRepository,
+  create: vi.fn(),
+  send: vi.fn(),
+};
+
 const mockAgentAdapter: any = {
   getConversation: vi.fn(),
 };
@@ -109,6 +115,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
   DurableAgentRepository: vi.fn(function () { return mockDurableRepository; }),
   ClaudePrintAgentService: vi.fn(function () { return mockDurableService; }),
   CodexPrintAgentService: vi.fn(function () { return mockCodexPrintService; }),
+  PiPrintAgentService: vi.fn(function () { return mockPiPrintService; }),
   TerminalFocusManager: vi.fn(function () { return mockFocusManager; }),
   TtyWriter: { send: (location: any, message: string) => mockTtyWriterSend(location, message) },
   AgentStatus: {
@@ -242,6 +249,8 @@ describe('agent command', () => {
     mockDurableRepository.resolve.mockReset().mockResolvedValue(null);
     mockDurableService.create.mockReset();
     mockDurableService.send.mockReset();
+    mockPiPrintService.create.mockReset();
+    mockPiPrintService.send.mockReset();
     mockFocusManager.findTerminal.mockReset();
     mockFocusManager.focusTerminal.mockReset();
     mockTtyWriterSend.mockReset().mockResolvedValue(undefined);
@@ -800,6 +809,27 @@ Waiting on user input`,
 
     expect(mockCodexPrintService.send).toHaveBeenCalledWith(durableAgent.id, 'review');
     expect(JSON.parse(logSpy.mock.calls[0][0] as string).target.provider).toBe('codex');
+  });
+
+  it('starts a durable Pi agent without tmux', async () => {
+    mockPiPrintService.create.mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111', name: 'reviewer', provider: 'pi',
+      mode: 'durable', cwd: process.cwd(), state: 'ready', providerSessionId: '22222222-2222-4222-8222-222222222222',
+    });
+    const program = new Command(); registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'start', '--type', 'pi', '--mode', 'durable', '--name', 'reviewer', '--cwd', process.cwd()]);
+    expect(mockPiPrintService.create).toHaveBeenCalledWith({ name: 'reviewer', cwd: process.cwd() });
+    expect(ui.text).toHaveBeenCalledWith('State: ready (Pi session not started)');
+  });
+
+  it('dispatches durable send to the persisted Pi provider', async () => {
+    const durableAgent = { id: '11111111-1111-4111-8111-111111111111', name: 'reviewer', provider: 'pi', mode: 'durable', cwd: '/project', state: 'ready' };
+    mockDurableRepository.resolve.mockResolvedValue(durableAgent);
+    mockPiPrintService.send.mockResolvedValue({ agentId: durableAgent.id, agentName: durableAgent.name, result: 'done', exitCode: 0, sessionId: '22222222-2222-4222-8222-222222222222' });
+    const program = new Command(); registerAgentCommand(program);
+    await program.parseAsync(['node', 'test', 'agent', 'send', 'review', '--id', durableAgent.id, '--json']);
+    expect(mockPiPrintService.send).toHaveBeenCalledWith(durableAgent.id, 'review');
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string).target.provider).toBe('pi');
   });
 
   it('sends synchronously to an exact durable-agent id without terminal injection', async () => {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -17,6 +17,7 @@ import {
     ClaudePrintAgentService,
     CodexPrintAgentService,
     DurableAgentRepository,
+    PiPrintAgentService,
     AgentStatus,
     TerminalFocusManager,
     AgentRegistry,
@@ -194,15 +195,16 @@ function createAgentManager(): AgentManager {
     return manager;
 }
 
-function createDurableAgentService(provider: DurableProvider = 'claude'): ClaudePrintAgentService | CodexPrintAgentService {
+function createDurableAgentService(provider: DurableProvider = 'claude'): ClaudePrintAgentService | CodexPrintAgentService | PiPrintAgentService {
     const repository = new DurableAgentRepository();
-    return provider === 'codex'
-        ? new CodexPrintAgentService({ repository })
-        : new ClaudePrintAgentService({ repository });
+    if (provider === 'codex') return new CodexPrintAgentService({ repository });
+    if (provider === 'pi') return new PiPrintAgentService({ repository });
+    return new ClaudePrintAgentService({ repository });
 }
 
 function formatPrintProvider(provider: DurableProvider): string {
-    return provider === 'codex' ? 'Codex' : 'Claude Code';
+    if (provider === 'codex') return 'Codex';
+    return provider === 'pi' ? 'Pi' : 'Claude Code';
 }
 
 const NAME_REGEX = /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/;
@@ -294,8 +296,8 @@ export function registerAgentCommand(program: Command): void {
                 throw new Error(`Unsupported agent mode "${mode}". Supported: interactive, durable.`);
             }
             const internalMode = mode === 'durable' ? AGENT_MODES.DURABLE : AGENT_MODES.INTERACTIVE;
-            if (internalMode === AGENT_MODES.DURABLE && !['claude', 'codex'].includes(agentType)) {
-                throw new Error('Durable mode currently supports only --type claude or --type codex.');
+            if (internalMode === AGENT_MODES.DURABLE && !['claude', 'codex', 'pi'].includes(agentType)) {
+                throw new Error('Durable mode currently supports only --type claude, --type codex, or --type pi.');
             }
             if (!NAME_REGEX.test(agentName)) {
                 ui.error(
@@ -642,6 +644,7 @@ export function registerAgentCommand(program: Command): void {
                 throw new Error(`Multiple durable agents match "${options.id}".`);
             }
             if (durableResolved) {
+                const providerService = createDurableAgentService(durableResolved.provider);
                 if (options.timeout !== undefined) {
                     throw new Error('--timeout is not supported for synchronous durable agents.');
                 }
@@ -652,7 +655,7 @@ export function registerAgentCommand(program: Command): void {
                         throw new Error(`Agent name "${options.id}" is ambiguous across interactive and durable modes. Use the durable agent ID.`);
                     }
                 }
-                const result = await durableService.send(options.id, prompt);
+                const result = await providerService.send(options.id, prompt);
                 if (options.json) {
                     console.log(JSON.stringify({
                         target: { id: result.agentId, name: result.agentName, provider: durableResolved.provider, mode: AGENT_MODES.DURABLE },

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -637,9 +637,6 @@ export function registerAgentCommand(program: Command): void {
 
             const repository = new DurableAgentRepository();
             const durableResolved = await repository.resolve(options.id);
-            const durableService = durableResolved && !Array.isArray(durableResolved)
-                ? createDurableAgentService(durableResolved.provider)
-                : createDurableAgentService();
             if (Array.isArray(durableResolved)) {
                 throw new Error(`Multiple durable agents match "${options.id}".`);
             }


### PR DESCRIPTION
## Summary

- add durable Pi print agents backed by Pi JSON event mode
- persist and resume provider session UUIDs through the generalized print-agent store
- wire Pi creation, send dispatch, list, detail, and console visibility into the agent CLI

## Design

Source: docs/ai/design/2026-08-17-feature-pi-print-mode.md

Pi CLI behavior is grounded in the installed @earendil-works/pi-coding-agent documentation and source. The open Codex print-mode PR #148 was used only as a read-only consistency reference.

## Validation

- npm test (all 6 projects; agent-manager 552 tests, CLI 986 tests)
- npm run build (all 6 projects)
- npm run lint (0 errors; existing warnings only)
- pure Pi protocol coverage: 100% statements, branches, functions, and lines with enforced thresholds
- npx ai-devkit@latest lint --feature pi-print-mode

## Risks

No known blockers. Store schema v2 retains strict legacy Claude record reads; Pi session IDs are late-bound under run ownership and validated for provider uniqueness.