### PR TITLE
fix(cli): rename durable agent start mode

### DIFF
--- a/docs/ai/design/2026-08-07-feature-agent-print-mode.md
+++ b/docs/ai/design/2026-08-07-feature-agent-print-mode.md
@@ -260,7 +260,7 @@ sequenceDiagram
     participant C as CLI
     participant P as Capability Probe
     participant S as Print Store
-    U->>C: agent start --type claude --mode print
+    U->>C: agent start --type claude --mode durable
     C->>C: validate name and realpath(cwd)
     C->>P: --version and --help
     P-->>C: required flags present

--- a/docs/ai/implementation/2026-08-18-feature-durable-agents-sqlite.md
+++ b/docs/ai/implementation/2026-08-18-feature-durable-agents-sqlite.md
@@ -27,7 +27,7 @@ description: Implementation record for the durable-agent persistence backend
 - Added `dbPath` and readonly store options. Legacy timing options remain accepted but unused with TypeScript and README deprecations.
 - Implemented acquisition with process inspection outside `BEGIN IMMEDIATE`, transaction reread, and conditional claim. Provider recording and completion require `(id, token)`; recovery/reconciliation also compare the observed owner/run start identity.
 - Kept writable `list()` reconciliation behavior while readonly `list()` performs only a query.
-- Standardized the unreleased domain API on `DurableAgent*`, including files, store options, run/result types, error classes/codes, CLI references, tests, and documentation. Claude-specific print-provider class names and the `--mode print` mechanism remain unchanged.
+- Standardized the unreleased domain API on `DurableAgent*`, including files, store options, run/result types, error classes/codes, CLI references, tests, and documentation. Claude-specific print-provider class names remain unchanged, while the user-facing CLI mode is `--mode durable`.
 
 ## Integration Points
 

--- a/docs/ai/planning/2026-08-07-feature-agent-print-mode.md
+++ b/docs/ai/planning/2026-08-07-feature-agent-print-mode.md
@@ -60,7 +60,7 @@ Every production behavior follows strict red → green → refactor. After each 
 ### Phase 3: CLI integration
 
 - [x] Task 3.1: Add print mode to `agent start` without changing interactive defaults.
-  - Outcome: `--mode interactive|print`, Claude-only validation, correct output, and existing tmux path unchanged.
+  - Outcome: `--mode interactive|durable`, Claude-only validation, correct output, and existing tmux path unchanged.
   - Dependencies: Task 2.3.
   - Validation: command tests for omitted/interactive/print/invalid combinations.
   - Scenarios: CLI start tests.

--- a/docs/ai/requirements/2026-08-07-feature-agent-print-mode.md
+++ b/docs/ai/requirements/2026-08-07-feature-agent-print-mode.md
@@ -14,7 +14,7 @@ The feature must add a Claude-first print mode in which AI DevKit owns a stable 
 
 ### Terminology
 
-- **Logical agent:** the durable AI DevKit identity created by `agent start --mode print`.
+- **Logical agent:** the durable AI DevKit identity created by `agent start --mode durable`.
 - **Provider session:** the Claude conversation identified by the caller-assigned Claude UUID.
 - **Provider process:** one ephemeral `claude -p` child process.
 - **Run:** processing one `agent send` message by one provider process.
@@ -26,7 +26,7 @@ The logical agent exists while no provider process is running. One logical agent
 ### Primary goals
 
 - Preserve the existing `ai-devkit agent start` and `ai-devkit agent send --id` user journey.
-- Add `ai-devkit agent start --type claude --mode print --name NAME --cwd PATH`.
+- Add `ai-devkit agent start --type claude --mode durable --name NAME --cwd PATH`.
 - Keep interactive mode as the default and leave its behavior unchanged.
 - At durable-agent start:
   - validate the name, cwd, Claude executable, installed Claude version, and required print-mode capabilities without invoking a model;
@@ -76,7 +76,7 @@ The logical agent exists while no provider process is running. One logical agent
 As an AI DevKit user, I can run:
 
 ```bash
-ai-devkit agent start --type claude --mode print --name reviewer --cwd /repo
+ai-devkit agent start --type claude --mode durable --name reviewer --cwd /repo
 ```
 
 and receive a stable AI DevKit agent ID. Creation validates local configuration and persists an idle logical agent, but consumes no model tokens and creates no Claude transcript.
@@ -111,8 +111,8 @@ As a user, if the AI DevKit process dies after marking the agent busy, a later o
 
 ### CLI and compatibility
 
-- `agent start` accepts `--mode interactive|print`; omitted mode is `interactive`.
-- `--mode print` is accepted only with `--type claude` and rejects unsupported combinations before persistence.
+- `agent start` accepts `--mode interactive|durable`; omitted mode is `interactive`.
+- `--mode durable` is accepted only with `--type claude` and rejects unsupported combinations before persistence.
 - Existing interactive command tests remain unchanged or are augmented only for additive mode parsing.
 - Existing interactive agents continue to use tmux/process detection and terminal input.
 - `agent send --id` resolves both existing interactive agents and durable durable agents without ambiguous silent preference. Exact stable durable-agent ID wins; duplicate or ambiguous names produce an actionable error.
@@ -129,7 +129,7 @@ As a user, if the AI DevKit process dies after marking the agent busy, a later o
 
 ### Provider execution
 
-- No Claude process is spawned during `agent start --mode print`.
+- No Claude process is spawned during `agent start --mode durable`.
 - The first send passes `-p`, `--session-id`, `--output-format stream-json`, and `--verbose` as discrete argv values.
 - Later sends pass `-p`, `--resume`, the exact stored UUID, `--output-format stream-json`, and `--verbose`.
 - Prompt content is written only to stdin and never appears in provider argv, normal status output, or error messages.

--- a/docs/ai/testing/2026-08-07-feature-agent-print-mode.md
+++ b/docs/ai/testing/2026-08-07-feature-agent-print-mode.md
@@ -74,7 +74,7 @@ description: Offline TDD, security, integration, and compatibility validation
 
 - [ ] Omitted `--mode` routes to existing interactive start unchanged.
 - [ ] `--mode interactive` routes to existing interactive start unchanged.
-- [ ] `--mode print` accepts Claude only and rejects other provider combinations.
+- [ ] `--mode durable` accepts Claude only and rejects other provider combinations.
 - [ ] Print start displays stable identity and does not display PID/tmux attach instructions.
 - [ ] List merges live and durable rows without fake PID/session file values.
 - [x] List table and JSON label live agents as `interactive` and internal print-mode agents as `durable`, without leaking `print` in list presentation.
@@ -100,7 +100,7 @@ description: Offline TDD, security, integration, and compatibility validation
 ## End-to-End Tests
 
 - [ ] Invoke the built CLI with an injected fake `claude` executable, temporary HOME/store, and temporary cwd.
-- [ ] Run `agent start --type claude --mode print`, verify no fake-provider invocation and no transcript fixture.
+- [ ] Run `agent start --type claude --mode durable`, verify no fake-provider invocation and no transcript fixture.
 - [ ] Run first `agent send`, verify captured argv/session ID, stdin prompt, cwd, stream result, and ready state.
 - [ ] Run second `agent send`, verify exact `--resume`, same provider UUID, and updated last result.
 - [ ] Hold one fake run open and verify a second CLI send exits non-zero with a clear busy error.

--- a/packages/agent-manager/README.md
+++ b/packages/agent-manager/README.md
@@ -24,16 +24,16 @@ ai-devkit agent send "run the tests and report back" --id <agent-name> --wait
 npm test 2>&1 | ai-devkit agent send --id <agent-name> --stdin
 ```
 
-Claude Code can also be registered as a durable print-mode agent. Registration
+Claude Code can also be registered as a durable agent. Registration
 does not launch Claude; each send starts one synchronous process and later sends
 resume the same Claude session:
 
 ```bash
-ai-devkit agent start --type claude --mode print --name reviewer --cwd /path/to/project
+ai-devkit agent start --type claude --mode durable --name reviewer --cwd /path/to/project
 ai-devkit agent send "review the current diff" --id reviewer
 ```
 
-Print mode inherits Claude Code's settings, permissions, hooks, MCP servers, and
+Durable mode inherits Claude Code's settings, permissions, hooks, MCP servers, and
 tool side effects for that working directory. AI DevKit adds no permission bypass
 or automatic retry, and prompts are delivered over stdin rather than command-line
 arguments. `--timeout` is not supported for durable agents in this first release.

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -737,12 +737,25 @@ Waiting on user input`,
     const program = new Command();
     registerAgentCommand(program);
     await program.parseAsync([
-      'node', 'test', 'agent', 'start', '--type', 'claude', '--mode', 'print',
+      'node', 'test', 'agent', 'start', '--type', 'claude', '--mode', 'durable',
       '--name', 'reviewer', '--cwd', process.cwd(),
     ]);
 
     expect(mockDurableService.create).toHaveBeenCalledWith({ name: 'reviewer', cwd: process.cwd() });
     expect(ui.success).toHaveBeenCalledWith(expect.stringContaining('11111111-1111-4111-8111-111111111111'));
+  });
+
+  it('rejects the old print mode name for durable agent start', async () => {
+    const program = new Command();
+    registerAgentCommand(program);
+    await program.parseAsync([
+      'node', 'test', 'agent', 'start', '--type', 'claude', '--mode', 'print',
+      '--name', 'reviewer', '--cwd', process.cwd(),
+    ]);
+
+    expect(ui.error).toHaveBeenCalledWith('Failed to start agent: Unsupported agent mode "print". Supported: interactive, durable.');
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(mockDurableService.create).not.toHaveBeenCalled();
   });
 
   it('sends synchronously to an exact durable-agent id without terminal injection', async () => {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -264,7 +264,7 @@ export function registerAgentCommand(program: Command): void {
         .command('start')
         .description('Start a new agent in a managed tmux session')
         .requiredOption('--type <type>', `Agent type: ${Object.keys(AGENTS).join(', ')}`)
-        .option('--mode <mode>', 'Agent mode: interactive or print', 'interactive')
+        .option('--mode <mode>', 'Agent mode: interactive or durable', 'interactive')
         .option('--name <name>', 'Human-readable name for the agent (lowercase alphanumeric + hyphens, 2-64 chars; default: {folder}-{timestamp})')
         .option('--cwd <path>', 'Working directory for the agent (default: current directory)')
         .option('--debug', 'Enable debug logging')
@@ -281,12 +281,12 @@ export function registerAgentCommand(program: Command): void {
                 ui.error(`Unsupported agent type "${agentType}". Supported: ${Object.keys(AGENTS).join(', ')}.`);
                 process.exit(1);
             }
-            if (!['interactive', 'print'].includes(mode)) {
-                throw new Error(`Unsupported agent mode "${mode}". Supported: interactive, print.`);
+            if (!['interactive', 'durable'].includes(mode)) {
+                throw new Error(`Unsupported agent mode "${mode}". Supported: interactive, durable.`);
             }
-            const internalMode = mode === 'print' ? AGENT_MODES.DURABLE : AGENT_MODES.INTERACTIVE;
+            const internalMode = mode === 'durable' ? AGENT_MODES.DURABLE : AGENT_MODES.INTERACTIVE;
             if (internalMode === AGENT_MODES.DURABLE && agentType !== 'claude') {
-                throw new Error('Print mode currently supports only --type claude.');
+                throw new Error('Durable mode currently supports only --type claude.');
             }
             if (!NAME_REGEX.test(agentName)) {
                 ui.error(
@@ -637,7 +637,7 @@ export function registerAgentCommand(program: Command): void {
                     const liveAgents = await manager.listAgents();
                     const liveExact = liveAgents.filter((agent) => agent.name.toLowerCase() === String(options.id).toLowerCase());
                     if (liveExact.length > 0) {
-                        throw new Error(`Agent name "${options.id}" is ambiguous across interactive and print modes. Use the durable agent ID.`);
+                        throw new Error(`Agent name "${options.id}" is ambiguous across interactive and durable modes. Use the durable agent ID.`);
                     }
                 }
                 const result = await durableService.send(options.id, prompt);
@@ -721,7 +721,7 @@ export function registerAgentCommand(program: Command): void {
             if (durableResolved) {
                 const liveExact = agents.filter((agent) => agent.name.toLowerCase() === String(options.id).toLowerCase());
                 if (options.id !== durableResolved.id && liveExact.length > 0) {
-                    throw new Error(`Agent name "${options.id}" is ambiguous across interactive and print modes. Use the durable agent ID.`);
+                    throw new Error(`Agent name "${options.id}" is ambiguous across interactive and durable modes. Use the durable agent ID.`);
                 }
                 if (options.json) {
                     console.log(JSON.stringify(durableResolved, null, 2));
@@ -733,7 +733,7 @@ export function registerAgentCommand(program: Command): void {
                 ui.text(`  ${chalk.bold('Session ID:')}  ${durableResolved.providerSessionId}`);
                 ui.text(`  ${chalk.bold('Name:')}        ${durableResolved.name}`);
                 ui.text(`  ${chalk.bold('Provider:')}    Claude Code`);
-                ui.text(`  ${chalk.bold('Mode:')}        print`);
+                ui.text(`  ${chalk.bold('Mode:')}        durable`);
                 ui.text(`  ${chalk.bold('CWD:')}         ${formatCwd(durableResolved.cwd)}`);
                 ui.text(`  ${chalk.bold('State:')}       ${durableResolved.state}`);
                 ui.text(`  ${chalk.bold('Session:')}     ${durableResolved.sessionHealth}`);

--- a/web/content/docs/8-agent-management.md
+++ b/web/content/docs/8-agent-management.md
@@ -54,13 +54,13 @@ ai-devkit agent start --type claude --name backend --cwd ./packages/backend
 
 `--type` accepts `claude`, `codex`, `copilot`, `gemini_cli`, `grok_cli`, `opencode`, or `pi`. Names default to the current folder plus a timestamp. Use `--cwd <path>` to choose a working directory and `--debug` to show startup diagnostics.
 
-The default `--mode interactive` starts the agent in tmux. Claude also supports a durable print mode that keeps a named agent available without an interactive terminal:
+The default `--mode interactive` starts the agent in tmux. Claude also supports a durable mode that keeps a named agent available without an interactive terminal:
 
 ```bash
-ai-devkit agent start --type claude --mode print --name backend --cwd ./packages/backend
+ai-devkit agent start --type claude --mode durable --name backend --cwd ./packages/backend
 ```
 
-Print mode currently supports only `--type claude`.
+Durable mode currently supports only `--type claude`.
 
 ### List Agents
 


### PR DESCRIPTION
## Summary
- Rename the user-facing durable agent startup mode from `print` to `durable`.
- Update CLI validation/help/detail output and ambiguity errors to use durable terminology.
- Refresh README, web docs, and feature docs examples/criteria to use `--mode durable`.
- Add command coverage for accepting `--mode durable` and rejecting the old `--mode print` value.

## Validation
- `npx vitest run --config vitest.config.ts src/__tests__/commands/agent.test.ts` (75 passed)
- `npm run lint --workspace ai-devkit` (exit 0; existing warnings only)
- `npm run build --workspace ai-devkit` (exit 0)
- Commit hook: repo lint/test passed; 84 test files, 1020 tests passed

## Risks
- Low. This intentionally rejects the old unreleased/incorrect `--mode print` CLI value while keeping Claude print execution internals unchanged.