### PR TITLE
docs(web): refine CLI enhancements roadmap

### DIFF
--- a/web/content/roadmap/3-cli-enhancements.md
+++ b/web/content/roadmap/3-cli-enhancements.md
@@ -4,4 +4,6 @@ status: in-progress
 order: 2
 ---
 
-The CLI now includes interactive setup and skill flows, install and lint commands, memory updates, and stronger terminal output patterns. We are still expanding workflow coverage and polishing command ergonomics to reduce friction in day-to-day use.
+Shipped CLI workflows include interactive setup and installation, linting, skill and memory management, date-prefixed feature-document initialization, plugins, Telegram and Slack channels, durable task tracking, and the multi-agent management console.
+
+Remaining work focuses on consistent command ergonomics, clearer diagnostics, stronger non-interactive workflows, and reducing friction across these established surfaces rather than adding another broad command category.


### PR DESCRIPTION
## Summary

- separate shipped CLI surfaces from remaining ergonomic work
- include feature docs, plugins, channels, tasks, and the agent console

## Audit evidence

Closes the verified roadmap finding from `/tmp/docs-audit-report.md`: `web/content/roadmap/3-cli-enhancements.md:2-7` omitted major shipped command families registered under `packages/cli/src/commands/*.ts`, including docs initialization, plugins, channels, task plugins, and agent management/console workflows.

## Files changed

- `web/content/roadmap/3-cli-enhancements.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; no runtime behavior changed.
