### PR TITLE
docs(web): expand agent CLI reference

### DIFF
--- a/web/content/docs/8-agent-management.md
+++ b/web/content/docs/8-agent-management.md
@@ -44,6 +44,24 @@ AI DevKit detects active sessions from the following tools:
 
 ## Commands
 
+### Start an Agent
+
+Start a named agent in a managed tmux session:
+
+```bash
+ai-devkit agent start --type claude --name backend --cwd ./packages/backend
+```
+
+`--type` accepts `claude`, `codex`, `copilot`, `gemini_cli`, `grok_cli`, `opencode`, or `pi`. Names default to the current folder plus a timestamp. Use `--cwd <path>` to choose a working directory and `--debug` to show startup diagnostics.
+
+The default `--mode interactive` starts the agent in tmux. Claude also supports a durable print mode that keeps a named agent available without an interactive terminal:
+
+```bash
+ai-devkit agent start --type claude --mode print --name backend --cwd ./packages/backend
+```
+
+Print mode currently supports only `--type claude`.
+
 ### List Agents
 
 List all detected running agents.
@@ -55,12 +73,33 @@ ai-devkit agent list --json
 
 **Table output includes:**
 
-| Agent | CWD | Type | Status | Working On | Active |
-|-------|-----|------|--------|------------|--------|
-| `my-project` | `~/code/my-project` | `Claude Code` | 🟢 run | implementing new feature | just now |
-| `website` | `~/code/website` | `Codex` | ⚪ idle | fixed css bug | 10m ago |
+| Agent | Project | Type | Mode | Status | Working On | Active |
+|-------|---------|------|------|--------|------------|--------|
+| `my-project` | `my-project` | `Claude Code` | `interactive` | 🟢 run | implementing new feature | just now |
+| `website-review` | `website` | `Claude Code` | `durable` | ready | not started | never |
 
-Use `--json` when you want the raw machine-readable agent list.
+`Project` is the final folder name from the agent's project path. `Mode` is `interactive` for terminal sessions and `durable` for print agents. Use `--json` when you want the raw machine-readable agent list.
+
+### List Historical Sessions
+
+List sessions that can be inspected or resumed. By default, results are limited to the current working directory and the 50 most recent sessions.
+
+```bash
+ai-devkit agent sessions
+ai-devkit agent sessions --all --type codex --limit 20
+ai-devkit agent sessions --cwd ./packages/cli --json
+```
+
+Use `--all` to include every working directory, `--cwd <path>` to choose one directory, `--type <type>` to filter by agent, `--limit <n>` to control the result count (`0` means no limit), and `--json` for machine-readable output.
+
+Inspect one historical session by its ID:
+
+```bash
+ai-devkit agent session detail <session-id>
+ai-devkit agent session detail <session-id> --tail 50 --verbose
+```
+
+The detail command supports `--type`, `--tail <n>`, `--full`, `--verbose`, and `--json`.
 
 ### Open Agent
 
@@ -100,6 +139,46 @@ Useful options:
 - `--tail <n>` to show only the last `n` messages
 - `--full` to show the entire conversation history
 - `--verbose` to include tool call and tool result details
+
+### Stop an Agent
+
+Stop a running agent by name:
+
+```bash
+ai-devkit agent kill my-project
+```
+
+For managed agents, AI DevKit also cleans up the associated tmux session.
+
+### Rename an Agent
+
+Rename an agent in the local registry without renaming its project directory:
+
+```bash
+ai-devkit agent rename my-project backend-api
+```
+
+Names must be 2-64 characters, use lowercase letters, numbers, and hyphens, and start and end with a letter or number.
+
+### Manage Agent Groups
+
+Groups let you address several running agents with one send command:
+
+```bash
+ai-devkit agent group create reviewers --agent frontend --agent backend
+ai-devkit agent group add reviewers security
+ai-devkit agent send --group reviewers "Review the current changes"
+```
+
+Available group commands are:
+
+- `agent group create <name> [--agent <identifier> ...]`
+- `agent group update <name> [--agent <identifier> ...]`
+- `agent group add <name> <identifier>`
+- `agent group remove-agent <name> <identifier>`
+- `agent group remove <name>`
+- `agent group list`
+- `agent group detail <name>`
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- document managed `agent start`, including all seven startable adapters and Claude-only print mode
- document historical sessions, lifecycle commands, agent groups, and group sends
- correct the `agent list` columns and interactive/durable mode descriptions

## Audit evidence

Closes the verified agent CLI reference findings from `/tmp/docs-audit-report.md`: registrations in `packages/cli/src/commands/agent.ts:267-340,342-526,674-846` and `packages/cli/src/commands/agent/group.command.ts:16-99` were absent from `web/content/docs/8-agent-management.md`; current list headers are defined at `packages/cli/src/commands/agent.ts:365-386`. The startable set is exactly `claude`, `codex`, `copilot`, `gemini_cli`, `grok_cli`, `opencode`, and `pi` in `packages/agent-manager/src/utils/agents.ts:4,18-26` (not Antigravity).

## Files changed

- `web/content/docs/8-agent-management.md`

## Validation

- docs-only change
- `npm ci` (exit 0; expected read-only Husky config warning)
- `npm run build` (exit 0; all 6 projects built)
- commit hook suite green: lint 6/6 projects, tests 6/6 projects (136 test files, 1,914 tests total)

## Risk

Documentation only; no runtime behavior changed.
