### PR TITLE
docs(web): surface durable task tracking

### DIFF
--- a/web/content/docs/10-dev-lifecycle-skill.md
+++ b/web/content/docs/10-dev-lifecycle-skill.md
@@ -56,7 +56,7 @@ npx ai-devkit@latest init
 npx ai-devkit@latest lint
 ```
 
-Then install the built-in skills. This includes `dev-lifecycle`, all phase skills, and supporting skills such as `memory`, `verify`, and `tdd`:
+Then install the built-in skills. This includes `dev-lifecycle`, all phase skills, and supporting skills such as `memory`, `task`, `verify`, and `tdd`:
 
 ```bash
 npx ai-devkit@latest skill add --built-in
@@ -66,6 +66,7 @@ These phase and supporting skills make `dev-lifecycle` effective:
 
 - `dev-worktree`, `dev-requirements`, `dev-design`, `dev-planning`, `dev-implementation`, `dev-testing`, and `dev-review` contain the focused lifecycle guidance
 - `memory` helps the agent reuse project context across sessions
+- `task` tracks durable lifecycle and debugging progress when the optional `@ai-devkit/task-manager` plugin is installed
 - `verify` helps the agent prove work is complete with fresh evidence
 - `tdd` helps the agent write tests before or alongside implementation
 

--- a/web/content/docs/6-memory.md
+++ b/web/content/docs/6-memory.md
@@ -227,5 +227,6 @@ Plugins can also read the configured memory database path through `runtime.getMe
 ## Next Steps
 
 - **[Skills](/docs/7-skills)**: Learn how to create reusable skill templates
+- **[Dev Lifecycle](/docs/10-dev-lifecycle-skill)**: Combine memory with the `task` skill for durable workflow progress
 - **[Plugins](/docs/14-plugins)**: Add optional CLI commands that can use the memory runtime
 - **[Getting Started](/docs/1-getting-started)**: New to AI DevKit? [Start here](/docs/1-getting-started)


### PR DESCRIPTION
## Summary

- add the built-in `task` skill to dev-lifecycle setup/supporting-skill guidance
- cross-link memory users to durable workflow progress guidance

## Audit evidence

Closes the task-visibility finding from `/tmp/docs-audit-report.md`. The durable task system ships in `packages/task-manager/`, the built-in skill is `skills/task/SKILL.md`, and `task` is in the curated list at `packages/cli/src/constants.ts:29`, but the lifecycle and memory pages did not surface it.

## Files changed

- `web/content/docs/10-dev-lifecycle-skill.md`
- `web/content/docs/6-memory.md`

## Validation

- docs-only change
- one-time install/build gate passed before the first commit
- commit hook suite green: lint and tests passed for all 6 projects (136 test files, 1,914 tests)

## Risk

Documentation only; the copy explicitly identifies the optional task-manager plugin dependency.
