### PR TITLE
docs(web): clarify init overwrite behavior

### DIFF
--- a/web/content/docs/2-supported-agents.md
+++ b/web/content/docs/2-supported-agents.md
@@ -166,18 +166,25 @@ ai-devkit init
 
 AI DevKit will:
 1. Detect your existing environments
-2. Ask before overwriting any existing configurations
-3. Add new environments alongside existing ones
+2. Ask once before replacing the selected environment templates in interactive mode
+3. Ask separately before replacing each existing phase document
+
+In non-interactive mode (`--yes`), existing environment templates and phase documents are skipped unless you also pass `--overwrite`. Template-driven initialization overwrites the selected artifacts without prompting.
 
 ### Override Protection
 
-When re-running `ai-devkit init`, you'll see a warning before any existing files are overwritten:
+When an interactively selected environment is already set up, `ai-devkit init` shows a warning and asks whether to replace the selected environment templates:
 
 ```
 Warning: The following environments are already set up: cursor, claude
 
+The following environments are already set up and will be overwritten:
+  Cursor, Claude Code
+
 Do you want to continue?
 ```
+
+Existing phase documents use a separate per-phase confirmation. This behavior belongs to `init`; the non-interactive `ai-devkit install` reconciliation flow does not show a general “existing install artifacts” overwrite prompt.
 
 ## For Contributors
 


### PR DESCRIPTION
## Summary

- describe interactive, non-interactive, and template-driven `init` overwrite behavior
- distinguish `init` confirmations from the removed general `install` artifact prompt

## Audit evidence and correction

The audit associated `web/content/docs/2-supported-agents.md:167-180` with the 0.44.0 removal in commit `291ffdf`. Source review proved that finding too broad: interactive `init` still confirms selected environment replacement and each existing phase (`packages/cli/src/commands/init.ts:213-239,299-323`). Commit `291ffdf` removed only the general `install` artifact prompt from `reconcileAndInstall`. This PR fixes what is true and documents that distinction explicitly.

## Files changed

- `web/content/docs/2-supported-agents.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; no runtime behavior changed.
