### PR TITLE
docs(web): generalize console channel guidance

### DIFF
--- a/web/content/docs/13-agent-console.md
+++ b/web/content/docs/13-agent-console.md
@@ -8,7 +8,7 @@ order: 13
 > ⚠️ **WARNING**
 > This feature is currently **experimental**. It requires an interactive terminal and depends on the same local agent detection used by [Agent Management](/docs/8-agent-management).
 
-The `agent console` command opens an interactive terminal UI for working with multiple AI agents at once. Use it when you want a multi-agent control room for monitoring active sessions, sending quick messages, starting managed agents, renaming or stopping agents, and connecting Telegram channels without switching between several terminal windows.
+The `agent console` command opens an interactive terminal UI for working with multiple AI agents at once. Use it when you want a multi-agent control room for monitoring active sessions, sending quick messages, starting managed agents, renaming or stopping agents, and connecting configured messaging channels without switching between several terminal windows.
 
 ```bash
 ai-devkit agent console
@@ -22,7 +22,7 @@ ai-devkit agent console
 - **An interactive terminal**: `agent console` requires a TTY
 - **Supported agent tools** installed for the workflows you want to use, such as Claude Code, Codex, Gemini CLI, or opencode
 - **tmux** installed if you want to start or kill managed agents from the console
-- **A configured Telegram channel** if you want to start remote channel bridges from the console (see [Channel](/docs/12-channel))
+- **A configured Telegram or Slack channel** if you want to start remote channel bridges from the console (see [Channel](/docs/12-channel))
 
 ## What the Console Shows
 
@@ -43,8 +43,8 @@ Press `h` inside the console to show the built-in help panel.
 | `k` / `Up` | Select previous agent |
 | `s` | Start a new managed agent |
 | `r` | Rename the selected agent |
-| `c` | Start a Telegram channel for the selected agent |
-| `C` | Stop the selected agent's Telegram channel |
+| `c` | Start a configured channel for the selected agent |
+| `C` | Stop the selected agent's channel |
 | `o` | Open the selected agent terminal |
 | `i` / `m` | Message the selected agent |
 | `K` | Kill the selected agent |
@@ -114,12 +114,13 @@ Managed agents started through AI DevKit are stopped together with their tmux se
 
 ## Channel Controls
 
-The console can start and stop Telegram channel bridges for the selected agent.
+The console can start and stop configured Telegram or Slack channel bridges for the selected agent.
 
 First configure a channel:
 
 ```bash
 ai-devkit channel connect telegram
+# or: ai-devkit channel connect slack --name work-slack
 ```
 
 Then open the console:
@@ -156,6 +157,7 @@ Run:
 
 ```bash
 ai-devkit channel connect telegram
+# or: ai-devkit channel connect slack --name work-slack
 ```
 
 Then reopen the channel picker with `c`.


### PR DESCRIPTION
## Summary

- replace Telegram-only console wording with provider-neutral channel guidance
- show both Telegram and Slack setup examples and generic channel controls

## Audit evidence

Closes the verified stale claim in `/tmp/docs-audit-report.md`: `web/content/docs/13-agent-console.md:11,25,46-47,115-139` described console controls as Telegram-only, while console channel state is generic (`packages/cli/src/tui/console/state/ConsoleContext.tsx:3-11,46-99`) and the channel service supports configured Slack connections.

## Files changed

- `web/content/docs/13-agent-console.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; merge after PR 02 because both touch the same page.
