### PR TITLE
docs(web): refresh skill management roadmap

### DIFF
--- a/web/content/roadmap/5-skill-management.md
+++ b/web/content/roadmap/5-skill-management.md
@@ -4,4 +4,4 @@ status: completed
 order: 5
 ---
 
-Stop copy-pasting prompts and scripts between projects. Skill Management will provide a centralized registry to version, install, and share your custom AI capabilities (like specific refactoring workflows or testing patterns) across all your projects and teams with a single command.
+Skill Management provides registries for discovering, installing, updating, and sharing reusable AI capabilities across projects. You can register project or global sources with `skill add-registry`, update every cached registry or one selected registry with `skill update [registry-id]`, and list, install, or remove skills in project and global agent locations.


### PR DESCRIPTION
## Summary

- rewrite the completed skill-management milestone in present tense
- name custom registries, scoped updates, and project/global management

## Audit evidence

Closes the verified roadmap finding from `/tmp/docs-audit-report.md`: `web/content/roadmap/5-skill-management.md:2-7` was marked completed but said the system “will provide” a registry. The shipped commands are registered in `packages/cli/src/commands/skill.ts:13-218`.

## Files changed

- `web/content/roadmap/5-skill-management.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; no runtime behavior changed.
