### PR TITLE
docs(web): list first-party plugins

### DIFF
--- a/web/content/docs/14-plugins.md
+++ b/web/content/docs/14-plugins.md
@@ -11,6 +11,15 @@ Use plugins for capabilities that should live outside the core CLI, such as dash
 
 > **Important:** Installing a plugin means installing and running npm package code on your machine. Install plugins only from sources you trust.
 
+## Available First-Party Plugins
+
+| Plugin | Purpose | Install | Documentation |
+|---|---|---|---|
+| `@ai-devkit/memory-dashboard` | Browse and manage local memory in a web dashboard | `ai-devkit plugin add @ai-devkit/memory-dashboard` | [Memory dashboard README](https://github.com/codeaholicguy/ai-devkit/tree/main/packages/memory-dashboard) |
+| `@ai-devkit/task-manager` | Track durable lifecycle and debugging progress with append-only task events | `ai-devkit plugin add @ai-devkit/task-manager` | [Task manager README](https://github.com/codeaholicguy/ai-devkit/tree/main/packages/task-manager) |
+
+After installation, run `ai-devkit memory-dashboard` for the memory UI or `ai-devkit task --help` for task commands.
+
 ## How Plugins Work
 
 AI DevKit keeps plugins in a dedicated npm workspace under your home directory:


### PR DESCRIPTION
## Summary

- add an available first-party plugins table
- include install commands, purposes, command entry points, and package documentation links

## Audit evidence

Closes the plugin-structure finding from `/tmp/docs-audit-report.md`. The page used only the memory dashboard example, while `@ai-devkit/task-manager` is also a shipped plugin package (`packages/task-manager/package.json:2`) with installation documented in `packages/task-manager/README.md:38`.

## Files changed

- `web/content/docs/14-plugins.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; no runtime behavior changed.
