### PR TITLE
docs(web): expand send wait adapter coverage

### DIFF
--- a/web/content/faq/use-ai-devkit-agent-send-wait-for-programmatic-agent-calls.md
+++ b/web/content/faq/use-ai-devkit-agent-send-wait-for-programmatic-agent-calls.md
@@ -1,6 +1,6 @@
 ---
 title: Use ai-devkit agent send --wait for Programmatic Agent Calls
-description: Use ai-devkit agent send --wait to call an existing interactive Claude Code, Codex, Gemini CLI, or opencode session from scripts and automation.
+description: Use ai-devkit agent send --wait to call an existing supported interactive coding-agent session from scripts and automation.
 order: 11
 ---
 
@@ -13,7 +13,7 @@ This is useful when you want the ergonomics of an interactive agent session but 
 Before using this workflow:
 
 - Install AI DevKit and make sure `ai-devkit` is available in your shell.
-- Start Claude Code, Codex, Gemini CLI, or opencode in the project you want to control.
+- Start a supported agent in the project you want to control: Claude Code, Codex, GitHub Copilot, Gemini CLI, Grok CLI, opencode, or Pi.
 - Keep that agent running in a supported terminal session such as tmux, iTerm2, or Apple Terminal.
 - Run `ai-devkit agent list` and confirm the session appears.
 
@@ -25,7 +25,10 @@ Start your coding agent normally in one terminal:
 claude
 # or codex
 # or gemini
+# or copilot
+# or grok
 # or opencode
+# or pi
 ```
 
 In another terminal, find the session identifier:
@@ -62,7 +65,7 @@ That means the agent keeps its current:
 - authentication and permission state
 - terminal session and interactive approvals
 
-This makes it a strong fit for automation that should continue work inside the same Claude Code, Codex, Gemini CLI, or opencode session.
+This makes it a strong fit for automation that should continue work inside the same supported interactive agent session.
 
 ## When should I still use claude -p or codex exec?
 
@@ -85,8 +88,11 @@ Current interactive adapters include:
 
 - Claude Code
 - Codex
+- GitHub Copilot
 - Gemini CLI
+- Grok CLI
 - opencode
+- Pi
 
 Support depends on AI DevKit being able to detect the live process, find its terminal, and read its session transcript.
 
@@ -172,7 +178,7 @@ This is why `agent send --wait` can be a practical bridge between automation and
 
 ### No running agents found
 
-Start Claude Code, Codex, Gemini CLI, or opencode first, then run:
+Start one of the supported interactive agents listed above, then run:
 
 ```bash
 ai-devkit agent list


### PR DESCRIPTION
## Summary

- add GitHub Copilot, Grok CLI, and Pi to the `agent send --wait` adapter guidance
- use a complete supported-agent list in prerequisites and troubleshooting

## Audit evidence

Closes the adapter-coverage finding from `/tmp/docs-audit-report.md`. Source verification showed all three adapters expose readable conversations (`CopilotAdapter.ts:182`, `GrokCliAdapter.ts:211`, `PiAdapter.ts:557`). Wait mode is adapter-generic: it reads `adapter.getConversation`, watches the same live agent, and completes on waiting/idle status (`packages/cli/src/services/agent/agent.service.ts:118-195,244-286`). Therefore the wider list is supported rather than a documented limitation.

## Files changed

- `web/content/faq/use-ai-devkit-agent-send-wait-for-programmatic-agent-calls.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; actual use still depends on live-process detection, terminal access, and a readable transcript as the page states.
