### PR TITLE
docs(web): correct structured debug skill name

### DIFF
--- a/web/content/faq/ai-devkit-vs-superpowers.md
+++ b/web/content/faq/ai-devkit-vs-superpowers.md
@@ -15,7 +15,7 @@ These tools take different paths to fix that.
 | **Install** | `npm install -g ai-devkit` | Agent-specific setup guide (see official repository) |
 | **Approach** | One operating model across agents: config, memory, communication, workflow skills, and verification | Behavior focused: process instructions injected into agent prompts |
 | **Memory** | Built-in local SQLite memory system | Relies on plan documents and git history |
-| **Skills** | Built-in core skills (`dev-lifecycle`, `debug`, `simplify-implementation`, `document-code`) plus community registry via `skill add/remove/find` | 14 built-in composable skills |
+| **Skills** | Built-in core skills (`dev-lifecycle`, `structured-debug`, `simplify-implementation`, `document-code`) plus community registry via `skill add/remove/find` | 14 built-in composable skills |
 | **Agents supported** | Broad setup support across Cursor, Claude Code, Codex, Copilot, Gemini CLI, opencode, Antigravity, and others | 4 (Claude Code, Cursor, Codex, opencode) |
 | **Documentation** | Phase-based directory structure (`docs/ai/`) | Design docs saved to `docs/plans/` |
 | **Execution model** | Single agent per feature with persistent memory | Sub-agent dispatching with two-stage review |
@@ -84,7 +84,7 @@ A distinctive feature is **sub-agent dispatching**. Superpowers can spin up fres
 
 ### Skills and Extensibility
 
-**AI DevKit** combines built-in workflow skills (`dev-lifecycle`, `debug`, `simplify-implementation`, `document-code`) with a community-driven skill registry. You can browse, install, and manage additional skills with CLI commands (`ai-devkit skill add`, `ai-devkit skill find`). This gives teams a solid default methodology plus extensibility for domain-specific capabilities.
+**AI DevKit** combines built-in workflow skills (`dev-lifecycle`, `structured-debug`, `simplify-implementation`, `document-code`) with a community-driven skill registry. You can browse, install, and manage additional skills with CLI commands (`ai-devkit skill add`, `ai-devkit skill find`). This gives teams a solid default methodology plus extensibility for domain-specific capabilities.
 
 **Superpowers** comes with 14 built-in skills that form one cohesive methodology. There is a `writing-skills` skill for contributing new skills, but the system is more monolithic, with skills designed to work together in one workflow.
 


### PR DESCRIPTION
## Summary

- replace the nonexistent `debug` built-in name with `structured-debug` in the Superpowers comparison FAQ

## Audit evidence

Closes the verified FAQ finding from `/tmp/docs-audit-report.md`: `web/content/faq/ai-devkit-vs-superpowers.md:18,87` named `debug`, while the shipped skill is `structured-debug` (`skills/structured-debug/SKILL.md`, `packages/cli/src/constants.ts:26`).

## Files changed

- `web/content/faq/ai-devkit-vs-superpowers.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; no runtime behavior changed.
