### PR TITLE
docs(skills): build workspace artifacts before full gates and commit hooks

### DIFF
--- a/skills/dev-commit/SKILL.md
+++ b/skills/dev-commit/SKILL.md
@@ -11,7 +11,7 @@ Make one intentional, verified commit without sweeping in unrelated work.
 
 1. Check repository state with `git status --short --branch`, `git diff --stat`, and `git diff`.
 2. Identify the files that belong to the requested change. Treat pre-existing user edits, local config, generated artifacts, dependency caches, build outputs, and unrelated formatting churn as out of scope unless the user explicitly includes them.
-3. Run appropriate validation before committing. Prefer the repo's targeted tests, lint, typecheck, build, or documented verification commands. Record skipped validation with the reason.
+3. Run appropriate validation before committing. Prefer the repo's targeted tests, lint, typecheck, build, or documented verification commands. Record skipped validation with the reason. In workspaces whose packages resolve against built artifacts, ensure install and build have run in that worktree (`npm ci`, `npm run build`) before full validation or commit hooks; a fresh worktree with stale artifacts fails hooks for environmental reasons.
 4. Stage only intended paths. Prefer explicit pathspecs such as `git add path/to/file` over `git add .`.
 5. Re-check with `git diff --cached --stat`, `git diff --cached`, and `git status --short`.
 6. Write a concise conventional commit message: `<type>(optional-scope): <summary>`.
@@ -23,7 +23,7 @@ Make one intentional, verified commit without sweeping in unrelated work.
 - Do not stage another person's unrelated edits. If intended and unrelated changes are mixed in one file, use an interactive or patch-based staging flow and review the staged diff carefully.
 - Do not amend, rebase, force-push, reset, or delete branches unless the user explicitly asks for that operation.
 - If validation fails, stop before committing unless the user explicitly instructs you to commit with failing validation. Report the failing command and key output.
-- If the repo has commit hooks, let them run. If a hook changes files, inspect and stage only intended hook outputs before retrying.
+- If the repo has commit hooks, let them run. If a hook changes files, inspect and stage only intended hook outputs before retrying. If a hook fails, first rule out environmental causes (missing install, stale workspace build artifacts, concurrent test runs sharing resources) by re-running the failing package in isolation; do not treat an environmental failure as a code regression or "stop" condition until isolated runs still fail.
 
 ## Message Style
 

--- a/skills/dev-worktree/SKILL.md
+++ b/skills/dev-worktree/SKILL.md
@@ -58,7 +58,8 @@ After selecting the target context:
    - Rust: `cargo fetch`, or `cargo build` when fetch-only is insufficient.
    - Go: `go mod download`.
    - Java/Kotlin: `./gradlew dependencies`, `./gradlew build`, or Maven equivalent.
-4. If no dependency manager is clearly detectable, continue and state what was checked.
+4. For workspaces whose packages resolve against built artifacts (for example `dist/` output consumed via workspace aliases), run the repository build (for example `npm run build`) after install. Full-suite validation and commit hooks fail on stale or missing artifacts with errors that look like code regressions. State when the build was skipped and why.
+5. If no dependency manager is clearly detectable, continue and state what was checked.
 
 ## Output
 
@@ -68,4 +69,5 @@ End with:
 - Branch name.
 - Whether worktree or no-worktree mode is active.
 - Dependency bootstrap command run, or why it was skipped.
+- Workspace build command run (when applicable), or why it was skipped.
 - Any workspace risks or blockers.


### PR DESCRIPTION
## Summary
Lesson from the 2026-08-17 telegram-fix recovery: fresh/resumed worktrees with stale workspace artifacts fail full-suite commit hooks with errors that look like code regressions (memory-dashboard StorageError; cli Cannot find package 'marked').

- **dev-worktree**: Dependency Bootstrap now runs the workspace build (e.g. `npm run build`) when packages resolve against built artifacts, and reports it in Output.
- **dev-commit**: validation step requires install+build in the worktree before hooks; hook-failure guardrail now says to rule out environmental causes (missing install, stale artifacts, concurrent runs) by re-running the failing package in isolation before treating failure as a regression.

## Validation
- Docs-only change; full workspace pre-commit suite green after `npm ci` + `npm run build` (which is itself the evidence for this change).