### PR TITLE
docs(web): align onboarding with setup-then-init flow

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -19,7 +19,7 @@ const operatingLayer = [
   {
     label: ".ai-devkit.json",
     title: "One setup for the whole agent team",
-    body: "Reconcile supported coding agents from one project-local source of truth, then re-run setup as your stack changes.",
+    body: "Reconcile project integrations from one local source of truth, then re-run project installation as your configuration changes.",
   },
   {
     label: "agent console",
@@ -64,9 +64,8 @@ export default function Home() {
               Your AI coding agents are a team now. Give them a way to work together.
             </h1>
             <p className="mb-8 max-w-2xl text-base leading-6 text-[#515367] sm:text-[16px]">
-              AI DevKit is the control plane for Claude Code, Codex,
-              Cursor, Gemini CLI, opencode, Pi, and other coding agents: one
-              shared config, one console, local-first memory, cross-agent
+              AI DevKit is the control plane for supported AI coding agents:
+              one shared config, one console, local-first memory, cross-agent
               communication, and proof before done.
             </p>
             <p className="mb-5 max-w-2xl text-sm font-medium leading-5 text-[#2e303a]">
@@ -78,7 +77,12 @@ export default function Home() {
             </p>
 
             <div className="flex flex-col gap-3 sm:items-start">
-              <CopyCommandButton command="npx ai-devkit@latest init" />
+              <CopyCommandButton command="npx ai-devkit@latest setup" />
+              <p className="max-w-xl text-sm leading-5 text-[#515367]">
+                Run setup once on this machine. Then run{" "}
+                <span className="font-mono">npx ai-devkit@latest init</span>{" "}
+                inside each project.
+              </p>
               <Link
                 href="/docs"
                 className="text-sm font-semibold text-[#2a3e9a] no-underline hover:text-[#0c2483] hover:opacity-100"
@@ -223,22 +227,22 @@ export default function Home() {
         <div className="mx-auto grid max-w-[1440px] gap-10 px-4 sm:px-6 lg:grid-cols-[1fr_1fr] lg:px-10">
           <div className="min-w-0">
             <p className="mb-3 font-mono text-[11px] font-medium uppercase leading-4 text-[#14521a]">
-              Start in 30 seconds
+              Once per machine, once per project
             </p>
             <h2 className="text-[32px] font-semibold leading-[40px] text-[#11131c] sm:text-[48px] sm:leading-[56px]">
-              Create your agent control plane.
+              Connect your agents, then initialize your workflow.
             </h2>
             <p className="mt-5 max-w-xl text-base leading-6 text-[#515367]">
-              The init flow writes project-local files you can review and
-              commit. Re-run it whenever your agent list, skills, or workflow
-              changes.
+              Setup connects detected local agents and installs their global
+              workflow skills. Init writes project-local files you can review
+              and commit.
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
               <Link
                 href="/docs/1-getting-started"
                 className="inline-flex min-h-12 w-full items-center justify-center rounded bg-[#b3f6ab] px-6 py-3 text-sm font-semibold text-[#003909] no-underline hover:bg-[#96d68f] hover:opacity-100 sm:w-auto"
               >
-                Start with one command
+                Follow the two-step setup
               </Link>
               <GitHubButton
                 repo="codeaholicguy/ai-devkit"
@@ -254,11 +258,16 @@ export default function Home() {
               <span className="h-3 w-3 rounded-full bg-[#b3f6ab]" />
             </div>
             <pre className="m-0 max-w-full overflow-x-auto p-0 leading-5 sm:leading-[22px]">
-              <code className="block whitespace-pre-wrap break-words text-[#fff] sm:whitespace-pre">{`npx ai-devkit@latest init --built-in
-ai-devkit agent console
+              <code className="block whitespace-pre-wrap break-words text-[#fff] sm:whitespace-pre">{`# Once on this machine
+npm install -g ai-devkit
+ai-devkit setup
+
+# Once in each project
+ai-devkit init
 ai-devkit agent list
+ai-devkit agent console
 ai-devkit agent send "review this branch for release risk" --group reviewers
-npm test 2>&1 | ai-devkit agent send --id codex --stdin
+npm test 2>&1 | ai-devkit agent send --id <agent-id> --stdin
 ai-devkit memory search --query "testing convention"`}</code>
             </pre>
           </div>

--- a/web/content/docs/0-what-is-ai-devkit.md
+++ b/web/content/docs/0-what-is-ai-devkit.md
@@ -84,23 +84,27 @@ AI DevKit isn't tied to a single tool. It supports [many AI coding environments]
 
 Here's what working with AI DevKit looks like in practice:
 
-1. Run `npx ai-devkit@latest init` in your terminal to set up your project
-2. Open `ai-devkit agent console` to inspect local running agents
-3. Use `ai-devkit agent send` to route prompts, logs, or test output to the right session
-4. Ask an agent to use the `dev-lifecycle` skill to clarify requirements, design, and implementation tasks
-5. Use memory, `tdd`, and `verify` while implementing
-6. Require verification output before the agent claims the work is complete
+1. Run `npx ai-devkit@latest setup` once to connect detected local agents
+2. Run `npx ai-devkit@latest init` in each project to create its workflow configuration
+3. Use `agent list`, then open `agent console` to inspect local running agents
+4. Use `agent send` to route prompts, logs, or test output to the right session
+5. Ask an agent to use the `dev-lifecycle` skill to clarify requirements, design, and implementation tasks
+6. Use memory, `tdd`, and `verify` while implementing
+7. Require verification output before the agent claims the work is complete
 
-Each step produces documentation in `docs/ai/` that gives your AI full context for the next step.
+Project initialization and lifecycle work produce documentation in `docs/ai/`, giving agents durable context for later phases.
 
 ## How It Works
 
-1. **Initialize** - Run `npx ai-devkit@latest init` to set up your project with workflow docs and environment-specific agent configuration.
-2. **Operate** - Use `agent list`, `agent console`, and `agent send` to supervise and route work across running local agents.
-3. **Develop** - Ask the agent to use installed workflow skills such as `dev-lifecycle`, `tdd`, and `verify` so it follows the workflow instead of improvising in chat.
-4. **Remember** - Store important decisions and patterns in memory so they persist across sessions.
-5. **Extend** - Install skills to give your AI specialized knowledge for your stack and domain.
-6. **Add tools** - Install plugins when you want optional CLI commands such as dashboards or heavier integrations.
+1. **Connect** - Run `npx ai-devkit@latest setup` once per machine to connect detected agents and install their global workflow skills.
+2. **Initialize** - Run `npx ai-devkit@latest init` once per project to create workflow docs and environment-specific project configuration.
+3. **Operate** - Use `agent list`, `agent console`, and `agent send` to supervise and route work across running local agents.
+4. **Develop** - Ask the agent to use installed workflow skills such as `dev-lifecycle`, `tdd`, and `verify` so it follows the workflow instead of improvising in chat.
+5. **Remember** - Store important decisions and patterns in memory so they persist across sessions.
+6. **Extend** - Install skills to give your AI specialized knowledge for your stack and domain.
+7. **Add tools** - Install plugins when you want optional CLI commands such as dashboards or heavier integrations.
+
+See [Getting Started](/docs/1-getting-started) for global-install, npx-only, and CI commands.
 
 ## Who Is It For?
 

--- a/web/content/docs/1-getting-started.md
+++ b/web/content/docs/1-getting-started.md
@@ -1,94 +1,138 @@
 ---
 title: Getting Started
-description: Set up AI DevKit as a control plane for Claude Code, Codex, Cursor, opencode, and other AI coding agents.
+description: Connect your coding agents once, then initialize AI DevKit's workflow in each project.
 order: 1
 ---
 
-**AI DevKit** is a control plane for AI coding agents. It gives supported tools like Cursor, Claude Code, Codex, Gemini CLI, opencode, Pi, GitHub Copilot, and others one setup model, one console, local-first memory, cross-agent communication, workflow skills, and verification.
+**AI DevKit** gives your coding agents one operating layer for setup, supervision, communication, local-first memory, workflow skills, and verification.
 
-Use it when your AI coding setup has grown from one assistant into multiple agents, terminals, config files, and memory gaps. Initialize the project once, then give every supported coding agent the same operating model.
+Getting started has two scopes:
 
-Workflow skills are part of AI DevKit, but they are not the whole product. The bigger idea is one operating layer for setup, supervision, communication, local-first memory, and verification across the agents you already use.
+1. **Once per machine:** run `setup` to connect detected local agents, install their session integrations, and install AI DevKit's built-in skills globally.
+2. **Once per project:** run `init` to create `.ai-devkit.json`, environment-specific project files, and workflow documentation.
 
-## Why AI DevKit?
-
-When working with AI coding agents, you often find yourself:
-- Managing multiple terminal sessions with no shared control surface
-- Copy-pasting prompts, logs, and test output between agents
-- Repeating the same instructions across sessions
-- Losing context between conversations
-- Struggling to maintain consistency across tools and features
-
-AI DevKit solves these problems by giving your coding agents:
-- **One local setup** — `.ai-devkit.json` reconciles supported agent files from one source of truth
-- **Agent console** — See and supervise running local agent sessions
-- **Agent send** — Route prompts, logs, and stdin to the right running agent
-- **Local memory** — Decisions and patterns that persist across sessions
-- **Workflow skills** — Reusable process guidance tailored to multi-agent coding
-- **Skills** — Reusable instruction packs your agents can load for domain-specific work
-- **Plugins** — Optional npm packages that add CLI commands
-- **Verification gates** — Fresh evidence before completion claims
+Keeping these steps separate makes it clear which changes affect your machine and which files belong in your project.
 
 ## Prerequisites
 
 Before you begin, make sure you have:
-- **Node.js** (version 20.20.0 or higher)
-- **npm** or **npx** (comes with Node.js)
-- At least one supported AI coding agent or environment, such as Cursor, Claude Code, Codex, Gemini CLI, opencode, Pi, GitHub Copilot, Devin, or Antigravity
 
-## Installation
+- **Node.js 20.20.0 or newer**
+- **npm** or **npx**, which comes with Node.js
+- At least one [supported AI coding agent or environment](/docs/2-supported-agents)
 
-Install AI DevKit globally using npm:
+Install and launch your coding agent at least once before running `setup`. AI DevKit detects an agent from its home directory, so a newly installed agent that has never started may be reported as skipped.
+
+## Choose How to Run AI DevKit
+
+### Option 1: Install the CLI globally
+
+Install the command, then set up detected agents:
 
 ```bash
 npm install -g ai-devkit
+ai-devkit setup
 ```
 
-Or use it directly with npx (no installation required):
+`npm install -g ai-devkit` installs the CLI but does **not** run `setup` for you.
+
+In each project, run:
 
 ```bash
+cd your-project
+ai-devkit init
+```
+
+### Option 2: Use npx only
+
+You can use AI DevKit without installing a global command:
+
+```bash
+npx ai-devkit@latest setup
+```
+
+Then initialize each project with npx too:
+
+```bash
+cd your-project
 npx ai-devkit@latest init
 ```
 
-## Initialize Your Project
+An npx-only installation does not make a permanent `ai-devkit` command available. Prefix every later command with `npx ai-devkit@latest`, including `agent`, `lint`, `memory`, and `skill` commands.
 
-Navigate to your project directory and run:
+## What the Two Commands Do
+
+### Machine setup
+
+`setup` checks for supported agent home directories. For each detected agent, it installs the available session hook or tracker and the AI DevKit built-in skills in that agent's global skill location.
+
+Read the setup summary carefully. A skipped agent was not changed. If an agent you use is skipped, launch it once and rerun the same setup command.
+
+### Project initialization
+
+Run `init` from the root of the project you want to use:
 
 ```bash
-npx ai-devkit@latest init
+ai-devkit init
 ```
 
-You'll be prompted to select which AI environments you use (Cursor, Claude Code, etc.). AI DevKit will then:
+The interactive flow asks which project environments and workflow phases you want. It then:
 
-1. **Create workflow docs** — A configured AI docs directory, `docs/ai/` by default, for requirements, design, planning, implementation, and testing
-2. **Set up AI environment files** — Configuration, skills, and MCP servers where supported
-3. **Save your preferences** — Stored in `.ai-devkit.json` for future updates
+1. Creates `.ai-devkit.json` with your project choices.
+2. Creates environment-specific project templates.
+3. Creates workflow documents under `docs/ai/` by default.
 
-## First Value Moment
+If the directory is not already a Git repository and Git is available, `init` also initializes one.
 
-After initialization, open the local agent console:
+## Verify the First Run
 
-Start one supported coding agent in this project first, such as Claude Code, Codex, Gemini CLI, or opencode. Then run:
+Restart your coding agent after machine setup, then start an agent session in the initialized project. Check discovery before opening the console:
 
 ```bash
 ai-devkit agent list
+```
+
+If the session appears, open the local console:
+
+```bash
 ai-devkit agent console
 ```
 
-Then send one task or log stream to a running agent:
+Then try sending a small task to the ID shown by `agent list`:
 
 ```bash
-ai-devkit agent send "summarize current branch and test status" --id <agent-name>
-npm test 2>&1 | ai-devkit agent send --id <agent-name> --stdin
+ai-devkit agent send "summarize the current branch and test status" --id <agent-id>
 ```
 
-This is the core loop: see your agents, send work to the right session, and keep memory and verification available when the task needs them.
+For an npx-only setup, use the same sequence with the npx prefix:
+
+```bash
+npx ai-devkit@latest agent list
+npx ai-devkit@latest agent console
+npx ai-devkit@latest agent send "summarize the current branch and test status" --id <agent-id>
+```
+
+## CI and Non-Interactive Initialization
+
+CI normally needs project workflow artifacts, not local session hooks. Supply the project environment and phases explicitly, and use `--built-in` when CI needs project-local copies of the built-in skills:
+
+```bash
+npx -y ai-devkit@latest init \
+  --yes \
+  --environment <environment> \
+  --all \
+  --built-in
+```
+
+`init --built-in` is a CI and non-interactive convenience. For a normal local first run, use `setup` to install built-in skills globally.
+
+For a repeatable team configuration, you can use an [init template](/docs/9-agent-setup#template-based-setup) instead of listing every choice in the command.
 
 ## Project Structure
 
-After initialization, you'll have workflow docs your agent can use as durable context. The default path is `docs/ai/`; projects can customize it in `.ai-devkit.json`.
+The default workflow documentation path is `docs/ai/`. You can customize it during initialization or in `.ai-devkit.json`.
 
-```
+```text
 docs/ai/
 ├── requirements/    # What you're building and why
 ├── design/          # Architecture and technical decisions
@@ -99,58 +143,26 @@ docs/ai/
 └── monitoring/      # Monitoring and observability
 ```
 
-This structure gives your coding agents a clear handoff between phases instead of relying on chat history.
+These documents give agents durable context between phases instead of relying on chat history alone.
 
-## Using Skills
+## Try the Workflow
 
-AI DevKit installs **skills** into your AI environment. Skills are reusable capability packs the agent can load when your request matches a workflow or domain.
+After `agent list` finds your session, ask your coding agent:
 
-Terminal commands still start with `ai-devkit`; skills are used by the agent inside your coding assistant.
+> Use the dev-lifecycle skill to start requirements for a small feature.
 
-### Core Skills
-
-| Skill | Purpose |
-|---------|---------|
-| `dev-lifecycle` | Orchestrate worktree setup, requirements, design, planning, implementation, testing, and review |
-| `dev-worktree`, `dev-requirements`, `dev-design`, `dev-planning`, `dev-implementation`, `dev-testing`, `dev-review`, `dev-pr` | Run focused lifecycle and publish-for-review phases directly |
-| `dev-commit` | Commit only intended, verified changes with a conventional message |
-| `tdd` | Add or change behavior test-first |
-| `verify` | Require fresh command output before completion claims |
-| `structured-debug` | Debug issues with reproduction, hypotheses, fixes, and verification |
-| `document-code` | Document and understand existing code |
-| `memory` | Store and retrieve reusable project knowledge |
-
-For detailed usage, see [Development with AI DevKit](/docs/3-development-with-ai-devkit).
-
-## Quick Example
-
-Here's how a typical workflow might look:
-
-```
-1. In your terminal:
-   $ npx ai-devkit@latest init
-   $ ai-devkit agent console
-
-2. In your AI coding agent:
-   > Use the dev-lifecycle skill to start requirements for user authentication with OAuth
-
-   AI: "What feature would you like to build?"
-   You: "Add user authentication with OAuth"
-
-   AI guides you through requirements -> design -> planning -> implementation -> verification -> review
-```
+The installed workflow skills guide requirements, design, planning, implementation, testing, verification, and review. See [Development with AI DevKit](/docs/3-development-with-ai-devkit) for the full workflow.
 
 ## Next Steps
 
-1. **Explore your AI editor** — Ask the agent to use `dev-lifecycle` on a small feature
-2. **Open the agent console** — [Operate running agents](/docs/13-agent-console)
-3. **Read the workflows guide** — [Development with AI DevKit](/docs/3-development-with-ai-devkit)
-4. **Set up memory** — [Give your AI long-term memory](/docs/6-memory)
-5. **Install skills** — [Extend your AI's capabilities](/docs/7-skills) or [browse AI coding agent skills](/skills)
-6. **Install plugins** — [Add optional CLI commands](/docs/14-plugins)
+1. [Check environment-specific project support](/docs/2-supported-agents)
+2. [Learn how project init and install work](/docs/9-agent-setup)
+3. [Operate running agents](/docs/13-agent-console)
+4. [Give agents long-term memory](/docs/6-memory)
+5. [Manage skills](/docs/7-skills)
+6. [Install plugins](/docs/14-plugins)
 
 ## Need Help?
 
-- Check the [Supported Agents](/docs/2-supported-agents) page for environment-specific setup
-- Browse the [Roadmap](/roadmap) to see what's coming
-- Open an issue on [GitHub](https://github.com/Codeaholicguy/ai-devkit) for bugs or questions
+- If `npx` fails inside Codex, see [Codex sandbox troubleshooting](/faq/codex-sandbox-npx-troubleshooting).
+- Open an issue on [GitHub](https://github.com/Codeaholicguy/ai-devkit) for bugs or questions.

--- a/web/content/docs/10-dev-lifecycle-skill.md
+++ b/web/content/docs/10-dev-lifecycle-skill.md
@@ -47,20 +47,22 @@ That feedback loop is the main reason the workflow feels more senior and less ch
 
 ## Quick Setup
 
-Start by initializing AI DevKit in your project:
+Connect detected agents once on your machine:
 
-> **Where to run these commands:** Run `init`, `lint`, and `skill add` in your terminal from the root of your project.
+```bash
+npx ai-devkit@latest setup
+```
+
+Then initialize and lint the project:
+
+> **Where to run these commands:** Run `init` and `lint` in your terminal from the root of your project.
 
 ```bash
 npx ai-devkit@latest init
 npx ai-devkit@latest lint
 ```
 
-Then install the built-in skills. This includes `dev-lifecycle`, all phase skills, and supporting skills such as `memory`, `task`, `verify`, and `tdd`:
-
-```bash
-npx ai-devkit@latest skill add --built-in
-```
+Machine setup installs the built-in skills globally for detected agents. This includes `dev-lifecycle`, all phase skills, and supporting skills such as `memory`, `task`, `verify`, and `tdd`. Use `skill add --built-in` only for manual recovery or explicit skill management; use `init --built-in` for project-local installation in CI.
 
 These phase and supporting skills make `dev-lifecycle` effective:
 
@@ -78,7 +80,7 @@ Before running these commands, make sure you have:
 
 If `lint` fails because your AI docs have not been set up yet, rerun `init` and then run `lint` again.
 
-If you want more background on setup, see [Agent Setup](/docs/9-agent-setup). For skill management details, see [Skills](/docs/7-skills).
+For the global-install, npx-only, and CI paths, see [Getting Started](/docs/1-getting-started). For project configuration, see [Agent Setup](/docs/9-agent-setup). For manual skill management, see [Skills](/docs/7-skills).
 
 ## Important Dependencies
 

--- a/web/content/docs/11-configuration-file.md
+++ b/web/content/docs/11-configuration-file.md
@@ -7,6 +7,8 @@ order: 11
 
 AI DevKit stores your project settings in a `.ai-devkit.json` file at your project root. This file is created by `ai-devkit init` and read by most other commands.
 
+This is the project-scoped half of onboarding. Complete the machine setup first by following [Getting Started](/docs/1-getting-started).
+
 There is also an optional global config at `~/.ai-devkit/.ai-devkit.json` for settings that apply across all your projects.
 
 Use this page as a reference for fields inside `.ai-devkit.json`. In most cases, prefer AI DevKit commands such as `ai-devkit init`, `ai-devkit phase`, and `ai-devkit skill add` to update the file for you. Edit the JSON directly only when you need to make a manual change that is not covered by a command.

--- a/web/content/docs/2-supported-agents.md
+++ b/web/content/docs/2-supported-agents.md
@@ -6,6 +6,8 @@ order: 2
 
 AI DevKit works with a variety of AI coding agents and coding environments. This page lists supported environments and explains what AI DevKit installs for each one, so teams can keep setup, skills, memory, and verification consistent across tools.
 
+Before selecting project environments here, complete the once-per-machine setup in [Getting Started](/docs/1-getting-started).
+
 Support levels here describe setup and environment integration. Agent session discovery, `agent console`, and `agent send` depend on whether the local agent exposes a detectable running session. See [Agent Management](/docs/8-agent-management) and [Agent Console](/docs/13-agent-console) for the operational control-plane commands.
 
 ## Status Legend

--- a/web/content/docs/3-development-with-ai-devkit.md
+++ b/web/content/docs/3-development-with-ai-devkit.md
@@ -61,21 +61,21 @@ Use the `dev-lifecycle` skill to guide you through the entire workflow. The skil
 
 If you want the full setup, dependencies, and usage guide, see [Dev Lifecycle Skill](/docs/10-dev-lifecycle-skill).
 
-### Installing the skill
+### Installing the skills
 
-Install the built-in AI DevKit skills:
-
-```bash
-ai-devkit skill add --built-in
-```
-
-or
+The normal first-run path installs built-in skills globally when you connect detected agents:
 
 ```bash
-npx ai-devkit@latest skill add --built-in
+ai-devkit setup
 ```
 
-Once installed, the skill is immediately available to your AI agent. For more details on managing skills, see [Skills](/docs/7-skills).
+With npx only:
+
+```bash
+npx ai-devkit@latest setup
+```
+
+Launch your agent once before setup so AI DevKit can detect its home directory. For manual skill installation and recovery options, see [Skills](/docs/7-skills). For the complete machine and project sequence, see [Getting Started](/docs/1-getting-started).
 
 ### How to use it
 

--- a/web/content/docs/5-understand-existing-code-with-ai-devkit.md
+++ b/web/content/docs/5-understand-existing-code-with-ai-devkit.md
@@ -16,7 +16,7 @@ When joining a new project or working with unfamiliar code, understanding how ev
 ## Prerequisites
 
 Before using `document-code`, ensure you have:
-- Initialized AI DevKit in your project (`ai-devkit init`)
+- Completed the machine setup and project initialization in [Getting Started](/docs/1-getting-started)
 - An AI editor with skill support
 
 ## Using the Skill
@@ -148,7 +148,7 @@ These files can be committed to version control, making your knowledge base sear
 
 | Problem | Solution |
 |---------|----------|
-| Command not recognized | Run `ai-devkit init` first to install commands |
+| Command not recognized | Install the CLI globally, or prefix the command with `npx ai-devkit@latest` as described in [Getting Started](/docs/1-getting-started) |
 | Analysis seems incomplete | Try analyzing a smaller entry point first |
 | Diagrams not rendering | Ensure your editor supports Mermaid syntax |
 | Entry point not found | Check the path is relative to your project root |

--- a/web/content/docs/6-memory.md
+++ b/web/content/docs/6-memory.md
@@ -17,6 +17,8 @@ Before using Memory, ensure you have:
 - **AI DevKit CLI** installed: `npm install -g ai-devkit` or use `npx ai-devkit@latest`
 - For MCP usage: A compatible AI coding agent or environment (Cursor, Claude Code, etc.)
 
+If this is your first AI DevKit command, complete [Getting Started](/docs/1-getting-started) first. With npx only, prefix every CLI example below with `npx ai-devkit@latest`.
+
 ## How It Works
 
 You can interact with Memory in three ways:

--- a/web/content/docs/7-skills.md
+++ b/web/content/docs/7-skills.md
@@ -7,6 +7,8 @@ order: 7
 
 **Skills** are reusable instruction packs that extend what your AI coding agents can do. Each skill teaches an agent a specific workflow or domain practice, such as frontend design, database optimization, security review, or multi-agent coordination.
 
+The normal onboarding flow installs AI DevKit's built-in skills globally during machine setup. Complete [Getting Started](/docs/1-getting-started) first; use this page when you want to manage skills manually or add skills from another registry.
+
 > **Note:** AI DevKit reads your project configuration from `.ai-devkit.json`. If this file doesn't exist when you run `skill add`, you'll be prompted to select which AI environments to configure. Skills require at least one skill-capable environment (Cursor, Claude Code, GitHub Copilot, Codex, opencode, Antigravity, Junie, Cline, Devin, Grok, Pi, Kilo Code, or Roo Code).
 
 ## How Skills Work
@@ -54,16 +56,16 @@ For more detail on the core workflow skills, see the built-in skill pages for [`
 
 ## Quick Start
 
-Get up and running in 30 seconds:
+After machine setup, initialize the project and add the skill you want:
 
 ```bash
-# 1. Initialize ai-devkit in your project (if not already done)
+# 1. Initialize AI DevKit in your project (if not already done)
 ai-devkit init
 
 # 2. Install a skill from a registry
 ai-devkit skill add anthropics/skills frontend-design
 
-# 3. Done! Your AI agent can now use the skill.
+# 3. Your AI agent can now use the skill.
 ```
 
 Once installed, simply ask your AI agent to use the skill's capabilities—it will automatically apply the techniques and patterns defined in the skill.

--- a/web/content/docs/9-agent-setup.md
+++ b/web/content/docs/9-agent-setup.md
@@ -1,30 +1,44 @@
 ---
 title: Agent Setup
-description: Configure AI DevKit once and generate repeatable setup for Claude Code, Codex, Cursor, MCP servers, skills, memory, and workflow docs.
+description: Connect local agents once per machine and generate repeatable workflow configuration for each project.
 slug: agent-setup
 order: 9
 ---
 
-AI DevKit provides two commands for agent setup: `ai-devkit init` creates your project configuration (`.ai-devkit.json`), and `ai-devkit install` applies it to your workspace. Together they give you repeatable setup, easy onboarding, and consistent agent files after configuration changes.
+AI DevKit separates machine integration from project workflow configuration:
+
+1. Run `ai-devkit setup` once per machine. It connects detected local agents, installs their available session integrations, and installs built-in skills globally.
+2. Run `ai-devkit init` once per project. It creates `.ai-devkit.json`, workflow docs, and environment-specific project templates.
+3. Run `ai-devkit install` later when you need to reconcile installable project artifacts from `.ai-devkit.json`.
+
+Start with the complete [Getting Started flow](/docs/1-getting-started), including the separate global-install, npx-only, and CI paths.
 
 For teams adopting AI coding agents across multiple tools, this setup becomes the shared foundation of the control plane: one config that generates workflow docs, skills, MCP server files, and environment-specific instructions.
 
 Before running these commands:
-- Install AI DevKit (`npm install -g ai-devkit`) or use `npx ai-devkit@latest ...`
+- Install AI DevKit (`npm install -g ai-devkit`) and run `ai-devkit setup`, or use `npx ai-devkit@latest setup`
 - Run commands from your project root directory
 - Make sure you have permission to create or update agent-related files in the repository
 
+Global npm installation does not run `setup` automatically. If you use npx only, prefix every command on this page with `npx ai-devkit@latest`.
+
 Key concepts:
-- **Environment**: An AI coding tool you work with, such as Cursor, Claude Code, or Codex. AI DevKit generates the configuration files each environment expects.
+- **Environment**: An AI coding tool you use in the project. AI DevKit generates the configuration files each environment expects.
 - **Phase**: A stage of the software development lifecycle, such as requirements, design, or testing. AI DevKit provides document templates for each phase.
 
-## When to Use `install` vs `init`
+## When to Use `setup`, `init`, and `install`
+
+Use `ai-devkit setup` when:
+
+- You are connecting AI DevKit to agents on a machine for the first time
+- You installed or launched another supported agent and want AI DevKit to detect it
+- You need to restore global built-in skills or a session integration
 
 Use `ai-devkit init` when:
 - You are setting up AI DevKit in a project for the first time
 - You want interactive prompts to choose environments and phases
 - You want non-interactive bootstrap from a template file (`ai-devkit init --template`)
-- You want to install AI DevKit built-in skills (prompted interactively, or pass `--built-in` for CI)
+- You need project workflow docs and environment-specific templates
 
 Use `ai-devkit install` when:
 - `.ai-devkit.json` already exists
@@ -33,7 +47,7 @@ Use `ai-devkit install` when:
 
 ## Basic Usage
 
-The simplest way to get started is the interactive setup. This walks you through choosing environments, phases, and built-in skills:
+After completing machine setup, the simplest project path is interactive initialization. This walks you through choosing environments and phases:
 
 ```bash
 ai-devkit init
@@ -88,7 +102,7 @@ Once `.ai-devkit.json` is committed to your repository, teammates and CI pipelin
 ai-devkit install
 ```
 
-Each teammate still needs the AI DevKit CLI available locally, either from a global install (`npm install -g ai-devkit`) or by using `npx ai-devkit@latest install`.
+Each teammate still needs the AI DevKit CLI available locally. With a global installation, run `ai-devkit setup` once and then use `ai-devkit install`. With npx only, use `npx ai-devkit@latest setup` once and prefix the install command too: `npx ai-devkit@latest install`.
 
 ### Template-based Setup
 
@@ -160,17 +174,17 @@ After running `ai-devkit init --template`, MCP server definitions are saved to `
 
 *If omitted, `ai-devkit init` will prompt you to select them interactively. Required for fully non-interactive runs.
 
-## Built-in Skills
+## Built-in Skills in CI
 
-When running `ai-devkit init` interactively (without a template), you are prompted to install AI DevKit's built-in skills. In non-interactive environments such as CI, pass `--built-in` to install them automatically:
+For normal local onboarding, `ai-devkit setup` installs built-in skills globally for detected agents. In non-interactive environments such as CI, pass `--built-in` to `init` when the job needs project-local copies:
 
 ```bash
-ai-devkit init --environment cursor,claude --all --built-in
+ai-devkit init --yes --environment <environment> --all --built-in
 ```
 
-The `--all` flag selects all available phases. Combined with `--environment` and `--built-in`, this gives a fully non-interactive setup.
+The `--all` flag selects all available phases. Combined with `--yes`, `--environment`, and `--built-in`, this gives a fully non-interactive project initialization.
 
-When using a template with a `skills` section, skills from the template are installed from that configuration instead of using the interactive built-in skills prompt. In that case, avoid combining the template with `--built-in` unless you intentionally want built-in skills added separately.
+When using a template with a `skills` section, skills from the template are installed from that configuration. Avoid combining the template with `--built-in` unless you intentionally want built-in skills added separately.
 
 ## MCP Servers
 

--- a/web/content/faq/ai-devkit-codex-integration.md
+++ b/web/content/faq/ai-devkit-codex-integration.md
@@ -24,28 +24,29 @@ AI DevKit then uses that local mapping to list, inspect, open, and message activ
 
 ## How do I install it?
 
-From the AI DevKit repository root, create the Codex hooks directory and copy the hook script:
+Run the AI DevKit machine setup after you have launched Codex at least once:
 
 ```bash
-mkdir -p ~/.codex/hooks
-cp hooks/codex/hooks/codex-session-mapping.cjs ~/.codex/hooks/codex-session-mapping.cjs
+ai-devkit setup
 ```
 
-Then copy the AI DevKit Codex hook configuration:
+With npx only:
 
 ```bash
-cp hooks/codex/hooks.json ~/.codex/hooks.json
+npx ai-devkit@latest setup
 ```
 
-Restart Codex, then check what AI DevKit can see:
+Setup preserves existing hook entries while adding the AI DevKit session hook. Restart Codex, start a session, and check discovery before opening the console:
 
 ```bash
 ai-devkit agent list
 ```
 
-## What if I already have ~/.codex/hooks.json?
+For the complete setup-then-init sequence, see [Getting Started](/docs/1-getting-started).
 
-Do not overwrite an existing `~/.codex/hooks.json` if it contains other hooks you want to keep. Instead, merge this `SessionStart` entry into your existing `hooks` object:
+## Manual troubleshooting
+
+If `setup` reports a failed Codex hook step, verify that `~/.codex` exists and that you can write to it. As a recovery option, merge this `SessionStart` entry into the existing `hooks` object in `~/.codex/hooks.json`:
 
 ```json
 {
@@ -66,7 +67,7 @@ Do not overwrite an existing `~/.codex/hooks.json` if it contains other hooks yo
 }
 ```
 
-If your file already has a `SessionStart` array, add the object above to that array.
+If the file already has a `SessionStart` array, add the object above to that array. Copy `codex-session-mapping.cjs` from the AI DevKit package's Codex assets into `~/.codex/hooks/`, or rerun `setup` to install the matching script automatically. Do not replace an existing hooks file wholesale.
 
 ## When should I install it?
 
@@ -74,7 +75,7 @@ Install it if you use Codex with AI DevKit agent management features, especially
 
 ## Does this replace AI DevKit setup?
 
-No. The Codex hook improves Codex session visibility for AI DevKit. You should still initialize AI DevKit in your project when you want skills, memory, workflow docs, or other AI DevKit project configuration:
+No. Machine setup improves Codex session visibility and installs global skills. You should still initialize AI DevKit in each project when you want workflow docs and other project configuration:
 
 ```bash
 ai-devkit init

--- a/web/content/faq/ai-devkit-pi-integration.md
+++ b/web/content/faq/ai-devkit-pi-integration.md
@@ -4,13 +4,19 @@ description: How to improve AI DevKit's Pi session detection with the @ai-devkit
 order: 12
 ---
 
-AI DevKit can detect Pi sessions through its agent management system. For the most accurate Pi integration, install the dedicated Pi session tracker package:
+AI DevKit can detect Pi sessions through its agent management system. For the most accurate integration, launch Pi at least once and run the AI DevKit machine setup:
 
 ```bash
-pi install npm:@ai-devkit/pi-session-tracker
+ai-devkit setup
 ```
 
-Package page: https://pi.dev/packages/@ai-devkit/pi-session-tracker
+With npx only:
+
+```bash
+npx ai-devkit@latest setup
+```
+
+Setup installs the dedicated Pi session tracker and built-in AI DevKit skills for detected agents. For the complete setup-then-init sequence, see [Getting Started](/docs/1-getting-started).
 
 ## What does the Pi session tracker do?
 
@@ -30,9 +36,9 @@ Without the tracker, AI DevKit may still detect Pi through local processes, but 
 
 Install it if you use Pi with AI DevKit agent management features, especially if you want AI DevKit to more reliably list, inspect, or message your active Pi sessions.
 
-## How do I install it in Pi?
+## Manual troubleshooting
 
-Run this from Pi:
+If the Pi tracker step fails during `setup`, retry its underlying installation command:
 
 ```bash
 pi install npm:@ai-devkit/pi-session-tracker
@@ -46,7 +52,7 @@ ai-devkit agent list
 
 ## Does this replace AI DevKit setup?
 
-No. The Pi session tracker improves Pi session visibility for AI DevKit. You should still initialize AI DevKit in your project when you want skills, memory, workflow docs, or other AI DevKit project configuration:
+No. Machine setup improves Pi session visibility and installs global skills. You should still initialize AI DevKit in each project when you want workflow docs and other project configuration:
 
 ```bash
 ai-devkit init

--- a/web/content/faq/ai-devkit-vs-spec-kit.md
+++ b/web/content/faq/ai-devkit-vs-spec-kit.md
@@ -42,7 +42,9 @@ The main difference is what each tool focuses on:
 
 ```bash
 npm install -g ai-devkit
-npx ai-devkit@latest init
+ai-devkit setup
+cd your-project
+ai-devkit init
 # open your AI coding tool in this project folder
 Use the dev-lifecycle skill to start requirements for <feature>
 ```
@@ -73,7 +75,9 @@ AI DevKit is a **control plane for AI coding agents** that you install globally 
 
 ```bash
 npm install -g ai-devkit
-npx ai-devkit@latest init
+ai-devkit setup
+cd your-project
+ai-devkit init
 ```
 
 After initialization, your project gets a `docs/ai/` directory with subdirectories for requirements, design, planning, implementation, and testing. Your AI agent uses workflow skills such as `dev-lifecycle`, `tdd`, and `verify` to plan before code and review before push.
@@ -149,10 +153,12 @@ Ready to give your AI coding agents one control plane? Install AI DevKit and ini
 
 ```bash
 npm install -g ai-devkit
-npx ai-devkit@latest init
+ai-devkit setup
+cd your-project
+ai-devkit init
 ```
 
-Then ask the agent to use `dev-lifecycle` so it clarifies the feature before editing code, or explore the [documentation](https://ai-devkit.com/docs) to learn more.
+Then ask the agent to use `dev-lifecycle` so it clarifies the feature before editing code. See [Getting Started](https://ai-devkit.com/docs/1-getting-started) for the npx-only and CI paths.
 
 ## Sources
 

--- a/web/content/faq/ai-devkit-vs-superpowers.md
+++ b/web/content/faq/ai-devkit-vs-superpowers.md
@@ -36,7 +36,9 @@ These tools take different paths to fix that.
 
 ```bash
 npm install -g ai-devkit
-npx ai-devkit@latest init
+ai-devkit setup
+cd your-project
+ai-devkit init
 # then in your AI editor
 Use the dev-lifecycle skill to start requirements for <feature>
 ```
@@ -53,7 +55,9 @@ AI DevKit is a **control plane for AI coding agents** that you install globally 
 
 ```bash
 npm install -g ai-devkit
-npx ai-devkit@latest init
+ai-devkit setup
+cd your-project
+ai-devkit init
 ```
 
 After initialization, your project gets a `docs/ai/` directory with subdirectories for requirements, design, planning, implementation, and testing. Your AI agent uses workflow skills such as `dev-lifecycle`, `tdd`, and `verify` to plan before code and review before push.
@@ -132,10 +136,12 @@ Ready to give your AI coding agents one control plane? Install AI DevKit and ini
 
 ```bash
 npm install -g ai-devkit
-npx ai-devkit@latest init
+ai-devkit setup
+cd your-project
+ai-devkit init
 ```
 
-Then ask the agent to use `dev-lifecycle` so it clarifies the feature before editing code, or explore the [documentation](https://ai-devkit.com/docs) to learn more.
+Then ask the agent to use `dev-lifecycle` so it clarifies the feature before editing code. See [Getting Started](https://ai-devkit.com/docs/1-getting-started) for the npx-only and CI paths.
 
 ## Sources
 

--- a/web/content/faq/codex-sandbox-npx-troubleshooting.md
+++ b/web/content/faq/codex-sandbox-npx-troubleshooting.md
@@ -6,6 +6,8 @@ order: 10
 
 If you run `npx ai-devkit` inside Codex and hit permission or connectivity errors, this is usually a sandbox configuration issue.
 
+For the canonical npx-only command sequence, see [Getting Started](/docs/1-getting-started). Prefix every AI DevKit command with `npx ai-devkit@latest` when you do not have a global installation.
+
 ## Why this happens
 
 Codex runs in sandbox mode by default. That means it can be blocked from:


### PR DESCRIPTION
## Summary

- Reframes onboarding as setup once per machine, then init once per project.
- Rewrites Getting Started with global-install, npx-only, and CI happy paths plus first-run verification.
- Corrects overview, workflow, agent setup, integration, comparison, and reference pages that skipped setup or promoted built-in flags as the normal path.
- Keeps manual hook, tracker, and skill commands as troubleshooting or reference material.

## Accuracy audit addressed

| Previous claim | Correction |
| --- | --- |
| Init was the first command | Setup is the machine-level entry point; init is project-level. |
| Start with one command | Onboarding explicitly shows the two scopes. |
| Global npm install completed integrations | Docs state that npm installation does not run setup. |
| npx users could switch to a bare command | Every npx-only example retains the npx prefix. |
| Init built-ins was the normal path | The flag is limited to CI and non-interactive guidance. |
| Manual Codex and Pi integration was primary | Setup is primary; manual commands are troubleshooting. |

## Canonical flow

Global CLI: npm install globally, run setup once, then run init in each project.

npx only: run the latest setup command once, then run the latest init command in each project and keep the npx prefix for later commands.

CI: run init non-interactively with explicit environment and phases; request project-local built-ins only when needed.

## Validation

- npm run lint in web
- npm run build in web: compiled and generated 161 static pages
- docs consistency grep for removed one-command framing, unconditional init built-ins, and mixed global/npx sequences
- git diff check

## Risks

Documentation and homepage copy only; no CLI behavior changes.