### PR TITLE
docs(skill): bias brainstorm toward minimal solutions and deletion cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Bias the brainstorm skill toward minimal solutions: baseline-first divergence, speculative-generality and verified-claim checks, and deletion cost in comparisons.
+
 ## [0.54.0] - 2026-08-21
 
 - [8284e76](https://github.com/codeaholicguy/ai-devkit/pull/194) Indexed cached registry skills.

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -9,11 +9,12 @@ Run a compact diverge-to-converge loop.
 
 ## Workflow
 
-1. Frame: restate the goal, constraints, audience, success criteria, and assumptions.
-2. Diverge: generate distinct options across practical, high-leverage, and unusual angles.
-3. Challenge: identify weak assumptions, obvious failure modes, tradeoffs, and ideas to reject.
-4. Compare: group related ideas and evaluate only on relevant criteria such as impact, effort, risk, novelty, confidence, or time-to-test.
-5. Converge: recommend the strongest 3 options with brief rationale and a concrete next step, experiment, outline, or decision checkpoint.
+1. Frame: goal, constraints, audience, success criteria, assumptions.
+2. Baseline: state the simplest honest solution first. Every option must beat it; the baseline stays a candidate.
+3. Diverge: distinct options across practical, high-leverage, and unusual angles.
+4. Challenge: weak assumptions, failure modes, tradeoffs, rejections. Always: reject speculative generality (each abstraction, layer, flag, and data copy needs a current caller) and verify load-bearing "needed" claims in the consuming code, not doc assertions.
+5. Compare: only relevant criteria, plus deletion cost (how easily the option can be removed later). Ties go to the smaller option.
+6. Converge: strongest 3 picks with rationale and a next step. Self-review first: for each new constant, object, layer, and flag ask "why do we need this?" Cut answers that are only messaging or future-proofing.
 
 ## Formats
 
@@ -25,4 +26,4 @@ Use Quick by default. Use Deep only for ambiguous or high-stakes decisions. Ask 
 - Technical: approaches, tradeoffs, risks, validation.
 - Content: angles, hooks, audiences, outlines.
 
-Avoid filler, near-duplicates, generic best practices, and premature recommendations. If asked for more ideas, explore a new axis before listing variants.
+Avoid filler, near-duplicates, generic best practices, premature recommendations, and scope without a current caller. If asked for more ideas, explore a new axis before listing variants.


### PR DESCRIPTION
## Summary

- add a **Baseline** step: state the simplest honest solution in 1–3 sentences before diverging; every option must justify what it adds over it, and the baseline stays a candidate
- add two mandatory **Challenge** axes: *speculative generality* (every abstraction/layer/flag/data copy needs a current caller) and *verified claims* (load-bearing "needed" claims must be checked against runtime behavior, not doc assertions)
- add **deletion cost** to Compare: on ties prefer the smaller option — complexity gets added on demand but is rarely removed voluntarily
- add a **self-review gate** before Converge: ask "why do we need this?" for each new constant/object/layer/flag; cut messaging-only or future-proofing answers
- note "scope without a current caller" in the Avoid list

## Rationale

Review arcs on #147 (capacity) and #196 (remove-registry) showed late-cut complexity that a baseline-first, deletion-cost-aware brainstorm would have caught at design time: a cache no runtime consumer read, multi-provider scaffolding with one real provider, a 77-line frozen registry-id snapshot used only for message wording, and a mutation object with unused fields. The lesson: always solve with the simple and minimal solution, and treat deletion cost as a first-class criterion.

## Validation

- Markdown-only change; no code paths affected