### PR TITLE
docs(web): update hooks and memory roadmaps

### DIFF
--- a/web/content/roadmap/6-hooks.md
+++ b/web/content/roadmap/6-hooks.md
@@ -1,7 +1,9 @@
 ---
 title: Hooks
-status: planned
+status: in-progress
 order: 6
 ---
 
-Streamline your workflow by automatically configuring agent-specific hooks, such as those for Claude Code or Cursor. This feature will enable you to define chain reactions, like automatically asking for code review immediately after an implementation step is completed, ensuring quality checks happen without you needing to remember to run them manually.
+Agent-specific hooks are partially shipped. AI DevKit can install Codex session-mapping hooks for more reliable session discovery and Claude hooks that forward channel-related tool activity and questions.
+
+A general hook automation system remains future work. That broader milestone would let teams define portable chain reactions, such as requesting review after implementation, instead of relying only on the integrations AI DevKit configures today.

--- a/web/content/roadmap/7-memory-management.md
+++ b/web/content/roadmap/7-memory-management.md
@@ -4,4 +4,6 @@ status: in-progress
 order: 7
 ---
 
-Memory management is underway. AI DevKit already supports storing, searching, and updating memory entries, and the next step is expanding that into easier browse, merge, and delete workflows so your knowledge base stays clean as projects evolve.
+Memory management is underway. AI DevKit supports storing, searching, and updating entries, while the first-party memory dashboard and the agent console's recent-memory pane provide browse-oriented views.
+
+Dedicated merge and delete workflows, richer curation, and deeper browsing controls remain future work so knowledge bases can stay clean as projects evolve.


### PR DESCRIPTION
## Summary

- mark hooks in progress and distinguish shipped Codex/Claude integrations from the future generic system
- record shipped memory browse views while keeping merge/delete and curation future-facing

## Audit evidence

Closes the two partial-roadmap findings from `/tmp/docs-audit-report.md`. Existing hook integrations are recorded in CHANGELOG commits `0b1cc33`, `e04ae44`, and `172ef94`; the generic chain-reaction system is not shipped. Memory CLI operations are in `packages/cli/src/commands/memory.ts:17-86`, the recent list is `packages/cli/src/tui/console/MemoryListPane.tsx:71-123`, and the dashboard ships under `packages/memory-dashboard/`.

## Files changed

- `web/content/roadmap/6-hooks.md`
- `web/content/roadmap/7-memory-management.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; unshipped capabilities remain explicitly future work.
