### PR TITLE
feat(cli): Index cached skills for configured registries

### DIFF
--- a/packages/cli/src/__tests__/commands/skill.test.ts
+++ b/packages/cli/src/__tests__/commands/skill.test.ts
@@ -7,6 +7,7 @@ const mockAddSkill = vi.fn();
 const mockListGlobalSkills = vi.fn();
 const mockListSkills = vi.fn();
 const mockRemoveSkill = vi.fn();
+const mockUpdateSkillIndexForRegistry = vi.fn();
 const mockProjectGetSkillRegistries = vi.fn();
 const mockProjectAddSkillRegistry = vi.fn();
 const mockGlobalGetSkillRegistries = vi.fn();
@@ -32,6 +33,7 @@ vi.mock('../../lib/SkillManager.js', () => ({
     listGlobalSkills: (...args: unknown[]) => mockListGlobalSkills(...args),
     listSkills: (...args: unknown[]) => mockListSkills(...args),
     removeSkill: (...args: unknown[]) => mockRemoveSkill(...args),
+    updateSkillIndexForRegistry: (...args: unknown[]) => mockUpdateSkillIndexForRegistry(...args),
     updateSkills: vi.fn(),
     findSkills: vi.fn(),
     rebuildIndex: vi.fn(),
@@ -56,6 +58,7 @@ describe('skill command', () => {
     mockListGlobalSkills.mockResolvedValue([]);
     mockListSkills.mockResolvedValue([]);
     mockRemoveSkill.mockImplementation(async () => undefined);
+    mockUpdateSkillIndexForRegistry.mockImplementation(async () => undefined);
     mockProjectGetSkillRegistries.mockResolvedValue({});
     mockProjectAddSkillRegistry.mockResolvedValue({});
     mockGlobalGetSkillRegistries.mockResolvedValue({});
@@ -76,6 +79,7 @@ describe('skill command', () => {
       { force: undefined },
     );
     expect(mockGlobalAddSkillRegistry).not.toHaveBeenCalled();
+    expect(mockUpdateSkillIndexForRegistry).toHaveBeenCalledWith('shopback/skills');
   });
 
   it('reports an identical target-scope registry as already registered', async () => {

--- a/packages/cli/src/__tests__/lib/SkillManager.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillManager.test.ts
@@ -19,6 +19,7 @@ vi.mock("fs-extra", () => ({
     remove: vi.fn(),
     readdir: vi.fn(),
     realpath: vi.fn(),
+    readFile: vi.fn(),
     readJson: vi.fn(),
     writeJson: vi.fn(),
   },
@@ -1538,6 +1539,84 @@ describe("SkillManager", () => {
       const results = await skillManager.findSkills("nonexistent");
 
       expect(results).toEqual([]);
+    });
+
+    it("indexes configured non-GitHub registries from matching local cache on refresh", async () => {
+      mockFetch({ registries: {} });
+      mockGlobalConfigManager.getSkillRegistries.mockResolvedValue({
+        "shopback/experiment-skills": "git@gitlab.com:shopback/earn-more/earn-more-experiment/skills.git",
+      });
+      mockConfigManager.getSkillRegistries.mockResolvedValue({});
+      mockedGitUtil.fetchGitHead.mockResolvedValue("unused");
+      mockedSkillUtil.extractSkillDescription.mockReturnValue("ASF experiment workflow");
+
+      const expectedRegistryPath = path.join(
+        os.homedir(),
+        ".ai-devkit",
+        "skills",
+        "shopback",
+        "experiment-skills",
+      );
+      const unrelatedRegistryPath = path.join(
+        os.homedir(),
+        ".ai-devkit",
+        "skills",
+        "unrelated",
+        "skills",
+      );
+
+      (mockedFs.pathExists as any).mockImplementation(async (checkedPath: string) => {
+        return checkedPath === expectedRegistryPath
+          || checkedPath === path.join(expectedRegistryPath, "skills")
+          || checkedPath === path.join(expectedRegistryPath, "skills", "asf", "SKILL.md")
+          || checkedPath.endsWith("skills.json");
+      });
+      (mockedFs.readJson as any).mockResolvedValue({
+        meta: {
+          version: 1,
+          createdAt: Date.now() - 1000,
+          updatedAt: Date.now() - 1000,
+          registryHeads: {},
+        },
+        skills: [
+          {
+            name: "unrelated-skill",
+            registry: "unrelated/skills",
+            path: "skills/unrelated-skill",
+            description: "Should not be indexed",
+            lastIndexed: Date.now(),
+          },
+        ],
+      });
+      (mockedFs.readdir as any).mockImplementation(async (checkedPath: string) => {
+        if (checkedPath === path.join(expectedRegistryPath, "skills")) {
+          return [{ name: "asf", isDirectory: () => true }];
+        }
+        if (checkedPath === path.join(unrelatedRegistryPath, "skills")) {
+          return [{ name: "unrelated-skill", isDirectory: () => true }];
+        }
+        return [];
+      });
+      (mockedFs.readFile as any).mockResolvedValue("# ASF\n\nASF experiment workflow");
+
+      const results = await skillManager.findSkills("asf", { refresh: true });
+
+      expect(results).toEqual([
+        expect.objectContaining({
+          name: "asf",
+          registry: "shopback/experiment-skills",
+          path: "skills/asf",
+          description: "ASF experiment workflow",
+        }),
+      ]);
+      expect(mockedFs.readdir).toHaveBeenCalledWith(
+        path.join(expectedRegistryPath, "skills"),
+        { withFileTypes: true },
+      );
+      expect(mockedFs.readdir).not.toHaveBeenCalledWith(
+        path.join(unrelatedRegistryPath, "skills"),
+        { withFileTypes: true },
+      );
     });
   });
 });

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -78,6 +78,9 @@ export function registerSkillCommand(program: Command): void {
       const registries = await configManager.getSkillRegistries();
       const mutation = planSkillRegistryAdd(registries, id, url, { force: options.force });
       await configManager.addSkillRegistry(id, url, { force: options.force });
+      if (mutation.status !== 'already-registered') {
+        await new SkillManager(new ConfigManager()).updateSkillIndexForRegistry(id);
+      }
 
       if (mutation.status === 'already-registered') {
         ui.info(`Registry "${id}" is already registered.`);

--- a/packages/cli/src/lib/SkillIndex.ts
+++ b/packages/cli/src/lib/SkillIndex.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { SkillRegistry } from './SkillRegistry.js';
-import { extractSkillDescription } from '../util/skill.js';
+import { SkillRegistry, SKILL_CACHE_DIR } from './SkillRegistry.js';
+import { extractSkillDescription, isValidSkillName } from '../util/skill.js';
 import { fetchGitHead } from '../util/git.js';
 import { fetchGitHubSkillPaths, fetchRawGitHubFile } from '../util/github.js';
 import { ui } from '../util/terminal-ui.js';
@@ -66,6 +66,30 @@ export class SkillIndex {
     }
   }
 
+  async updateRegistryFromCache(registryId: string): Promise<void> {
+    const localSkills = await this.readLocalRegistrySkills(registryId);
+    if (!localSkills) {
+      return;
+    }
+
+    const existingIndex = await this.readExistingIndex();
+    const nextIndex: SkillIndexData = {
+      meta: {
+        version: 1,
+        createdAt: existingIndex?.meta?.createdAt || Date.now(),
+        updatedAt: Date.now(),
+        registryHeads: existingIndex?.meta?.registryHeads || {},
+      },
+      skills: [
+        ...(existingIndex?.skills || []).filter(skill => skill.registry !== registryId),
+        ...localSkills,
+      ],
+    };
+
+    await fs.ensureDir(path.dirname(SKILL_INDEX_PATH));
+    await fs.writeJson(SKILL_INDEX_PATH, nextIndex, { spaces: 2 });
+  }
+
   private async ensureSkillIndex(forceRefresh = false): Promise<SkillIndexData> {
     const indexExists = await fs.pathExists(SKILL_INDEX_PATH);
 
@@ -78,7 +102,7 @@ export class SkillIndex {
           return index;
         }
         ui.info(`Index is older than 24h, checking for updates...`);
-      } catch (error) {
+      } catch (ignore) {
         ui.warning('Failed to read skill index, will rebuild');
       }
     }
@@ -95,7 +119,7 @@ export class SkillIndex {
           spinner.succeed('Seed index fetched successfully');
           return seedIndex;
         }
-      } catch (error) {
+      } catch (ignore) {
         spinner.fail('Failed to fetch seed index, falling back to build');
       }
     }
@@ -125,12 +149,8 @@ export class SkillIndex {
     const registry = await this.registry.fetchMergedRegistry();
     const registryIds = Object.keys(registry.registries);
 
-    let existingIndex: SkillIndexData | null = null;
-    try {
-      if (await fs.pathExists(SKILL_INDEX_PATH)) {
-        existingIndex = await fs.readJson(SKILL_INDEX_PATH);
-      }
-    } catch { /* ignore */ }
+    const existingIndex = await this.readExistingIndex();
+    const localSkills = await this.readConfiguredLocalRegistrySkills(registryIds);
 
     ui.info(`Building skill index from ${registryIds.length} registries...`);
 
@@ -165,7 +185,6 @@ export class SkillIndex {
     for (const result of headResults) {
       const { registryId, headSha, owner, repo, error } = result;
       if (error || !headSha || !owner || !repo) {
-        if (error) ui.warning(`Skipping ${registryId}: ${error}`);
         continue;
       }
 
@@ -218,7 +237,7 @@ export class SkillIndex {
       }
     }
 
-    const skills = [...unchangedSkills, ...newSkills];
+    const skills = this.mergeSkills([...unchangedSkills, ...newSkills], localSkills);
 
     const meta: IndexMeta = {
       version: 1,
@@ -236,5 +255,80 @@ export class SkillIndex {
       const descMatch = skill.description.toLowerCase().includes(keyword);
       return nameMatch || descMatch;
     });
+  }
+
+  private async readExistingIndex(): Promise<SkillIndexData | null> {
+    try {
+      if (await fs.pathExists(SKILL_INDEX_PATH)) {
+        return await fs.readJson(SKILL_INDEX_PATH);
+      }
+    } catch { /* ignore */ }
+
+    return null;
+  }
+
+  private async readConfiguredLocalRegistrySkills(registryIds: string[]): Promise<SkillEntry[]> {
+    const skills: SkillEntry[] = [];
+
+    for (const registryId of registryIds) {
+      const registrySkills = await this.readLocalRegistrySkills(registryId);
+      if (registrySkills) {
+        skills.push(...registrySkills);
+      }
+    }
+
+    return skills;
+  }
+
+  private async readLocalRegistrySkills(registryId: string): Promise<SkillEntry[] | null> {
+    const registryPath = path.join(SKILL_CACHE_DIR, registryId);
+    const skillsPath = path.join(registryPath, 'skills');
+
+    if (!await fs.pathExists(registryPath) || !await fs.pathExists(skillsPath)) {
+      return null;
+    }
+
+    const entries = await fs.readdir(skillsPath, { withFileTypes: true });
+    const skills: SkillEntry[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !isValidSkillName(entry.name)) {
+        continue;
+      }
+
+      const skillMdPath = path.join(skillsPath, entry.name, 'SKILL.md');
+      if (!await fs.pathExists(skillMdPath)) {
+        continue;
+      }
+
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+      skills.push({
+        name: entry.name,
+        registry: registryId,
+        path: path.join('skills', entry.name).split(path.sep).join('/'),
+        description: extractSkillDescription(content),
+        lastIndexed: Date.now(),
+      });
+    }
+
+    return skills;
+  }
+
+  private mergeSkills(remoteSkills: SkillEntry[], localSkills: SkillEntry[]): SkillEntry[] {
+    const merged = new Map<string, SkillEntry>();
+
+    for (const skill of remoteSkills) {
+      merged.set(this.skillKey(skill), skill);
+    }
+
+    for (const skill of localSkills) {
+      merged.set(this.skillKey(skill), skill);
+    }
+
+    return [...merged.values()];
+  }
+
+  private skillKey(skill: SkillEntry): string {
+    return `${skill.registry}:${skill.name}`;
   }
 }

--- a/packages/cli/src/lib/SkillManager.ts
+++ b/packages/cli/src/lib/SkillManager.ts
@@ -358,6 +358,10 @@ export class SkillManager {
     return this.index.rebuildIndex(outputPath);
   }
 
+  async updateSkillIndexForRegistry(registryId: string): Promise<void> {
+    return this.index.updateRegistryFromCache(registryId);
+  }
+
   private async resolveProjectEnvironments(): Promise<string[]> {
     ui.info('Loading project configuration...');
     let config = await this.configManager.read();


### PR DESCRIPTION
## Summary
- Index configured registry IDs from matching local cache folders under ~/.ai-devkit/skills during skill find --refresh
- Add targeted local-cache index updates after skill add-registry
- Keep missing local cache silent and avoid scanning unrelated cached registries

## Validation
- npm run test --workspace packages/cli
- npm run lint --workspace packages/cli (exit 0; existing warnings remain)
- npm run build --workspace packages/cli

## Risks
- Registries without a matching local cache remain absent from search until their cache exists and the index is refreshed or add-registry runs.