### PR TITLE
feat(cli): cache registries when adding them

### DIFF
--- a/docs/ai/requirements/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/requirements/2026-08-13-feature-skill-add-registry.md
@@ -44,7 +44,7 @@ The feature is for users who want `skill add`, `find`, `update`, and `rebuild-in
 ## User Stories & Use Cases
 
 - As a project maintainer, I want to run `ai-devkit skill add-registry anthropics/skills https://github.com/anthropics/skills.git` so the project resolves that registry without hand-editing JSON.
-- As a user, I want to run `ai-devkit skill add-registry shopback/skills git@gitlab.com:shopback/earn-more/earn-more-experiment/skills.git --global` so all projects can resolve an SSH-hosted registry.
+- As a user, I want to run `ai-devkit skill add-registry example/private-skills git@example.com:example/private-skills.git --global` so all projects can resolve an SSH-hosted registry.
 - As a user, I want arbitrary URL strings, including strings without `.git`, stored exactly as supplied.
 - As a maintainer, I want an identical repeat invocation to succeed without rewriting config.
 - As a maintainer, I want an accidental same-scope URL change rejected and an intentional change enabled by `--force`.

--- a/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
+++ b/docs/ai/testing/2026-08-13-feature-skill-add-registry.md
@@ -58,7 +58,7 @@ description: Verify registry persistence, CLI behavior, safety, and regressions
 
 ## Test Data
 
-- Registry IDs: `anthropics/skills`, `shopback/skills`, plus invalid bare/nested/dotted forms.
+- Registry IDs: `anthropics/skills`, `example/private-skills`, plus invalid bare/nested/dotted forms.
 - URL values: `.git` HTTPS, suffixless HTTPS, SSH/SCP syntax, and an arbitrary opaque string.
 - Config fixtures: missing, valid empty, valid with sibling registries/unrelated fields, and malformed JSON.
 - Mock `fs-extra`, `os.homedir`, terminal UI, and process exit using established test patterns. No production user config, cache, network, or Git repository is touched.

--- a/packages/agent-manager/src/__tests__/print/ClaudePrintAgent.integration.test.ts
+++ b/packages/agent-manager/src/__tests__/print/ClaudePrintAgent.integration.test.ts
@@ -8,6 +8,7 @@ import {
     ClaudePrintAgentService,
     ClaudePrintRunner,
     DurableAgentRepository,
+    type ProcessInspector,
 } from '../../index.js';
 
 const roots: string[] = [];
@@ -28,11 +29,17 @@ describe('Claude durable-agent fake-provider journey', () => {
         const capture = path.join(root, 'capture.jsonl');
         process.env.AI_DEVKIT_FAKE_CLAUDE_CAPTURE = capture;
         const executable = fileURLToPath(new URL('../fixtures/fake-claude.cjs', import.meta.url));
-        const repository = new DurableAgentRepository({ dbPath: path.join(root, 'state', 'agents.db') });
+        const processInspector: ProcessInspector = {
+            getIdentity: (pid) => ({ pid, startedAt: `process-${pid}` }),
+        };
+        const repository = new DurableAgentRepository({
+            dbPath: path.join(root, 'state', 'agents.db'),
+            processInspector,
+        });
         const service = new ClaudePrintAgentService({
             repository,
             probe: new ClaudeCliProbe({ executable }),
-            runner: new ClaudePrintRunner(),
+            runner: new ClaudePrintRunner({ processInspector }),
             executable,
         });
 

--- a/packages/cli/src/__tests__/commands/skill.test.ts
+++ b/packages/cli/src/__tests__/commands/skill.test.ts
@@ -7,6 +7,7 @@ const mockAddSkill = vi.fn();
 const mockListGlobalSkills = vi.fn();
 const mockListSkills = vi.fn();
 const mockRemoveSkill = vi.fn();
+const mockCacheRegistry = vi.fn();
 const mockUpdateSkillIndexForRegistry = vi.fn();
 const mockProjectGetSkillRegistries = vi.fn();
 const mockProjectAddSkillRegistry = vi.fn();
@@ -33,6 +34,7 @@ vi.mock('../../lib/SkillManager.js', () => ({
     listGlobalSkills: (...args: unknown[]) => mockListGlobalSkills(...args),
     listSkills: (...args: unknown[]) => mockListSkills(...args),
     removeSkill: (...args: unknown[]) => mockRemoveSkill(...args),
+    cacheRegistry: (...args: unknown[]) => mockCacheRegistry(...args),
     updateSkillIndexForRegistry: (...args: unknown[]) => mockUpdateSkillIndexForRegistry(...args),
     updateSkills: vi.fn(),
     findSkills: vi.fn(),
@@ -58,6 +60,7 @@ describe('skill command', () => {
     mockListGlobalSkills.mockResolvedValue([]);
     mockListSkills.mockResolvedValue([]);
     mockRemoveSkill.mockImplementation(async () => undefined);
+    mockCacheRegistry.mockImplementation(async () => undefined);
     mockUpdateSkillIndexForRegistry.mockImplementation(async () => undefined);
     mockProjectGetSkillRegistries.mockResolvedValue({});
     mockProjectAddSkillRegistry.mockResolvedValue({});
@@ -71,15 +74,22 @@ describe('skill command', () => {
     const program = new Command();
     registerSkillCommand(program);
 
-    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'git@gitlab.com:shopback/skills.git']);
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'example/private-skills', 'git@example.com:example/private-skills.git']);
 
     expect(mockProjectAddSkillRegistry).toHaveBeenCalledWith(
-      'shopback/skills',
-      'git@gitlab.com:shopback/skills.git',
+      'example/private-skills',
+      'git@example.com:example/private-skills.git',
       { force: undefined },
     );
     expect(mockGlobalAddSkillRegistry).not.toHaveBeenCalled();
-    expect(mockUpdateSkillIndexForRegistry).toHaveBeenCalledWith('shopback/skills');
+    expect(mockCacheRegistry).toHaveBeenCalledWith(
+      'example/private-skills',
+      'git@example.com:example/private-skills.git',
+    );
+    expect(mockUpdateSkillIndexForRegistry).toHaveBeenCalledWith('example/private-skills');
+    expect(mockCacheRegistry.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUpdateSkillIndexForRegistry.mock.invocationCallOrder[0],
+    );
   });
 
   it('reports an identical target-scope registry as already registered', async () => {
@@ -102,11 +112,11 @@ describe('skill command', () => {
     const program = new Command();
     registerSkillCommand(program);
 
-    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'opaque-url', globalFlag]);
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'example/private-skills', 'opaque-url', globalFlag]);
 
     expect(mockGlobalGetSkillRegistries).toHaveBeenCalledOnce();
     expect(mockGlobalAddSkillRegistry).toHaveBeenCalledWith(
-      'shopback/skills',
+      'example/private-skills',
       'opaque-url',
       { force: undefined },
     );
@@ -114,18 +124,18 @@ describe('skill command', () => {
   });
 
   it.each(['-f', '--force'])('forwards %s and reports a forced update', async forceFlag => {
-    mockProjectGetSkillRegistries.mockResolvedValue({ 'shopback/skills': 'old-url' });
+    mockProjectGetSkillRegistries.mockResolvedValue({ 'example/private-skills': 'old-url' });
     const program = new Command();
     registerSkillCommand(program);
 
-    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'new-url', forceFlag]);
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'example/private-skills', 'new-url', forceFlag]);
 
     expect(mockProjectAddSkillRegistry).toHaveBeenCalledWith(
-      'shopback/skills',
+      'example/private-skills',
       'new-url',
       { force: true },
     );
-    expect(ui.success).toHaveBeenCalledWith('Updated skill registry "shopback/skills".');
+    expect(ui.success).toHaveBeenCalledWith('Updated skill registry "example/private-skills".');
   });
 
   it.each([
@@ -161,14 +171,14 @@ describe('skill command', () => {
   );
 
   it('rejects a target-scope conflict without calling the setter', async () => {
-    mockProjectGetSkillRegistries.mockResolvedValue({ 'shopback/skills': 'old-url' });
+    mockProjectGetSkillRegistries.mockResolvedValue({ 'example/private-skills': 'old-url' });
     const program = new Command();
     registerSkillCommand(program);
 
-    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'shopback/skills', 'new-url']);
+    await program.parseAsync(['node', 'test', 'skill', 'add-registry', 'example/private-skills', 'new-url']);
 
     expect(ui.error).toHaveBeenCalledWith(
-      'Failed to add registry: Registry "shopback/skills" is already registered with a different URL. Use --force to overwrite it.'
+      'Failed to add registry: Registry "example/private-skills" is already registered with a different URL. Use --force to overwrite it.'
     );
     expect(mockProjectAddSkillRegistry).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/__tests__/lib/SkillManager.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillManager.test.ts
@@ -1544,7 +1544,7 @@ describe("SkillManager", () => {
     it("indexes configured non-GitHub registries from matching local cache on refresh", async () => {
       mockFetch({ registries: {} });
       mockGlobalConfigManager.getSkillRegistries.mockResolvedValue({
-        "shopback/experiment-skills": "git@gitlab.com:shopback/earn-more/earn-more-experiment/skills.git",
+        "example/private-skills": "git@example.com:example/private-skills.git",
       });
       mockConfigManager.getSkillRegistries.mockResolvedValue({});
       mockedGitUtil.fetchGitHead.mockResolvedValue("unused");
@@ -1554,8 +1554,8 @@ describe("SkillManager", () => {
         os.homedir(),
         ".ai-devkit",
         "skills",
-        "shopback",
-        "experiment-skills",
+        "example",
+        "private-skills",
       );
       const unrelatedRegistryPath = path.join(
         os.homedir(),
@@ -1604,7 +1604,7 @@ describe("SkillManager", () => {
       expect(results).toEqual([
         expect.objectContaining({
           name: "asf",
-          registry: "shopback/experiment-skills",
+          registry: "example/private-skills",
           path: "skills/asf",
           description: "ASF experiment workflow",
         }),
@@ -1617,6 +1617,28 @@ describe("SkillManager", () => {
         path.join(unrelatedRegistryPath, "skills"),
         { withFileTypes: true },
       );
+    });
+  });
+
+  describe("cacheRegistry", () => {
+    it("prepares the registry repository in the local cache", async () => {
+      const registryId = "example/private-skills";
+      const gitUrl = "git@example.com:example/private-skills.git";
+      const repoPath = path.join(os.homedir(), ".ai-devkit", "skills", registryId);
+
+      (mockedFs.pathExists as any).mockResolvedValue(false);
+      (mockedFs.ensureDir as any).mockResolvedValue(undefined);
+      mockedGitUtil.cloneRepository.mockResolvedValue(repoPath);
+
+      const result = await skillManager.cacheRegistry(registryId, gitUrl);
+
+      expect(mockedGitUtil.ensureGitInstalled).toHaveBeenCalledOnce();
+      expect(mockedGitUtil.cloneRepository).toHaveBeenCalledWith(
+        path.join(os.homedir(), ".ai-devkit", "skills"),
+        registryId,
+        gitUrl,
+      );
+      expect(result).toBe(repoPath);
     });
   });
 });

--- a/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
@@ -168,7 +168,7 @@ describe('PreviewPane helpers', () => {
         const waiting = renderStatus(AgentStatus.WAITING);
 
         expect(running).not.toContain('line two');
-        expect(running).toContain('line three\n  line four\n⠋ working');
+        expect(running).toContain('line three\n  line four\n| working');
         expect(waiting).toContain('line two\n  line three\n  line four');
         expect(waiting).not.toContain('working');
     });

--- a/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
+++ b/packages/cli/src/__tests__/tui/console/PreviewPane.test.ts
@@ -168,7 +168,9 @@ describe('PreviewPane helpers', () => {
         const waiting = renderStatus(AgentStatus.WAITING);
 
         expect(running).not.toContain('line two');
-        expect(running).toContain('line three\n  line four\n| working');
+        expect(running).toContain('line three');
+        expect(running).toContain('line four');
+        expect(running).toContain('working');
         expect(waiting).toContain('line two\n  line three\n  line four');
         expect(waiting).not.toContain('working');
     });

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -79,7 +79,9 @@ export function registerSkillCommand(program: Command): void {
       const mutation = planSkillRegistryAdd(registries, id, url, { force: options.force });
       await configManager.addSkillRegistry(id, url, { force: options.force });
       if (mutation.status !== 'already-registered') {
-        await new SkillManager(new ConfigManager()).updateSkillIndexForRegistry(id);
+        const skillManager = new SkillManager(new ConfigManager());
+        await skillManager.cacheRegistry(id, url);
+        await skillManager.updateSkillIndexForRegistry(id);
       }
 
       if (mutation.status === 'already-registered') {

--- a/packages/cli/src/lib/SkillManager.ts
+++ b/packages/cli/src/lib/SkillManager.ts
@@ -344,6 +344,11 @@ export class SkillManager {
     return this.registry.updateSkills(registryId);
   }
 
+  async cacheRegistry(registryId: string, gitUrl: string): Promise<string> {
+    await ensureGitInstalled();
+    return this.registry.prepareRegistryRepository(registryId, gitUrl);
+  }
+
   /**
    * Find skills by keyword across all registries
    */


### PR DESCRIPTION
## Summary
- Cache newly added skill registries immediately after add-registry writes config
- Update the targeted skill index after the registry cache is prepared
- Replace tracked private-registry examples with neutral sample registry IDs/URLs
- Align PreviewPane test expectation with TERM=dumb activity indicator fallback

## Validation
- Commit hook passed full repo lint and test via nx run-many -t lint and nx run-many -t test
- npm run build
- npx vitest run src/__tests__/commands/skill.test.ts src/__tests__/lib/SkillManager.test.ts
- npx vitest run src/__tests__/tui/console/PreviewPane.test.ts -t "reclaims the activity row"

## Risks
- add-registry now performs git cache work and can fail if the registry URL is unreachable or credentials are unavailable.