### PR TITLE
feat(cli): check tmux prerequisite during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Added a read-only tmux prerequisite check to setup and platform-aware installation hints to managed agent startup.
+
 ## [0.58.0] - 2026-09-01
 
 - [6d4fdc1](https://github.com/codeaholicguy/ai-devkit/pull/208) Added opt-in hybrid semantic memory search with embedding storage, maintenance, and CLI configuration.

--- a/docs/ai/design/2026-08-20-feature-tmux-setup-check.md
+++ b/docs/ai/design/2026-08-20-feature-tmux-setup-check.md
@@ -1,0 +1,20 @@
+---
+phase: design
+title: Tmux Setup Prerequisite Design
+description: Pure inspection and shared platform guidance for setup and agent start
+---
+
+# Tmux Setup Prerequisite Design
+
+```mermaid
+flowchart LR
+  Setup[setup command] --> Inspect[inspectTmux]
+  Inspect --> Run[injected tmux -V runner]
+  Setup --> Guide[platform instruction resolver]
+  Start[agent start guard] --> Guide
+  Guide --> OS[injected platform and host readers]
+```
+
+`util/tmux.ts` owns a discriminated inspection result and fixed guidance recipes. Environment access is assembled by `createTmuxInspectionDeps`; tests inject every boundary. Setup checks once after option validation and before its service. Agent start resolves the same guidance only after `TmuxUnavailableError`.
+
+`parseOsRelease` normalizes `ID` and `ID_LIKE` as data. No host-controlled value is interpolated into commands. `ENOENT` means missing; other failures remain distinct. Unknown systems fall back, while Nix, BSD, and native Windows are explicit punts and WSL is labeled as distro-local.

--- a/docs/ai/implementation/2026-08-20-feature-tmux-setup-check.md
+++ b/docs/ai/implementation/2026-08-20-feature-tmux-setup-check.md
@@ -1,0 +1,15 @@
+---
+phase: implementation
+title: Tmux Setup Prerequisite Implementation
+description: Shipped code structure, behavior, and edge cases
+---
+
+# Tmux Setup Prerequisite Implementation
+
+- `packages/cli/src/util/tmux.ts`: injected inspection, os-release parsing, fixed recipes, and read-only defaults.
+- `packages/cli/src/commands/setup.ts`: one prerequisite check and separate output block before agent setup.
+- `packages/cli/src/commands/agent.ts`: shared guidance for `TmuxUnavailableError`.
+- CLI tests: mock-only state, mapping, setup continuation, and runtime-copy coverage.
+- Product docs and changelog: prerequisite, provisional version floor, and shipped behavior.
+
+`ENOENT` maps to missing; other failures produce a non-fatal diagnostic. No package manager runs, no shell is invoked, and parsed host data cannot enter executable arguments. The implementation follows all five approved decisions without flags, prompts, version rejection, init/install changes, or agent-table rows.

--- a/docs/ai/planning/2026-08-20-feature-tmux-setup-check.md
+++ b/docs/ai/planning/2026-08-20-feature-tmux-setup-check.md
@@ -1,0 +1,17 @@
+---
+phase: planning
+title: Tmux Setup Prerequisite Plan
+description: Ordered implementation and validation tasks
+---
+
+# Tmux Setup Prerequisite Plan
+
+- [x] Define mock-only tests for inspection, parsing, platform mapping, and guidance.
+- [x] Implement the injected check-only module.
+- [x] Add setup host-prerequisites output with warning-and-continue behavior.
+- [x] Add the shared hint to the agent-start guard.
+- [x] Update product docs, lifecycle docs, and changelog.
+- [x] Run clean install, build, full tests, lint, typecheck/compile, feature lint, and coverage.
+- [ ] Review, commit, rebase, push, and open the PR.
+
+Tests precede production behavior. Setup and guard integrations depend on the shared resolver. Fixed recipes prevent hostile os-release interpolation; no external service or real package-manager invocation is used.

--- a/docs/ai/requirements/2026-08-20-feature-tmux-setup-check.md
+++ b/docs/ai/requirements/2026-08-20-feature-tmux-setup-check.md
@@ -1,0 +1,25 @@
+---
+phase: requirements
+title: Tmux Setup Prerequisite Requirements
+description: Surface tmux before the first managed interactive agent start
+---
+
+# Tmux Setup Prerequisite Requirements
+
+## Problem and Goals
+
+Users currently discover the tmux dependency only when an interactive managed agent fails to start. Setup should check `tmux -V` once before agent wiring, report the version in a separate host-prerequisites block, warn with platform-aware manual guidance when missing, continue setup, and reuse the guidance at runtime.
+
+## Non-goals
+
+- No package installation, prompt, install flag, version rejection, doctor command, or checks in `init`/`install`.
+- Native Windows and BSD interactive-agent support remain out of scope; WSL receives Linux-distro guidance.
+
+## Acceptance Criteria
+
+- Available, missing, and execution-error states are distinct and tested with mocks.
+- Mainstream Linux families and macOS receive fixed copy-paste commands; unknown and explicitly punted hosts receive honest fallbacks.
+- Missing or broken tmux never changes setup's exit status.
+- The provisional tmux 2.6+ floor appears only in documentation.
+
+All scope decisions were approved in `/tmp/tmux-setup-impl-brief.md`; no open product questions remain.

--- a/docs/ai/testing/2026-08-20-feature-tmux-setup-check.md
+++ b/docs/ai/testing/2026-08-20-feature-tmux-setup-check.md
@@ -1,0 +1,26 @@
+---
+phase: testing
+title: Tmux Setup Prerequisite Testing
+description: Mock-only coverage and workspace validation evidence
+---
+
+# Tmux Setup Prerequisite Testing
+
+- [x] Available version parsing, raw output, missing executable, execution failure, and unparsed output.
+- [x] Quoted/malformed os-release parsing.
+- [x] Debian/Ubuntu, Fedora/RHEL-like, Alpine, Arch/Manjaro, and macOS recipes.
+- [x] WSL labeling, Nix guidance, BSD/native Windows punts, and unknown/missing os-release fallback.
+- [x] Setup success, missing, and error output with warning-and-continue behavior.
+- [x] Interactive start guard includes the shared platform hint.
+
+All tests inject subprocess, filesystem, platform, release, and PATH behavior. They never install software or invoke a real package manager.
+
+## Fresh Validation Evidence
+
+- `npm ci`: exit 0.
+- `npm run build`: exit 0; all six projects built, including TypeScript declaration compilation.
+- `npm test`: exit 0; 85 files and 1,042 tests passed across six projects.
+- `npm run lint`: exit 0; five pre-existing unrelated warnings, zero errors.
+- `npm run test:e2e`: exit 0; 41 tests passed.
+- `npx ai-devkit@latest lint --feature tmux-setup-check`: exit 0.
+- Targeted `tmux.ts` coverage: 100% statements, branches, functions, and lines across 19 mock-only tests.

--- a/packages/cli/src/__tests__/commands/agent.test.ts
+++ b/packages/cli/src/__tests__/commands/agent.test.ts
@@ -57,9 +57,14 @@ const mockSelect: any = vi.fn();
 
 const mockTtyWriterSend = vi.fn<(location: any, message: string) => Promise<void>>().mockResolvedValue(undefined);
 const mockKillAgent = vi.fn<(...args: any[]) => Promise<any>>();
-const { mockEnableDebug, mockDebugLogger } = vi.hoisted(() => ({
+const { mockEnableDebug, mockDebugLogger, mockTmuxIsAvailable, mockTmuxInstructions } = vi.hoisted(() => ({
   mockEnableDebug: vi.fn(),
   mockDebugLogger: vi.fn(),
+  mockTmuxIsAvailable: vi.fn().mockResolvedValue(true),
+  mockTmuxInstructions: vi.fn().mockResolvedValue({
+    command: 'sudo apt-get update && sudo apt-get install tmux',
+    message: 'Install it with: sudo apt-get update && sudo apt-get install tmux.',
+  }),
 }));
 let restoreStdin: (() => void) | undefined;
 
@@ -128,7 +133,7 @@ vi.mock('@ai-devkit/agent-manager', () => ({
     default: vi.fn(function () { return mockRegistry; }),
   },
   TmuxManager: vi.fn(function () { return {
-    isAvailable: vi.fn().mockResolvedValue(true),
+    isAvailable: mockTmuxIsAvailable,
     sessionExists: vi.fn().mockResolvedValue(false),
     createSession: vi.fn().mockResolvedValue(undefined),
     sendKeys: vi.fn().mockResolvedValue(undefined),
@@ -169,6 +174,12 @@ vi.mock('../../util/debug.js', () => ({
   enableDebug: () => mockEnableDebug(),
   createLogger: () => mockDebugLogger,
 }));
+
+vi.mock('../../util/tmux.js', () => ({
+  resolveTmuxInstallInstructions: mockTmuxInstructions,
+}));
+
+vi.mock('../../util/tmux-deps.js', () => ({ createTmuxInspectionDeps: () => ({}) }));
 
 vi.mock('../../services/agent/agent.service.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/agent/agent.service.js')>();
@@ -255,6 +266,11 @@ describe('agent command', () => {
     mockFocusManager.focusTerminal.mockReset();
     mockTtyWriterSend.mockReset().mockResolvedValue(undefined);
     mockKillAgent.mockReset();
+    mockTmuxIsAvailable.mockReset().mockResolvedValue(true);
+    mockTmuxInstructions.mockReset().mockResolvedValue({
+      command: 'sudo apt-get update && sudo apt-get install tmux',
+      message: 'Install it with: sudo apt-get update && sudo apt-get install tmux.',
+    });
     Object.values(mockGroupStore).forEach((method) => method.mockReset());
     mockGroupStore.list.mockReturnValue([]);
     process.exitCode = undefined;
@@ -355,6 +371,19 @@ describe('agent command', () => {
 
     expect(mockEnableDebug).toHaveBeenCalledTimes(1);
     expect(ui.success).toHaveBeenCalledWith('Agent "agent1" started (claude, PID 12345)');
+  });
+
+  it('shows the platform-aware tmux install hint when interactive start is unavailable', async () => {
+    mockTmuxIsAvailable.mockResolvedValue(false);
+    const program = new Command();
+    registerAgentCommand(program);
+
+    await program.parseAsync(['node', 'test', 'agent', 'start', '--type', 'claude', '--name', 'agent1']);
+
+    expect(ui.error).toHaveBeenCalledWith(
+      'tmux is not installed or not in PATH. Install it with: sudo apt-get update && sudo apt-get install tmux.',
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it('shows info when no agents are running', async () => {

--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -2,17 +2,31 @@ import { Command } from 'commander';
 
 const {
   mockSetupService,
+  mockInspectTmux,
+  mockResolveTmuxInstallInstructions,
   mockUi,
 } = vi.hoisted(() => ({
   mockSetupService: {
     run: vi.fn(),
   },
+  mockInspectTmux: vi.fn(),
+  mockResolveTmuxInstallInstructions: vi.fn(),
   mockUi: {
     error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    text: vi.fn(),
     summary: vi.fn(),
     table: vi.fn(),
   },
 }));
+
+vi.mock('../../util/tmux.js', () => ({
+  inspectTmux: mockInspectTmux,
+  resolveTmuxInstallInstructions: mockResolveTmuxInstallInstructions,
+}));
+
+vi.mock('../../util/tmux-deps.js', () => ({ createTmuxInspectionDeps: () => ({}) }));
 
 vi.mock('../../services/setup/setup.service.js', () => ({
   createSetupService: () => mockSetupService,
@@ -45,6 +59,8 @@ describe('setup command', () => {
         },
       ],
     });
+    mockInspectTmux.mockResolvedValue({ state: 'available', version: '3.4', rawVersion: 'tmux 3.4' });
+    mockResolveTmuxInstallInstructions.mockResolvedValue({ command: 'brew install tmux', message: 'Install it with: brew install tmux.' });
   });
 
   afterEach(() => {
@@ -58,6 +74,8 @@ describe('setup command', () => {
     await program.parseAsync(['node', 'test', 'setup']);
 
     expect(mockSetupService.run).toHaveBeenCalledWith({ agents: undefined });
+    expect(mockUi.text).toHaveBeenCalledWith('Host Prerequisites');
+    expect(mockUi.success).toHaveBeenCalledWith('tmux 3.4 available');
     expect(mockUi.summary).toHaveBeenCalledWith({
       title: 'Setup Summary',
       items: [
@@ -73,6 +91,34 @@ describe('setup command', () => {
         ['pi', 'pi-session-tracker', 'skipped', '~/.pi does not exist.'],
       ],
     });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('warns with platform-aware instructions and continues setup when tmux is missing', async () => {
+    mockInspectTmux.mockResolvedValue({ state: 'missing', version: null, rawVersion: null });
+    mockResolveTmuxInstallInstructions.mockResolvedValue({
+      command: 'sudo apt-get update && sudo apt-get install tmux',
+      message: 'Install it with: sudo apt-get update && sudo apt-get install tmux.',
+    });
+    const program = new Command();
+    registerSetupCommand(program);
+
+    await program.parseAsync(['node', 'test', 'setup']);
+
+    expect(mockUi.warning).toHaveBeenCalledWith(expect.stringContaining('sudo apt-get install tmux'));
+    expect(mockSetupService.run).toHaveBeenCalledOnce();
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('warns and continues setup when tmux cannot be executed', async () => {
+    mockInspectTmux.mockResolvedValue({ state: 'error', version: null, rawVersion: 'permission denied' });
+    const program = new Command();
+    registerSetupCommand(program);
+
+    await program.parseAsync(['node', 'test', 'setup']);
+
+    expect(mockUi.warning).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+    expect(mockSetupService.run).toHaveBeenCalledOnce();
     expect(process.exitCode).toBe(0);
   });
 

--- a/packages/cli/src/__tests__/util/tmux.test.ts
+++ b/packages/cli/src/__tests__/util/tmux.test.ts
@@ -1,0 +1,156 @@
+import {
+  inspectTmux,
+  parseOsRelease,
+  resolveTmuxInstallInstructions,
+} from '../../util/tmux.js';
+
+describe('tmux host prerequisite', () => {
+  it('reports an available tmux version while retaining raw output', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: 'tmux 3.4\n' });
+
+    await expect(inspectTmux({
+      run,
+      platform: 'linux',
+      readOsRelease: vi.fn(),
+      releaseText: '',
+      which: vi.fn(),
+    })).resolves.toEqual({ state: 'available', version: '3.4', rawVersion: 'tmux 3.4' });
+    expect(run).toHaveBeenCalledWith('tmux', ['-V']);
+  });
+
+  it('reports a missing executable without throwing', async () => {
+    const error = Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' });
+
+    await expect(inspectTmux({
+      run: vi.fn().mockRejectedValue(error),
+      platform: 'linux',
+      readOsRelease: vi.fn(),
+      releaseText: '',
+      which: vi.fn(),
+    })).resolves.toEqual({ state: 'missing', version: null, rawVersion: null });
+  });
+
+  it('reports execution failures without treating them as missing', async () => {
+    await expect(inspectTmux({
+      run: vi.fn().mockRejectedValue(new Error('permission denied')),
+      platform: 'linux',
+      readOsRelease: vi.fn(),
+      releaseText: '',
+      which: vi.fn(),
+    })).resolves.toEqual({ state: 'error', version: null, rawVersion: 'permission denied' });
+  });
+
+  it('safely stringifies non-Error execution failures', async () => {
+    await expect(inspectTmux({
+      run: vi.fn().mockRejectedValue('failed'),
+      platform: 'linux', readOsRelease: vi.fn(), releaseText: '', which: vi.fn(),
+    })).resolves.toEqual({ state: 'error', version: null, rawVersion: 'failed' });
+  });
+
+  it('retains unparsed version output', async () => {
+    await expect(inspectTmux({
+      run: vi.fn().mockResolvedValue({ stdout: 'unexpected output' }),
+      platform: 'linux',
+      readOsRelease: vi.fn(),
+      releaseText: '',
+      which: vi.fn(),
+    })).resolves.toEqual({ state: 'available', version: null, rawVersion: 'unexpected output' });
+  });
+
+  it('parses quoted os-release values and ignores malformed lines', () => {
+    expect(parseOsRelease('ID="ubuntu"\nID_LIKE="debian linux"\nBROKEN\n')).toEqual({
+      id: 'ubuntu',
+      idLike: ['debian', 'linux'],
+    });
+  });
+
+  it('parses single-quoted and empty os-release values', () => {
+    expect(parseOsRelease("ID='ALPINE'\n")).toEqual({ id: 'alpine', idLike: [] });
+    expect(parseOsRelease('')).toEqual({ id: '', idLike: [] });
+  });
+
+  it.each([
+    ['linux', 'ID=ubuntu', '', 'sudo apt-get update && sudo apt-get install tmux'],
+    ['linux', 'ID=debian', '', 'sudo apt-get update && sudo apt-get install tmux'],
+    ['linux', 'ID=fedora', '', 'sudo dnf install tmux'],
+    ['linux', 'ID=rocky\nID_LIKE="rhel fedora"', '', 'sudo dnf install tmux'],
+    ['linux', 'ID=alpine', '', 'sudo apk add tmux'],
+    ['linux', 'ID=arch', '', 'sudo pacman -S tmux'],
+    ['linux', 'ID=manjaro\nID_LIKE=arch', '', 'sudo pacman -S tmux'],
+    ['darwin', '', '', 'brew install tmux'],
+  ])('maps %s %s to a copy-paste command', async (platform, osRelease, releaseText, command) => {
+    const instructions = await resolveTmuxInstallInstructions({
+      platform: platform as NodeJS.Platform,
+      readOsRelease: vi.fn().mockResolvedValue(osRelease),
+      releaseText,
+      which: vi.fn().mockResolvedValue(true),
+    });
+
+    expect(instructions.command).toBe(command);
+    expect(instructions.message).toContain(command);
+  });
+
+  it('labels WSL commands as running inside the Linux distribution', async () => {
+    const instructions = await resolveTmuxInstallInstructions({
+      platform: 'linux',
+      readOsRelease: vi.fn().mockResolvedValue('ID=ubuntu'),
+      releaseText: '5.15.0-microsoft-standard-WSL2',
+      which: vi.fn(),
+    });
+
+    expect(instructions.message).toContain('inside your WSL distribution');
+  });
+
+  it('provides explicit guidance for NixOS, native Windows, BSD, and unknown Linux', async () => {
+    const cases = [
+      ['linux', 'ID=nixos', 'nix shell nixpkgs#tmux'],
+      ['win32', '', 'WSL'],
+      ['freebsd', '', 'not currently supported'],
+      ['linux', 'ID=unknown', 'system package manager'],
+    ] as const;
+
+    for (const [platform, osRelease, expected] of cases) {
+      const instructions = await resolveTmuxInstallInstructions({
+        platform,
+        readOsRelease: vi.fn().mockResolvedValue(osRelease),
+        releaseText: '',
+        which: vi.fn().mockResolvedValue(false),
+      });
+      expect(instructions.message).toContain(expected);
+    }
+  });
+
+  it('covers unsupported Unix, OpenBSD, missing Homebrew, and WSL fallback guidance', async () => {
+    const unsupported = await resolveTmuxInstallInstructions({
+      platform: 'aix', readOsRelease: vi.fn(), releaseText: '', which: vi.fn(),
+    });
+    expect(unsupported.message).toContain('system package manager');
+
+    const openbsd = await resolveTmuxInstallInstructions({
+      platform: 'openbsd', readOsRelease: vi.fn(), releaseText: '', which: vi.fn(),
+    });
+    expect(openbsd.message).toContain('not currently supported');
+
+    const macos = await resolveTmuxInstallInstructions({
+      platform: 'darwin', readOsRelease: vi.fn(), releaseText: '', which: vi.fn().mockRejectedValue(new Error('no PATH')),
+    });
+    expect(macos.message).toContain('Install Homebrew first');
+
+    const wsl = await resolveTmuxInstallInstructions({
+      platform: 'linux', readOsRelease: vi.fn().mockResolvedValue('ID=unknown'), releaseText: 'WSL2', which: vi.fn(),
+    });
+    expect(wsl.message).toContain('inside your WSL distribution');
+  });
+
+  it('falls back gracefully when os-release cannot be read', async () => {
+    const instructions = await resolveTmuxInstallInstructions({
+      platform: 'linux',
+      readOsRelease: vi.fn().mockRejectedValue(new Error('missing')),
+      releaseText: '',
+      which: vi.fn(),
+    });
+
+    expect(instructions.command).toBeNull();
+    expect(instructions.message).toContain('system package manager');
+  });
+});

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -61,6 +61,8 @@ import { registerAgentGroupCommand } from './agent/group.command.js';
 import { AGENT_CONSOLE_RENDER_OPTIONS, ConsoleApp } from '../tui/console/ConsoleApp.js';
 import { generateAgentName } from '../util/agent.js';
 import { select } from '@inquirer/prompts';
+import { resolveTmuxInstallInstructions } from '../util/tmux.js';
+import { createTmuxInspectionDeps } from '../util/tmux-deps.js';
 
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_PATTERN = /\x1b\[[0-9;]*m/g;
@@ -332,7 +334,8 @@ export function registerAgentCommand(program: Command): void {
                 ui.text(`Attach: tmux attach -t ${entry.tmuxSession}`);
             } catch (err) {
                 if (err instanceof TmuxUnavailableError) {
-                    ui.error('tmux is not installed or not in PATH. Install it first (e.g., brew install tmux).');
+                    const instructions = await resolveTmuxInstallInstructions(createTmuxInspectionDeps());
+                    ui.error(`tmux is not installed or not in PATH. ${instructions.message}`);
                 } else if (err instanceof AgentNameInUseError) {
                     ui.error(`Agent "${err.agentName}" is already running (PID ${err.pid}). Choose a different name.`);
                 } else if (err instanceof AgentPidPollTimeoutError) {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -6,6 +6,8 @@ import {
   type SetupStepStatus,
 } from '../services/setup/setup.service.js';
 import { ui } from '../util/terminal-ui.js';
+import { inspectTmux, resolveTmuxInstallInstructions } from '../util/tmux.js';
+import { createTmuxInspectionDeps } from '../util/tmux-deps.js';
 
 interface SetupCommandOptions {
   agent?: string;
@@ -25,6 +27,18 @@ export async function setupCommand(options: SetupCommandOptions = {}): Promise<v
   if (agents === null) {
     process.exitCode = 1;
     return;
+  }
+
+  const tmuxDeps = createTmuxInspectionDeps();
+  const tmux = await inspectTmux(tmuxDeps);
+  ui.text('Host Prerequisites');
+  if (tmux.state === 'available') {
+    ui.success(tmux.version ? `tmux ${tmux.version} available` : `${tmux.rawVersion} available`);
+  } else if (tmux.state === 'missing') {
+    const instructions = await resolveTmuxInstallInstructions(tmuxDeps);
+    ui.warning(`tmux is required for interactive managed agents. ${instructions.message} Setup will continue.`);
+  } else {
+    ui.warning(`Could not run tmux -V (${tmux.rawVersion}). Setup will continue.`);
   }
 
   const report = await createSetupService().run({ agents });

--- a/packages/cli/src/util/tmux-deps.ts
+++ b/packages/cli/src/util/tmux-deps.ts
@@ -1,0 +1,29 @@
+import { execFile } from 'child_process';
+import { access, readFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import type { InspectTmuxDeps } from './tmux.js';
+
+const execFileAsync = promisify(execFile);
+
+export function createTmuxInspectionDeps(): InspectTmuxDeps {
+  return {
+    run: (command, args) => execFileAsync(command, [...args]),
+    platform: os.platform(),
+    readOsRelease: () => readFile('/etc/os-release', 'utf8'),
+    releaseText: os.release(),
+    which: async command => {
+      const directories = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+      for (const directory of directories) {
+        try {
+          await access(path.join(directory, command));
+          return true;
+        } catch {
+          // Continue searching PATH.
+        }
+      }
+      return false;
+    },
+  };
+}

--- a/packages/cli/src/util/tmux.ts
+++ b/packages/cli/src/util/tmux.ts
@@ -1,0 +1,131 @@
+export type TmuxInspection =
+  | { state: 'available'; version: string | null; rawVersion: string }
+  | { state: 'missing'; version: null; rawVersion: null }
+  | { state: 'error'; version: null; rawVersion: string };
+
+type Run = (command: string, args: readonly string[]) => Promise<{ stdout: string | Buffer }>;
+type Which = (command: string) => Promise<boolean>;
+
+export interface TmuxPlatformDeps {
+  platform: NodeJS.Platform;
+  readOsRelease: () => Promise<string>;
+  releaseText: string;
+  which: Which;
+}
+
+export interface InspectTmuxDeps extends TmuxPlatformDeps {
+  run: Run;
+}
+
+export interface TmuxInstallInstructions {
+  command: string | null;
+  message: string;
+}
+
+export async function inspectTmux(deps: InspectTmuxDeps): Promise<TmuxInspection> {
+  try {
+    const { stdout } = await deps.run('tmux', ['-V']);
+    const rawVersion = stdout.toString().trim();
+    const version = /^tmux\s+([^\s]+)/i.exec(rawVersion)?.[1] ?? null;
+    return { state: 'available', version, rawVersion };
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return { state: 'missing', version: null, rawVersion: null };
+    }
+    return {
+      state: 'error',
+      version: null,
+      rawVersion: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function parseOsRelease(value: string): { id: string; idLike: string[] } {
+  const fields = new Map<string, string>();
+  for (const line of value.split(/\r?\n/)) {
+    const match = /^([A-Z_]+)=(.*)$/.exec(line);
+    if (!match) continue;
+    fields.set(match[1], match[2].trim().replace(/^(?:"(.*)"|'(.*)')$/, '$1$2'));
+  }
+  return {
+    id: (fields.get('ID') ?? '').toLowerCase(),
+    idLike: (fields.get('ID_LIKE') ?? '').toLowerCase().split(/\s+/).filter(Boolean),
+  };
+}
+
+export async function resolveTmuxInstallInstructions(
+  deps: TmuxPlatformDeps,
+): Promise<TmuxInstallInstructions> {
+  if (deps.platform === 'win32') {
+    return {
+      command: null,
+      message: 'Native Windows managed interactive sessions are unsupported. Use a supported WSL distribution and install tmux inside it.',
+    };
+  }
+  if (deps.platform === 'freebsd' || deps.platform === 'openbsd') {
+    return {
+      command: null,
+      message: 'BSD managed interactive sessions are not currently supported; consult your system tmux documentation.',
+    };
+  }
+  if (deps.platform === 'darwin') {
+    const hasBrew = await deps.which('brew').catch(() => false);
+    const command = 'brew install tmux';
+    return {
+      command,
+      message: hasBrew
+        ? `Install it with: ${command}.`
+        : `Install Homebrew first, then run: ${command}.`,
+    };
+  }
+  if (deps.platform !== 'linux') {
+    return genericInstructions();
+  }
+
+  let release = { id: '', idLike: [] as string[] };
+  try {
+    release = parseOsRelease(await deps.readOsRelease());
+  } catch {
+    return genericInstructions();
+  }
+  const distroKeys = [release.id, ...release.idLike];
+  const isWsl = /microsoft|wsl/i.test(deps.releaseText);
+  const wslSuffix = isWsl ? ' inside your WSL distribution' : '';
+
+  if (distroKeys.includes('nixos')) {
+    return {
+      command: 'nix shell nixpkgs#tmux',
+      message: 'Nix environments are user-managed; use a declarative configuration or run: nix shell nixpkgs#tmux.',
+    };
+  }
+
+  const command = resolveLinuxCommand(distroKeys);
+  if (!command) return genericInstructions(isWsl);
+  return {
+    command,
+    message: `Install it${wslSuffix} with: ${command}. If you are root, omit sudo; otherwise ask your administrator if needed.`,
+  };
+}
+
+function resolveLinuxCommand(keys: string[]): string | null {
+  if (keys.some(key => ['ubuntu', 'debian'].includes(key))) {
+    return 'sudo apt-get update && sudo apt-get install tmux';
+  }
+  if (keys.some(key => ['fedora', 'rhel', 'centos', 'rocky', 'almalinux'].includes(key))) {
+    return 'sudo dnf install tmux';
+  }
+  if (keys.includes('alpine')) return 'sudo apk add tmux';
+  if (keys.some(key => ['arch', 'manjaro'].includes(key))) return 'sudo pacman -S tmux';
+  return null;
+}
+
+function genericInstructions(isWsl = false): TmuxInstallInstructions {
+  return {
+    command: null,
+    message: `Install tmux${isWsl ? ' inside your WSL distribution' : ''} with your system package manager. If you do not have admin access, ask your administrator.`,
+  };
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/web/content/docs/1-getting-started.md
+++ b/web/content/docs/1-getting-started.md
@@ -19,6 +19,11 @@ Before you begin, make sure you have:
 
 - **Node.js 20.20.0 or newer**
 - **npm** or **npx**, which comes with Node.js
+- **tmux** for interactive managed agents (provisional compatibility floor: tmux 2.6+; setup reports but does not reject older versions)
+- At least one [supported AI coding agent or environment](/docs/2-supported-agents)
+
+- **Node.js 20.20.0 or newer**
+- **npm** or **npx**, which comes with Node.js
 - At least one [supported AI coding agent or environment](/docs/2-supported-agents)
 
 Install and launch your coding agent at least once before running `setup`. AI DevKit detects an agent from its home directory, so a newly installed agent that has never started may be reported as skipped.

--- a/web/content/docs/8-agent-management.md
+++ b/web/content/docs/8-agent-management.md
@@ -56,6 +56,8 @@ ai-devkit agent start --type claude --name backend --cwd ./packages/backend
 
 The default `--mode interactive` starts the agent in tmux. Claude also supports a durable mode that keeps a named agent available without an interactive terminal:
 
+Run `ai-devkit setup` to check the host prerequisite early. It reports the installed tmux version or prints a platform-aware install command without installing packages or failing setup. tmux 2.6+ is the provisional documented compatibility floor; older versions are reported, not rejected.
+
 ```bash
 ai-devkit agent start --type claude --mode durable --name backend --cwd ./packages/backend
 ```


### PR DESCRIPTION
## Motivation

Interactive managed agents require tmux, but users previously discovered that prerequisite only when agent start failed. This surfaces the dependency during setup while retaining an actionable runtime guard.

## Design summary

- Add an injected, read-only `inspectTmux` check and pure platform instruction resolver.
- Render a separate Host Prerequisites block before agent setup.
- Reuse platform-aware guidance when interactive agent start encounters missing tmux.
- Cover inspection, distro mapping, setup output, and runtime messaging with mock-only tests.
- Document the prerequisite and provisional tmux 2.6+ floor; update the changelog and lifecycle docs.

## Approved decisions

1. Missing tmux warns and setup continues.
2. No install flag or host mutation.
3. Versions are reported but never rejected.
4. Host prerequisites render separately from the per-agent table.
5. Only setup and the runtime guard change; init/install/doctor remain untouched.

## Validation

- `npm ci`
- `npm run build` (all 6 projects; includes TypeScript declaration compilation)
- `npm test` (85 files, 1,042 tests)
- `npm run lint` (0 errors; 5 pre-existing unrelated warnings)
- `npm run test:e2e` (41 tests)
- `npx ai-devkit@latest lint --feature tmux-setup-check`
- targeted tmux pure-module coverage: 100% statements, branches, functions, and lines

## Risks

No known host-mutation risk: the feature only executes `tmux -V` and prints fixed guidance. Unknown platforms fall back without guessing.