### PR TITLE
docs(web): complete agent management roadmap

### DIFF
--- a/web/content/roadmap/10-agent-management.md
+++ b/web/content/roadmap/10-agent-management.md
@@ -1,7 +1,9 @@
 ---
 title: Agent Management
-status: in-progress
+status: completed
 order: 10
 ---
 
-Agent management is now available through the CLI: you can detect running agents, list them, inspect details, focus their terminals, and send input to supported tools such as Claude Code and Codex. Broader orchestration features, richer cross-agent controls, and a more unified management surface are still in progress.
+The original agent-management milestone is complete. AI DevKit can detect and list active agents, inspect live and historical sessions, focus terminals, send messages to agents or groups, start and stop managed agents, rename agents, and run durable Claude print agents. The agent console adds previews, messaging, start/rename/kill controls, pinning, name filtering, a scrollable detail pane, recent memory, and channel controls.
+
+Future work is narrower: expand provider parity where local CLIs expose different capabilities, improve multi-agent orchestration ergonomics, and continue hardening terminal and session detection across platforms.


### PR DESCRIPTION
## Summary

- mark the original agent-management milestone completed
- enumerate shipped CLI and console capabilities
- narrow future work to provider parity, orchestration ergonomics, and platform hardening

## Audit evidence

Closes the verified roadmap finding from `/tmp/docs-audit-report.md`: `web/content/roadmap/10-agent-management.md:2-7` mentioned only detection/list/detail/open/send, while managed start, print mode, sessions, groups, console controls, pinning, filtering, detail focus, memory, and channels ship in `packages/cli/src/commands/agent.ts` and `packages/cli/src/tui/console/`.

## Files changed

- `web/content/roadmap/10-agent-management.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; future scope remains explicit.
