### PR TITLE
fix(agent-manager): Codex session detection and summaries

### DIFF
--- a/packages/agent-manager/src/__tests__/adapters/CodexAdapter.test.ts
+++ b/packages/agent-manager/src/__tests__/adapters/CodexAdapter.test.ts
@@ -750,6 +750,45 @@ describe('CodexAdapter', () => {
             expect(mockedBatchGetSessionFileBirthtimes).not.toHaveBeenCalled();
         });
 
+        it('uses the hook session mapping instead of a stale registry entry for the same live pid', async () => {
+            registerEntry();
+            const sessionsDir = path.join(tmpDir, '.codex', 'sessions');
+            const dateDir = path.join(sessionsDir, '2026', '06', '26');
+            const mappingPath = path.join(tmpDir, '.codex', 'ai-devkit', 'sessions.json');
+            const currentSessionFile = path.join(dateDir, 'sess-current.jsonl');
+            const recentTs = new Date().toISOString();
+
+            fs.mkdirSync(dateDir, { recursive: true });
+            fs.mkdirSync(path.dirname(mappingPath), { recursive: true });
+            fs.writeFileSync(currentSessionFile, [
+                JSON.stringify({ type: 'session_meta', payload: { id: 'sess-current', timestamp: recentTs, cwd: '/repo-current' } }),
+                JSON.stringify({ type: 'event', timestamp: recentTs, payload: { type: 'token_count', message: 'Hello from current mapping' } }),
+            ].join('\n'));
+            fs.writeFileSync(mappingPath, JSON.stringify({ 100: currentSessionFile }));
+
+            (cachedAdapter as any).codexSessionsDir = sessionsDir;
+            (cachedAdapter as any).sessionMappingPath = mappingPath;
+
+            const processes: ProcessInfo[] = [
+                { pid: 100, command: 'codex', cwd: '/repo-current', tty: 'ttys001', startTime: new Date() },
+            ];
+            mockedListAgentProcesses.mockReturnValue(processes);
+            mockedEnrichProcesses.mockReturnValue(processes);
+
+            const agents = await cachedAdapter.detectAgents();
+
+            expect(agents).toHaveLength(1);
+            expect(agents[0]).toMatchObject({
+                type: 'codex',
+                pid: 100,
+                sessionId: 'sess-current',
+                sessionFilePath: currentSessionFile,
+                summary: 'Hello from current mapping',
+            });
+            expect(mockedMatchProcessesToSessions).not.toHaveBeenCalled();
+            expect(mockedBatchGetSessionFileBirthtimes).not.toHaveBeenCalled();
+        });
+
         it('falls through when no registry entry exists for the pid', async () => {
             const processes: ProcessInfo[] = [
                 { pid: 100, command: 'codex', cwd: '/repo-a', tty: 'ttys001', startTime: new Date() },
@@ -1564,6 +1603,99 @@ describe('CodexAdapter', () => {
 
             expect(result).toHaveLength(1);
             expect(result[0].firstUserMessage).toBe('first user');
+        });
+
+        it('captures the first current Codex response_item user message as firstUserMessage', async () => {
+            const day = path.join(sessionsDir, '2025', '01', '01');
+            writeCodexSession(day, 'response-item-user', [
+                { type: 'session_meta', payload: { id: 'response-item-user', cwd: '/repo', timestamp: '2025-01-01T00:00:00Z' } },
+                {
+                    type: 'response_item',
+                    timestamp: '2025-01-01T00:00:00.500Z',
+                    payload: {
+                        type: 'message',
+                        role: 'user',
+                        content: [{ type: 'input_text', text: '<environment_context>\n  <cwd>/repo</cwd>\n</environment_context>' }],
+                    },
+                },
+                {
+                    type: 'response_item',
+                    timestamp: '2025-01-01T00:00:01Z',
+                    payload: {
+                        type: 'message',
+                        role: 'assistant',
+                        content: [{ type: 'output_text', text: 'preamble' }],
+                    },
+                },
+                {
+                    type: 'response_item',
+                    timestamp: '2025-01-01T00:00:02Z',
+                    payload: {
+                        type: 'message',
+                        role: 'user',
+                        content: [{ type: 'input_text', text: 'first current user' }],
+                    },
+                },
+                {
+                    type: 'response_item',
+                    timestamp: '2025-01-01T00:00:03Z',
+                    payload: {
+                        type: 'message',
+                        role: 'user',
+                        content: [{ type: 'input_text', text: 'second current user' }],
+                    },
+                },
+            ]);
+
+            const result = await adapter.listSessions({ cwd: '/repo' });
+
+            expect(result).toHaveLength(1);
+            expect(result[0].firstUserMessage).toBe('first current user');
+        });
+
+        it('captures the first current Codex event_msg user message as firstUserMessage', async () => {
+            const day = path.join(sessionsDir, '2025', '01', '01');
+            writeCodexSession(day, 'event-msg-user', [
+                { type: 'session_meta', payload: { id: 'event-msg-user', cwd: '/repo', timestamp: '2025-01-01T00:00:00Z' } },
+                {
+                    type: 'event_msg',
+                    timestamp: '2025-01-01T00:00:01Z',
+                    payload: {
+                        type: 'item_completed',
+                        item: {
+                            type: 'AgentMessage',
+                            content: [{ type: 'Text', text: 'preamble' }],
+                        },
+                    },
+                },
+                {
+                    type: 'event_msg',
+                    timestamp: '2025-01-01T00:00:02Z',
+                    payload: {
+                        type: 'item_completed',
+                        item: {
+                            type: 'UserMessage',
+                            content: [{ type: 'text', text: 'first event user' }],
+                        },
+                    },
+                },
+                {
+                    type: 'event_msg',
+                    timestamp: '2025-01-01T00:00:03Z',
+                    payload: {
+                        type: 'item_completed',
+                        item: {
+                            type: 'UserMessage',
+                            content: [{ type: 'text', text: 'second event user' }],
+                        },
+                    },
+                },
+            ]);
+
+            const result = await adapter.listSessions({ cwd: '/repo' });
+
+            expect(result).toHaveLength(1);
+            expect(result[0].firstUserMessage).toBe('first event user');
         });
 
         it('returns empty firstUserMessage when no user_message exists', async () => {

--- a/packages/agent-manager/src/adapters/CodexAdapter.ts
+++ b/packages/agent-manager/src/adapters/CodexAdapter.ts
@@ -119,11 +119,11 @@ export class CodexAdapter implements AgentAdapter {
         const processes = relevant.filter((process) => this.canHandle(process));
         if (processes.length === 0) return [];
 
-        const { cachedAgents, remaining } = this.tryRegistryCache(processes);
-        if (remaining.length === 0) return cachedAgents;
+        const mappingResult = this.mapSessionMappingMatches(processes);
+        const { cachedAgents, remaining } = this.tryRegistryCache(mappingResult.fallback);
+        if (remaining.length === 0) return [...mappingResult.agents, ...cachedAgents];
 
-        const mappingResult = this.mapSessionMappingMatches(remaining);
-        const { direct, fallback } = this.tryResumeMatching(mappingResult.fallback);
+        const { direct, fallback } = this.tryResumeMatching(remaining);
         const directResult = this.mapDirectMatches(direct);
         const { sessions, contentCache } = this.discoverSessions(fallback);
         if (sessions.length === 0) {
@@ -887,13 +887,12 @@ export class CodexAdapter implements AgentAdapter {
             const ts = this.parseTimestamp(entry.timestamp);
             if (ts) lastTimestamp = ts;
 
-            if (
-                !firstUserMessage &&
-                entry.payload?.type === 'user_message' &&
-                typeof entry.payload.message === 'string' &&
-                entry.payload.message.trim().length > 0
-            ) {
-                firstUserMessage = entry.payload.message.trim();
+            if (!firstUserMessage) {
+                const message = this.toConversationMessage(entry, false);
+                const content = message?.content.trim() ?? '';
+                if (message?.role === 'user' && content.length > 0 && !this.isSyntheticUserMessage(content)) {
+                    firstUserMessage = content;
+                }
             }
         }
 
@@ -916,5 +915,9 @@ export class CodexAdapter implements AgentAdapter {
             startedAt,
             sessionFilePath: filePath,
         };
+    }
+
+    private isSyntheticUserMessage(content: string): boolean {
+        return content.startsWith('<environment_context>') && content.includes('</environment_context>');
     }
 }


### PR DESCRIPTION
## Summary
- prefer Codex PID session mappings before registry cache so resumed/live agents show the current session detail
- extract Codex historical first messages from current response_item/event_msg formats
- skip synthetic environment_context records when choosing session list summaries

## Validation
- npm --workspace @ai-devkit/agent-manager test -- src/__tests__/adapters/CodexAdapter.test.ts
- npm --workspace @ai-devkit/agent-manager run typecheck
- npm --workspace @ai-devkit/agent-manager run lint
- npm --workspace @ai-devkit/agent-manager run build
- node packages/cli/dist/cli.js agent detail --id daily-assistant --json --tail 1
- node packages/cli/dist/cli.js agent sessions --all --type codex --json --limit 3
- commit hook: repo-wide lint and tests passed (1019 tests)

## Risks
- Low; changes are scoped to Codex adapter detection ordering and summary extraction.