### PR TITLE
feat(cli): show working animation in preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Added a scroll-safe `working` animation to the running agent's console preview, with a `TERM=dumb` ASCII fallback.
+
 ## [0.52.0] - 2026-08-18
 
 - [4690e3e](https://github.com/codeaholicguy/ai-devkit/pull/172) Simplified obsolete test cleanup guidance in the simplify-implementation skill.

--- a/docs/ai/design/2026-08-20-feature-preview-typing-indicator.md
+++ b/docs/ai/design/2026-08-20-feature-preview-typing-indicator.md
@@ -1,0 +1,59 @@
+---
+phase: design
+title: System Design & Architecture
+description: Define the technical architecture, components, and data models
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    PreviewSection -->|selected AgentInfo + messages| PreviewPane
+    PreviewPane -->|RUNNING only| PreviewActivityIndicator
+    PreviewPane -->|activity-adjusted maxLines| ConversationViewport
+    PreviewActivityIndicator -->|local 160 ms timer| FrameGlyph
+```
+
+`PreviewPane` derives activity from the selected `AgentInfo`, subtracts one line from the conversation budget while active, and mounts a bottom-row leaf after the flex-growing body. `PreviewActivityIndicator` alone owns frame state and its interval. Existing React/Ink primitives and console color tokens are reused.
+
+## Data Models
+**What data do we need to manage?**
+
+- Activity is derived from `agent.status === AgentStatus.RUNNING`; no persistent model changes are required.
+- Braille frames: `⠋⠙⠹⠸⠼⠴⠦⠧`. ASCII frames: `|/-\\`. Both are immutable fixed-width arrays.
+- Pure helpers select the frame set from terminal capability and map an index modulo the selected frame count.
+
+## API Design
+**How do components communicate?**
+
+- No external API, authentication, schema, or protocol changes.
+- The leaf accepts `active` and owns presentation/timing. Terminal fallback is selected from `process.env.TERM === 'dumb'` through pure frame logic.
+- `PreviewPaneProps` remains the public integration boundary; the selected agent already supplies status.
+
+## Component Breakdown
+**What are the major building blocks?**
+
+- `PreviewActivityIndicator`: memoized leaf, local frame index, deterministic reset on activation, interval creation/cleanup, fixed-width glyph plus dim `working` label.
+- `PreviewPane`: computes `active`, reserves one viewport line only while active, and mounts the leaf below conversation content.
+- Pure frame helpers: independently cover fallback selection and modular frame lookup.
+- Tests: focused leaf timer tests plus `PreviewPane` integration/regression tests using Vitest fake timers and Ink render utilities.
+
+## Design Decisions
+**Why did we choose this approach?**
+
+- Option C was selected over static text, animated dots, and shimmer for clarity and terminal-native fit.
+- The inactive row is reclaimed, accepting a one-line geometry change on status transition.
+- Cadence is 160 ms. Reduced-motion behavior is deferred.
+- Unicode is default; `TERM=dumb` is the only automatic ASCII fallback. An explicit capability setting is deferred.
+- Activity continues during input-paused polling and represents last observed status.
+- The activity row stays outside `buildPreviewRows`, row-count compensation, and viewport scroll state.
+
+## Non-Functional Requirements
+**How should the system perform?**
+
+- Frame updates are limited to the leaf subtree; parent render counts and Markdown layout calls remain stable across ticks.
+- At most one interval exists per mounted active preview and is cleared on deactivation or unmount.
+- Frame ticks never invoke scroll clamping or alter conversation row identity.
+- No new security surface or sensitive data handling is introduced.

--- a/docs/ai/implementation/2026-08-20-feature-preview-typing-indicator.md
+++ b/docs/ai/implementation/2026-08-20-feature-preview-typing-indicator.md
@@ -1,0 +1,55 @@
+---
+phase: implementation
+title: Implementation Guide
+description: Technical implementation notes, patterns, and code guidelines
+---
+
+# Implementation Guide
+
+## Development Setup
+
+- Work in `feature-preview-typing-indicator` and use the repository Node/npm toolchain.
+- No new dependencies or configuration are required.
+- Run `npm ci` and `npm run build` before full workspace gates.
+
+## Code Structure
+**How is the code organized?**
+
+- `packages/cli/src/tui/console/PreviewActivityIndicator.tsx`: isolated activity leaf and pure frame selection.
+- `packages/cli/src/tui/console/PreviewPane.tsx`: RUNNING mapping, adjusted body budget, and leaf mount.
+- `packages/cli/src/__tests__/tui/console/PreviewActivityIndicator.test.tsx`: pure logic and timer lifecycle.
+- `packages/cli/src/__tests__/tui/console/PreviewPane.test.ts`: status, geometry, scroll, and render-scope integration.
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Core Features
+- Frame selection uses immutable braille and ASCII arrays with modular indexing; `TERM=dumb` selects ASCII.
+- The memoized leaf owns frame index and a 160 ms interval, resets on activation, and clears the interval on deactivation/unmount.
+- `PreviewPane` subtracts exactly one line from the conversation viewport while the selected agent is `RUNNING`, then renders the activity leaf after the body.
+
+### Patterns & Best Practices
+- Timer state remains below the memoized preview boundary, so ticks cannot rerender the parent or recompute Markdown rows.
+- Activity chrome never enters `buildPreviewRows`, row-count compensation, or scroll offset calculations.
+- TDD red-green-refactor cycles and existing Ink `PassThrough` render utilities were used.
+
+## Integration Points
+**How do pieces connect?**
+
+- Existing `AgentInfo.status` is the sole integration input. There are no API, database, or third-party changes.
+
+## Error Handling
+**How do we handle failures?**
+
+- Inactive or absent agents render no activity row. `TERM=dumb` is handled as a deterministic display fallback; no errors or logging are introduced.
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- A local leaf interval limits 6.25 Hz updates to one glyph row.
+- The parent preview's existing message memoization remains intact; tests assert stable parent-render, Markdown-layout, and scroll-clamp counts across ticks.
+
+## Security Notes
+**What security measures are in place?**
+
+- No security boundary or sensitive data changes.

--- a/docs/ai/planning/2026-08-20-feature-preview-typing-indicator.md
+++ b/docs/ai/planning/2026-08-20-feature-preview-typing-indicator.md
@@ -1,0 +1,58 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+
+- [x] Milestone 1: Lifecycle documents capture the approved behavior and test plan.
+- [x] Milestone 2: TDD delivers frame logic, isolated animation, and scroll-safe preview integration.
+- [ ] Milestone 3: Docs, coverage, workspace gates, review, commits, and PR are complete. (Only publication remains.)
+
+## Task Breakdown
+**What specific work needs to be done?**
+
+### Phase 1: Foundation
+- [x] Task 1.1: Add failing pure-logic tests for Unicode/ASCII frame selection and cycling; validate with focused Vitest runs.
+- [x] Task 1.2: Add failing Ink tests for 160 ms cycling and cleanup; validate timer lifecycle with fake timers.
+
+### Phase 2: Core Features
+- [x] Task 2.1: Implement the isolated leaf and minimum frame logic required by the failing tests.
+- [x] Task 2.2: Add failing preview integration tests for RUNNING-only visibility and reclaimed height, then wire the leaf into `PreviewPane`.
+- [x] Task 2.3: Add regressions for parent render isolation, Markdown layout stability, scroll clamping, and timer cleanup across status changes.
+
+### Phase 3: Integration & Polish
+- [x] Task 3.1: Update agent-console documentation, changelog, implementation notes, and test evidence.
+- [x] Task 3.2: Run `npm ci`, `npm run build`, coverage, full workspace tests, lint, typecheck, lifecycle lint, and final review preparation.
+- [ ] Task 3.3: Create scoped conventional commits, rebase on `origin/main`, push, and open the requested PR.
+
+## Dependencies
+**What needs to happen in what order?**
+
+- Tests precede production code. Integration follows pure frame and leaf behavior.
+- No new external dependencies or coordination are required.
+- Optional task tracing is unavailable because this CLI build has no `task` command.
+
+## Timeline & Estimates
+**When will things be done?**
+
+- Complete sequentially in this lifecycle run; no calendar estimate is needed.
+
+## Risks & Mitigation
+**What could go wrong?**
+
+- Ink fake timers may require explicit render flushing; follow existing `PassThrough`, `waitUntilRenderFlush`, rerender, and unmount patterns.
+- Status-driven height changes could affect offsets; keep chrome outside preview rows and assert positive-offset stability.
+- Environment variables can leak between tests; save and restore `TERM` in test teardown.
+
+## Resources Needed
+**What do we need to succeed?**
+
+- One implementation agent, existing Vitest/Ink tooling, approved exploration, repository docs templates, and GitHub CLI.
+
+## Progress Summary
+
+Requirements, design, implementation, testing, documentation, validation, review, and conventional commit creation are complete. No scope changes or blockers were discovered. Remaining work is rebase, push, and PR creation.

--- a/docs/ai/requirements/2026-08-20-feature-preview-typing-indicator.md
+++ b/docs/ai/requirements/2026-08-20-feature-preview-typing-indicator.md
@@ -1,0 +1,54 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+description: Clarify the problem space, gather requirements, and define success criteria
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+
+The agent console preview updates conversation content by polling, but gives no continuous visual signal while the selected agent is running. Console users can mistake an unchanged preview for a stalled agent and must infer activity from the compact list status.
+
+## Goals & Objectives
+**What do we want to achieve?**
+
+- Show a quiet, terminal-native activity animation at the bottom of the visible preview for the currently selected `RUNNING` agent.
+- Keep animation renders isolated from Markdown layout and preserve preview scrolling.
+- Reclaim the activity row for conversation content whenever the indicator is inactive.
+- Provide a narrow ASCII fallback for `TERM=dumb` terminals.
+- Non-goals: token streaming, status freshness changes, durable-agent activity mapping, an explicit ASCII capability setting, and reduced-motion configuration.
+
+## User Stories & Use Cases
+**How will users interact with the solution?**
+
+- As a console user, I want the preview to show `working` while its selected agent is running so that I can tell the console is still observing active work.
+- The indicator appears only for `AgentStatus.RUNNING`; `WAITING`, `IDLE`, `UNKNOWN`, and no selection show no activity row.
+- Pinning has no effect on activity semantics.
+- Animation continues when list/conversation polling is paused by text input because it reflects the last observed status.
+- A status transition or unmount stops the timer immediately, without changing conversation scroll state.
+
+## Success Criteria
+**How will we know when we're done?**
+
+- Unicode terminals cycle `⠋⠙⠹⠸⠼⠴⠦⠧` every 160 ms beside lowercase `working`.
+- `TERM=dumb` cycles fixed-width `|/-\\` frames at the same cadence.
+- The row consumes exactly one preview line while active and disappears cleanly when inactive.
+- Only the leaf indicator re-renders for animation frames; Markdown rows and the parent preview do not re-render or reparse.
+- Frame ticks do not clamp/reset scrolling or interfere with poll-driven content updates.
+- Fake-timer Ink tests cover cycling, cleanup, status transitions, fallback, render isolation, and scroll/content stability; pure frame logic has 100% coverage.
+- Documentation, changelog, build, full workspace tests, lint, and typecheck are complete.
+
+## Constraints & Assumptions
+**What limitations do we need to work within?**
+
+- Ink 7 and the existing console test utilities are used; no new runtime dependency is introduced.
+- The timer is component-local and never stored in context, `ConsoleApp`, `PreviewSection`, or `PreviewPane` state.
+- Unicode is first-class; only `TERM=dumb` selects ASCII in this release.
+- `RUNNING` is the last status observed by polling, not proof of recent token output.
+- The approved Option C exploration and its five decisions are binding.
+
+## Questions & Open Items
+**What do we still need to clarify?**
+
+- None. Copy, geometry, cadence, fallback, and paused-polling behavior were approved before implementation.

--- a/docs/ai/testing/2026-08-20-feature-preview-typing-indicator.md
+++ b/docs/ai/testing/2026-08-20-feature-preview-typing-indicator.md
@@ -1,0 +1,75 @@
+---
+phase: testing
+title: Testing Strategy
+description: Define testing approach, test cases, and quality assurance
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+
+- 100% statements, branches, functions, and lines for new pure frame logic.
+- Component coverage for animation lifecycle and terminal fallback.
+- Integration coverage for status mapping, row budgeting, render isolation, and scroll/content stability.
+
+## Unit Tests
+**What individual components need testing?**
+
+### Frame logic
+- [x] Select braille frames by default and ASCII frames only for `TERM=dumb`.
+- [x] Cycle every frame and wrap indexes deterministically.
+- [x] Verify all fallback frames are one-cell ASCII.
+
+### Preview activity leaf
+- [x] Render frame zero immediately and advance one frame per 160 ms with fake timers.
+- [x] Clear the interval on unmount.
+- [x] Hide, reset, and stop ticking on active-to-inactive transition; restart deterministically on reactivation.
+- [x] Clean up correctly when status rerenders interleave with timer lifecycle.
+
+## Integration Tests
+**How do we test component interactions?**
+
+- [x] Show the bottom row only for the selected agent in `RUNNING`; hide for `WAITING`, `IDLE`, `UNKNOWN`, and no selection.
+- [x] Reserve one conversation line while active and reclaim it while inactive.
+- [x] Keep the indicator below the newest visible content.
+- [x] Advance frames without rerendering the preview parent or reparsing Markdown.
+- [x] Preserve visible content and avoid scroll-clamp callbacks across frame ticks.
+
+## End-to-End Tests
+**What user flows need validation?**
+
+- [x] Full console/workspace suite remains green.
+- [x] Build, lint, and type declarations succeed.
+
+## Test Data
+**What data do we use for testing?**
+
+- Existing `AgentInfo` and conversation fixtures, Ink `PassThrough` stdout, `render`/`renderToString`, `waitUntilRenderFlush`, and Vitest fake timers.
+- No database or seed data.
+
+## Test Reporting & Coverage
+**How do we verify and communicate test results?**
+
+- Focused coverage: `npm exec vitest -- run packages/cli/src/__tests__/tui/console/PreviewActivityIndicator.test.tsx --coverage` with inclusion scoped to frame logic.
+- Focused result: 5 tests passed; the new activity module reached 100% statements (20/20), branches (7/7), functions (6/6), and lines (17/17).
+- Workspace result: 6 projects passed, 139 tests files and 1,937 tests total across project outputs (`npm test`, exit 0).
+- Lint result: all 6 projects passed with 6 pre-existing unused-catch warnings and no errors (`npm run lint`, exit 0).
+- Typecheck result: all configured Nx typecheck targets passed; the CLI additionally passed `npx tsc --noEmit -p packages/cli/tsconfig.json`.
+- Build result: all 6 projects passed after a clean `npm ci`.
+- Lifecycle feature lint passed for all five feature documents and the worktree.
+
+## Manual Testing
+**What requires human validation?**
+
+- Inspect stripped Ink output for fixed-width glyph plus lowercase copy and correct bottom-row placement.
+- Browser/device compatibility is not applicable to this terminal UI.
+
+## Performance Testing
+**How do we validate performance?**
+
+- Render-count and Markdown-layout spies are the performance regression benchmark; frame ticks must leave both parent and Markdown counts unchanged.
+
+## Bug Tracking
+**How do we manage issues?**
+
+- Any failing acceptance scenario returns to TDD before full gates; blocking review findings return to implementation/testing.

--- a/packages/cli/src/__tests__/tui/console/PreviewActivityIndicator.test.tsx
+++ b/packages/cli/src/__tests__/tui/console/PreviewActivityIndicator.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { render, renderToString } from 'ink';
+import { PassThrough } from 'node:stream';
+import { stripVTControlCharacters } from 'node:util';
+import * as activity from '../../../tui/console/PreviewActivityIndicator.js';
+
+const originalTerm = process.env.TERM;
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalTerm === undefined) delete process.env.TERM;
+    else process.env.TERM = originalTerm;
+});
+
+describe('preview activity frames', () => {
+    it('cycles through every braille frame and wraps to the beginning', () => {
+        const getFrame = Reflect.get(activity, 'getPreviewActivityFrame') as
+            ((frameIndex: number, term?: string) => string) | undefined;
+
+        expect(getFrame).toBeTypeOf('function');
+        expect(Array.from({ length: 9 }, (_, index) => getFrame?.(index))).toEqual([
+            '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠋',
+        ]);
+    });
+
+    it('uses fixed-width ASCII frames for TERM=dumb', () => {
+        const getFrame = activity.getPreviewActivityFrame as
+            (frameIndex: number, term?: string) => string;
+        const frames = Array.from({ length: 5 }, (_, index) => getFrame(index, 'dumb'));
+
+        expect(frames).toEqual(['|', '/', '-', '\\', '|']);
+        expect(frames.every(frame => /^[\x00-\x7F]$/u.test(frame))).toBe(true);
+    });
+});
+
+describe('PreviewActivityIndicator', () => {
+    it('renders the TERM=dumb ASCII fallback and hides while inactive', () => {
+        process.env.TERM = 'dumb';
+
+        const active = stripVTControlCharacters(renderToString(
+            React.createElement(activity.PreviewActivityIndicator, { active: true }),
+        ));
+        const inactive = renderToString(
+            React.createElement(activity.PreviewActivityIndicator, { active: false }),
+        );
+
+        expect(active).toContain('| working');
+        expect(active).not.toMatch(/[^\x00-\x7F]/u);
+        expect(inactive).toBe('');
+    });
+
+    it('advances to the next frame every 160 ms', async () => {
+        vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+        const stdout = new PassThrough() as unknown as NodeJS.WriteStream;
+        Object.assign(stdout, { columns: 80, rows: 24, isTTY: true });
+        let output = '';
+        const originalWrite = stdout.write.bind(stdout);
+        vi.spyOn(stdout, 'write').mockImplementation(((...args: Parameters<typeof stdout.write>) => {
+            output += args[0].toString();
+            return originalWrite(...args);
+        }) as typeof stdout.write);
+        const instance = render(React.createElement(activity.PreviewActivityIndicator, { active: true }), {
+            stdout,
+            interactive: true,
+            patchConsole: false,
+        });
+        await instance.waitUntilRenderFlush();
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(stripVTControlCharacters(output)).toContain('⠋ working');
+
+        await vi.advanceTimersByTimeAsync(160);
+        await instance.waitUntilRenderFlush();
+
+        expect(stripVTControlCharacters(output)).toContain('⠙ working');
+        instance.unmount();
+        vi.useRealTimers();
+        await instance.waitUntilExit();
+    });
+
+    it('cleans up its timer on deactivation and unmount', async () => {
+        vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+        const stdout = new PassThrough() as unknown as NodeJS.WriteStream;
+        const instance = render(React.createElement(activity.PreviewActivityIndicator, { active: true }), {
+            stdout,
+            interactive: false,
+            patchConsole: false,
+        });
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(vi.getTimerCount()).toBe(1);
+
+        instance.rerender(React.createElement(activity.PreviewActivityIndicator, { active: false }));
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(vi.getTimerCount()).toBe(0);
+
+        instance.rerender(React.createElement(activity.PreviewActivityIndicator, { active: true }));
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(vi.getTimerCount()).toBe(1);
+
+        instance.unmount();
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(vi.getTimerCount()).toBe(0);
+        vi.useRealTimers();
+        await instance.waitUntilExit();
+    });
+});

--- a/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
@@ -21,6 +21,7 @@ const messages: ConversationMessage[] = [
 ];
 
 afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
 });
 
@@ -123,6 +124,94 @@ describe('PreviewPane helpers', () => {
         expect(output).toContain('user:\n  first question\n\nassistant:\n  first answer\n  with detail');
         expect(output).not.toContain('assistant: first answer');
         expect(output).not.toContain('assistant │ first answer');
+    });
+
+    it('shows a working indicator for the selected running agent', () => {
+        const agent = {
+            name: 'preview-test',
+            type: 'codex',
+            status: AgentStatus.RUNNING,
+            projectPath: '/tmp/project',
+            lastActive: new Date(),
+        } as AgentInfo;
+
+        const output = stripVTControlCharacters(renderToString(React.createElement(PreviewPane, {
+            agent,
+            messages: [],
+            error: null,
+            isLoading: false,
+        }), { columns: 80 }));
+
+        expect(output).toContain('working');
+    });
+
+    it('reclaims the activity row for conversation content when the agent stops running', () => {
+        const renderStatus = (status: AgentStatus) => {
+            const agent = {
+                name: 'preview-test',
+                type: 'codex',
+                status,
+                projectPath: '/tmp/project',
+                lastActive: new Date(),
+            } as AgentInfo;
+
+            return stripVTControlCharacters(renderToString(React.createElement(PreviewPane, {
+                agent,
+                messages: [{ role: 'assistant', content: 'line one\nline two\nline three\nline four' }],
+                error: null,
+                isLoading: false,
+                maxLines: 4,
+            }), { columns: 80 }));
+        };
+
+        const running = renderStatus(AgentStatus.RUNNING);
+        const waiting = renderStatus(AgentStatus.WAITING);
+
+        expect(running).not.toContain('line two');
+        expect(running).toContain('line three\n  line four\n⠋ working');
+        expect(waiting).toContain('line two\n  line three\n  line four');
+        expect(waiting).not.toContain('working');
+    });
+
+    it.each([
+        AgentStatus.WAITING,
+        AgentStatus.IDLE,
+        AgentStatus.UNKNOWN,
+    ])('hides the indicator for %s agents', status => {
+        const agent = {
+            name: 'preview-test',
+            type: 'codex',
+            status,
+            pinned: true,
+            projectPath: '/tmp/project',
+            lastActive: new Date(),
+        } as AgentInfo;
+        const output = renderToString(React.createElement(PreviewPane, {
+            agent,
+            messages: [],
+            error: null,
+            isLoading: false,
+        }));
+
+        expect(output).not.toContain('working');
+    });
+
+    it('keeps a pinned running agent active because pinning has no status effect', () => {
+        const agent = {
+            name: 'preview-test',
+            type: 'codex',
+            status: AgentStatus.RUNNING,
+            pinned: true,
+            projectPath: '/tmp/project',
+            lastActive: new Date(),
+        } as AgentInfo;
+
+        expect(renderToString(React.createElement(PreviewPane, {
+            agent,
+            messages: [],
+            error: null,
+            isLoading: false,
+        }))).toContain('working');
     });
 
     it('renders Markdown message bodies without source punctuation', () => {
@@ -228,6 +317,59 @@ describe('PreviewPane helpers', () => {
         instance.unmount();
         await instance.waitUntilExit();
         renderRowsSpy.mockRestore();
+    });
+
+    it('keeps animation ticks inside the leaf without touching parent renders or scroll state', async () => {
+        vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+        const agent = {
+            name: 'preview-test',
+            type: 'codex',
+            status: AgentStatus.RUNNING,
+            projectPath: '/tmp/project',
+            lastActive: new Date(),
+        } as AgentInfo;
+        const stableMessages: ConversationMessage[] = [{
+            role: 'assistant',
+            content: 'first line\nsecond line\nthird line\nfourth line',
+        }];
+        const renderRowsSpy = vi.spyOn(markdownPreview, 'renderMarkdownRows');
+        const onScrollOffsetClamp = vi.fn();
+        let parentRenders = 0;
+        const Parent = () => {
+            parentRenders += 1;
+            return React.createElement(PreviewPane, {
+                agent,
+                messages: stableMessages,
+                error: null,
+                isLoading: false,
+                maxLines: 4,
+                scrollOffset: 1,
+                onScrollOffsetClamp,
+            });
+        };
+        const stdout = new PassThrough() as unknown as NodeJS.WriteStream;
+        Object.assign(stdout, { columns: 80, rows: 24, isTTY: true });
+        const instance = render(React.createElement(Parent), {
+            stdout,
+            interactive: true,
+            patchConsole: false,
+            maxFps: 60,
+        });
+        await instance.waitUntilRenderFlush();
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(parentRenders).toBe(1);
+        expect(renderRowsSpy).toHaveBeenCalledTimes(1);
+        expect(onScrollOffsetClamp).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(480);
+        await instance.waitUntilRenderFlush();
+
+        expect(parentRenders).toBe(1);
+        expect(renderRowsSpy).toHaveBeenCalledTimes(1);
+        expect(onScrollOffsetClamp).not.toHaveBeenCalled();
+        instance.unmount();
+        vi.useRealTimers();
+        await instance.waitUntilExit();
     });
 
     it('rebuilds layout when content width changes while messages stay stable', async () => {

--- a/packages/cli/src/tui/console/PreviewActivityIndicator.tsx
+++ b/packages/cli/src/tui/console/PreviewActivityIndicator.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { TUI_COLORS } from '../design-system/index.js';
+
+interface PreviewActivityIndicatorProps {
+    active: boolean;
+}
+
+const BRAILLE_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧'] as const;
+const ASCII_FRAMES = ['|', '/', '-', '\\'] as const;
+
+export function getPreviewActivityFrame(frameIndex: number, term = process.env.TERM): string {
+    const frames = term === 'dumb' ? ASCII_FRAMES : BRAILLE_FRAMES;
+    return frames[frameIndex % frames.length];
+}
+
+const PreviewActivityIndicatorInner: React.FC<PreviewActivityIndicatorProps> = ({ active }) => {
+    const [frameIndex, setFrameIndex] = useState(0);
+
+    useEffect(() => {
+        if (!active) {
+            setFrameIndex(0);
+            return;
+        }
+
+        setFrameIndex(0);
+        const handle = setInterval(() => {
+            setFrameIndex(current => current + 1);
+        }, 160);
+
+        return () => clearInterval(handle);
+    }, [active]);
+
+    if (!active) return null;
+
+    return (
+        <Box>
+            <Text color={TUI_COLORS.accent}>{getPreviewActivityFrame(frameIndex)}</Text>
+            <Text dimColor> working</Text>
+        </Box>
+    );
+};
+
+export const PreviewActivityIndicator = React.memo(PreviewActivityIndicatorInner);

--- a/packages/cli/src/tui/console/PreviewPane.tsx
+++ b/packages/cli/src/tui/console/PreviewPane.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Box, Text } from 'ink';
-import type { AgentInfo, ConversationMessage } from '@ai-devkit/agent-manager';
+import { AgentStatus, type AgentInfo, type ConversationMessage } from '@ai-devkit/agent-manager';
 import type { ConversationFetchError } from './hooks/useAgentConversation.js';
 import { formatRelative } from './render/formatRelative.js';
 import { AGENT_TYPE_LABEL_DISPLAY } from './render/agentTypeLabel.js';
@@ -11,6 +11,7 @@ import {
     renderMarkdownRows,
     type MarkdownPreviewSpan,
 } from './render/markdownPreview.js';
+import { PreviewActivityIndicator } from './PreviewActivityIndicator.js';
 
 interface PreviewPaneProps {
     agent: AgentInfo | null;
@@ -162,6 +163,8 @@ const PreviewPaneInner: React.FC<PreviewPaneProps> = ({
     contentWidth = 80,
     onScrollOffsetClamp,
 }) => {
+    const activityActive = agent?.status === AgentStatus.RUNNING;
+    const bodyMaxLines = Math.max(1, maxLines - (activityActive ? 1 : 0));
     const rows = useMemo(() => buildPreviewRows(messages, contentWidth), [messages, contentWidth]);
     const rowCount = rows.length;
     const previousRowCountRef = useRef(rowCount);
@@ -171,7 +174,7 @@ const PreviewPaneInner: React.FC<PreviewPaneProps> = ({
         scrollOffset,
     );
     const viewport = rows.length > 0
-        ? buildPreviewViewportFromRows(rows, Math.max(4, maxLines), adjustedScrollOffset)
+        ? buildPreviewViewportFromRows(rows, bodyMaxLines, adjustedScrollOffset)
         : null;
     const clampedOffset = viewport?.clampedOffset;
 
@@ -258,6 +261,7 @@ const PreviewPaneInner: React.FC<PreviewPaneProps> = ({
             <Box flexDirection="column" flexGrow={1}>
                 {body}
             </Box>
+            <PreviewActivityIndicator active={activityActive} />
         </Box>
     );
 };

--- a/web/content/docs/13-agent-console.md
+++ b/web/content/docs/13-agent-console.md
@@ -31,6 +31,8 @@ The console has two main areas:
 1. **Agent list**: shows detected agents, status, name, agent type, recent summary or project path, and a `remote` marker when a channel bridge is connected.
 2. **Preview pane**: shows the selected agent's recent conversation with Markdown formatting, metadata, project path, and connected channel name when one is active.
 
+While the selected agent is running, the preview shows a live `working` spinner on its bottom row. The row returns to conversation content when the agent is no longer running; terminals reporting `TERM=dumb` use an ASCII spinner.
+
 On narrow terminals, the console hides the preview pane. Resize the terminal wider to show both panes.
 
 ## Hotkeys
@@ -66,6 +68,8 @@ ai-devkit agent console
 ```
 
 Use `j` and `k` to move between agents. The preview pane updates as you select agents and renders common Markdown formatting. Press `/` to filter the list by agent name; press `Esc` to clear the filter. Press `p` to pin or unpin an agent. Pinned agents are grouped at the top of the list.
+
+The bottom-row `working` animation reflects the selected agent's last observed running status. It continues while text entry temporarily pauses polling and disappears for waiting, idle, or unknown agents.
 
 Press `v` to focus the detail/chat pane, then use `j` and `k` to scroll. Press `Esc` or `Left` to return to the agent list. Press `M` to toggle a read-only list of recent memory items.
 


### PR DESCRIPTION
## Motivation

The console preview had no live signal while its selected agent was running, so an unchanged poll-driven conversation could look stalled.

## Design

Implements approved Option C as a dedicated bottom-row leaf: a fixed-width braille spinner at 160 ms followed by lowercase `working`.

The five binding decisions are preserved:

1. Copy is `working`.
2. The row is reclaimed for conversation content while inactive.
3. Braille cadence is 160 ms; reduced-motion configuration remains a future enhancement.
4. Unicode is first-class, with `|/-\\` selected only for `TERM=dumb`; an explicit ASCII capability is deferred.
5. Activity follows the last observed status and continues while input pauses polling.

The indicator appears only for the selected interactive agent in `AgentStatus.RUNNING`. Waiting, idle, unknown, and absent agents render no activity row; pinning does not affect activity semantics.

## Performance and correctness

- The interval and frame state live only in the memoized leaf component.
- Frame ticks do not rerender the preview parent or reparse Markdown.
- Activity chrome stays outside conversation rows, row-count compensation, and scroll state.
- The interval is cleared on status transition and unmount.
- Tests verify positive-offset scroll stability and no scroll-clamp calls across animation frames.

## Validation

- `npm ci`
- `npm run build` — 6 projects passed
- `npm test` — 139 files / 1,937 tests passed across 6 projects
- `npm run lint` — 6 projects passed; no errors (existing warnings only)
- `npx nx run-many -t typecheck` — all configured targets passed
- `npx tsc --noEmit -p packages/cli/tsconfig.json`
- Focused activity coverage — 100% statements, branches, functions, and lines
- `npx ai-devkit@latest lint --feature preview-typing-indicator`

## Risks

No known blocking risks. Status remains poll-observed rather than a token-stream freshness guarantee, as designed.
