### PR TITLE
feat(cli): complete init flow with shared project application service

### DIFF
--- a/docs/ai/design/2026-08-27-feature-init-complete.md
+++ b/docs/ai/design/2026-08-27-feature-init-complete.md
@@ -1,0 +1,57 @@
+---
+phase: design
+title: Complete Project Initialization Design
+description: Shared project application architecture for init and install
+---
+
+# Complete Project Initialization Design
+
+## Architecture
+
+```mermaid
+flowchart LR
+  I[init: collect desired state] --> C[Persist canonical config]
+  N[install: load desired state] --> A[Project application service]
+  C --> A
+  A --> E[Environment artifacts]
+  A --> P[Phase docs]
+  A --> S[Project skills]
+  A --> M[MCP target coordinator]
+  M --> G[Format generators]
+  A --> R[Shared report, copy, exit policy]
+```
+
+`init` owns the first-run outcome; `install` reconciles existing intent. Neither CLI handler calls the other.
+
+## Internal Contract
+
+```ts
+type ApplicationStatus = 'installed' | 'matched' | 'skipped' | 'conflict' | 'failed';
+interface ApplicationItemResult {
+  section: 'environment' | 'phase' | 'skill' | 'mcpServer';
+  name: string;
+  target?: string;
+  status: ApplicationStatus;
+  message?: string;
+}
+```
+
+The report is complete only without `conflict` or `failed`. Shared rendering and exit policy consume this contract.
+
+## Apply Order and Components
+
+1. Validate desired input.
+2. Persist `.ai-devkit.json`, registries, normalized skills, and MCP declarations.
+3. Apply environment templates.
+4. Create missing phases; overwrite only with approval or `--overwrite`.
+5. Apply project skills once.
+6. Group MCP environments by physical target and apply each once.
+7. Render one report and exit truthfully.
+
+Refactor `reconcileAndInstall` into this boundary. MCP generators retain format conversion and additive merge but expose target identity and parse errors. Claude/GitHub share a compatible `.mcp.json` writer. Existing unrelated servers and top-level keys remain preserved.
+
+## Reliability, Security, and Trade-offs
+
+Desired state is saved before side effects, allowing `install` to resume. Malformed MCP config fails without a write. Sequential application prevents concurrent target writes. No new shell execution, destructive MCP synchronization, data layer, flag, or speculative abstraction is introduced.
+
+Rejected alternatives: an MCP-only init path duplicates orchestration; mandatory `init && install` adds first-run load; calling `installCommand` from `initCommand` couples UI handlers and repeats work.

--- a/docs/ai/implementation/2026-08-27-feature-init-complete.md
+++ b/docs/ai/implementation/2026-08-27-feature-init-complete.md
@@ -1,0 +1,40 @@
+---
+phase: implementation
+title: Complete Project Initialization Implementation
+description: Implementation log for shared init/install application
+---
+
+# Complete Project Initialization Implementation
+
+## Development Setup
+
+- Worktree `.worktrees/feature-init-complete`, branch `feature-init-complete`, based on fetched `origin/main`.
+- `npm ci` completed.
+- Initial build failed in existing `packages/cli/src/util/config.ts`: Zod issue paths are `PropertyKey[]`, while `formatPath` accepts `(string | number)[]`.
+- Optional task tracing is unavailable.
+
+## Intended Structure
+
+- `services/install`: shared orchestration, item report, and exit policy.
+- `services/install/mcp`: target-aware merge and explicit parse failure.
+- `commands/init.ts`: selection/persistence followed by shared application.
+- `commands/install.ts`: validated load followed by the same service/renderer.
+- `__tests__`: TDD unit and real-filesystem public-flow coverage.
+
+## Implementation Log
+
+- Added a shared application report and renderer used by both commands. Required failures and unresolved MCP conflicts now exit 1.
+- Reworked `init` to persist normalized desired config, then call `reconcileAndInstall` once for environments, phases, skills, and MCP.
+- Existing phase docs are preserved by default; interactive callers can approve replacement and `--overwrite` bypasses prompts.
+- `SkillManager.addSkill` now distinguishes a new installation from an already matching target.
+- MCP reports carry per-server/target results, explicit non-interactive policy, and physical-target deduplication for Claude/GitHub `.mcp.json`.
+- All MCP readers now propagate malformed-file errors instead of treating corrupt files as empty.
+- Custom registries are persisted before skill resolution; config remains the resumable desired-state record.
+- Updated environment help and success/incomplete copy.
+- Added real-filesystem reconciliation tests across all seven supported MCP target files.
+
+Focused TDD evidence included intentional red failures followed by green runs for phase preservation, init MCP delegation, result/exit contracts, shared MCP targets, malformed config, skill matching, report rendering, registry ordering, and explicit non-interactive conflicts.
+
+## Deviations and Follow-ups
+
+No design deviations. The initial base TypeScript failure did not recur after deterministic package build; no unrelated source fix was required.

--- a/docs/ai/planning/2026-08-27-feature-init-complete.md
+++ b/docs/ai/planning/2026-08-27-feature-init-complete.md
@@ -1,0 +1,31 @@
+---
+phase: planning
+title: Complete Project Initialization Plan
+description: TDD task plan for shared project application
+---
+
+# Complete Project Initialization Plan
+
+## Milestone 1: Shared contracts
+
+- [x] Define item results and incomplete exit policy with focused tests.
+- [x] Refactor environment, phase, skill, and MCP work into one application service used by install.
+- [x] Add phase match/preserve/overwrite policy for interactive and CI paths.
+
+## Milestone 2: Complete init and MCP hardening
+
+- [x] Persist normalized desired skills and delegate init application once.
+- [x] Fail malformed MCP parsing without writes.
+- [x] Deduplicate shared physical MCP targets.
+- [x] Update truthful copy and stale environment help.
+
+## Milestone 3: Integration and closure
+
+- [x] Implement the testing document scenarios, using real filesystems where specified.
+- [x] Reconcile lifecycle docs and feature lint.
+- [x] Run build, full tests, and lint; perform design-alignment review.
+- [ ] Create logical conventional commits, rebase, push, and open the PR.
+
+## Dependencies and Risks
+
+Mock registry/network and prompt boundaries only. Existing install tests encode phase replacement and will change. A clean bootstrap exposed a base Zod `PropertyKey[]` compile mismatch; resolve minimally if still required. Task tracing is unavailable in CLI 0.55.0 (`unknown command 'task'`), so progress stays here.

--- a/docs/ai/requirements/2026-08-27-feature-init-complete.md
+++ b/docs/ai/requirements/2026-08-27-feature-init-complete.md
@@ -1,0 +1,42 @@
+---
+phase: requirements
+title: Complete Project Initialization
+description: Make init fully apply project configuration through the install reconciler
+---
+
+# Complete Project Initialization
+
+## Problem Statement
+
+`init --template` installs project skills and saves MCP definitions, but only `install` generates agent MCP files. It still reports success, leaving first-time users with partial setup and an unexpected configure/apply split.
+
+## Goals and Non-Goals
+
+- Make `init` completely apply supported project artifacts in one command.
+- Give `init` and `install` one shared service with `installed`, `matched`, `skipped`, `conflict`, and `failed` item states.
+- Preserve `setup` for machine scope and `install` for existing-config reconciliation.
+- Exit nonzero and use incomplete copy for failures or unresolved conflicts.
+- Preserve phase docs unless overwrite is approved; reject malformed MCP targets; write shared MCP targets once.
+- Keep every existing interface. Do not add `--no-install`/`--apply`, remove deleted MCP entries, or promise transactional rollback.
+
+## User Stories
+
+- A first-time user gets usable declared artifacts after `init`.
+- A template author gets consistent docs, skills, and MCP application.
+- A teammate or CI job converges committed configuration with `install`.
+- Existing user docs and agent settings survive unless replacement is authorized.
+
+## Success Criteria
+
+1. Template init generates all supported selected MCP files.
+2. Both commands share application logic and truthful results.
+3. `failed` or unresolved `conflict` exits 1; matching state exits 0.
+4. Template phase replacement prompts interactively or requires `--overwrite` non-interactively.
+5. Malformed MCP files remain untouched and fail application.
+6. Claude plus GitHub applies shared `.mcp.json` once.
+7. Existing flags remain compatible and environment help is accurate.
+8. Six-project build, full tests, and lint pass.
+
+## Constraints and Decisions
+
+Persist desired config and registries before environments, phases, skills, and MCP so partial work is resumable. Keep project template skills because machine setup covers only some agents and built-ins. Option C and these boundaries were approved on 2026-08-27; no open questions remain.

--- a/docs/ai/testing/2026-08-27-feature-init-complete.md
+++ b/docs/ai/testing/2026-08-27-feature-init-complete.md
@@ -1,0 +1,41 @@
+---
+phase: testing
+title: Complete Project Initialization Testing
+description: TDD and integration coverage for shared project application
+---
+
+# Complete Project Initialization Testing
+
+## Coverage Goal
+
+Cover every new shared-application and MCP coordination branch. Use real temporary filesystems for critical flows; mock registry/network and prompts.
+
+## Approved Scenarios
+
+- [x] Complete template init creates config/docs, delegates project skills, and creates all supported MCP target files.
+- [x] Plain interactive init applies accepted built-in skills.
+- [x] `--yes` performs no prompts, including MCP conflict handling.
+- [x] Second init/install reports matches without rewriting phase or MCP content.
+- [x] Existing phase docs survive install and template init by default.
+- [x] Interactive approval and `--overwrite` replace phase docs.
+- [x] MCP conflicts fail non-interactively unless `--overwrite` is passed.
+- [x] Malformed MCP files fail without replacement.
+- [x] Skill and MCP failures exit nonzero with incomplete copy.
+- [x] `--config` input is applied into the canonical project config by the shared service.
+- [x] Claude plus GitHub performs one coherent `.mcp.json` merge.
+- [x] Existing setup tests retain machine-global scope while init tests assert project application.
+- [x] Environment help no longer advertises the stale three-value set.
+
+## Regression Coverage
+
+- [x] Preserve unrelated MCP servers/top-level keys and additive deletion behavior.
+- [x] Preserve flags and `name`/`skill` config aliases.
+- [x] Installed/matched-only runs exit 0; required conflicts/failures exit 1.
+
+## Validation Evidence
+
+Focused service/command/MCP/SkillManager suites passed during TDD. A built-CLI smoke run of `init --template ... --yes` created config, requirements docs, and seven physical MCP target files in one command; rerun preserved the phase and matched all MCP files. Final workspace validation evidence is recorded after the final commands below.
+
+- `npm run build` — exit 0; Nx built all 6 projects.
+- `npm test` — exit 0; Nx tested all 6 projects: 154 files and 2,030 tests passed.
+- `npm run lint` — exit 0; Nx linted all 6 projects. Three pre-existing unused-catch warnings remain in untouched files (`memory/search.ts`, `cli/channel.ts`, `cli/util/skill.ts`); no errors or warnings in changed files.

--- a/e2e/cli.e2e.ts
+++ b/e2e/cli.e2e.ts
@@ -58,7 +58,7 @@ describe('init command', () => {
   it('should initialize with environment and all phases', () => {
     const result = run('init -e claude --all', { cwd: projectDir });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('AI DevKit initialized successfully');
+    expect(result.stdout).toContain('AI DevKit project initialized successfully!');
 
     // Config file should exist
     const configPath = join(projectDir, '.ai-devkit.json');
@@ -124,7 +124,7 @@ paths:
 
     const result = run(`init -t "${templatePath}"`, { cwd: projectDir });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('AI DevKit initialized successfully');
+    expect(result.stdout).toContain('AI DevKit project initialized successfully!');
   });
 
   it('should save template registries to config', () => {

--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -11,6 +11,8 @@ const {
   mockLoadInitTemplate,
   mockExecFileSync,
   mockIsInteractiveTerminal,
+  mockReconcileAndInstall,
+  mockGetInstallExitCode,
 } = vi.hoisted(() => ({
   mockConfigManager: {
     exists: vi.fn(),
@@ -18,6 +20,7 @@ const {
     create: vi.fn(),
     setEnvironments: vi.fn(),
     addPhase: vi.fn(),
+    update: vi.fn(),
   } as any,
   mockTemplateManager: {
     checkEnvironmentExists: vi.fn(),
@@ -41,11 +44,19 @@ const {
     success: vi.fn(),
     info: vi.fn(),
     text: vi.fn(),
+    summary: vi.fn(),
   } as any,
   mockConfirm: vi.fn() as any,
   mockLoadInitTemplate: vi.fn() as any,
   mockExecFileSync: vi.fn() as any,
   mockIsInteractiveTerminal: vi.fn() as any,
+  mockReconcileAndInstall: vi.fn() as any,
+  mockGetInstallExitCode: vi.fn() as any,
+}));
+
+vi.mock('../../services/install/install.service.js', () => ({
+  reconcileAndInstall: (...args: unknown[]) => mockReconcileAndInstall(...args),
+  getInstallExitCode: (...args: unknown[]) => mockGetInstallExitCode(...args)
 }));
 
 vi.mock('child_process', () => ({
@@ -98,6 +109,10 @@ function confirmCallsMatching(pattern: RegExp): any[] {
   );
 }
 
+function appliedConfig(): any {
+  return mockReconcileAndInstall.mock.calls.at(-1)?.[0];
+}
+
 describe('init command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -111,6 +126,7 @@ describe('init command', () => {
     mockConfigManager.create.mockResolvedValue({ environments: [], phases: [] });
     mockConfigManager.setEnvironments.mockResolvedValue(undefined);
     mockConfigManager.addPhase.mockResolvedValue(undefined);
+    mockConfigManager.update.mockResolvedValue({});
 
     mockTemplateManager.checkEnvironmentExists.mockResolvedValue(false);
     mockTemplateManager.setupMultipleEnvironments.mockResolvedValue(['AGENTS.md']);
@@ -125,6 +141,14 @@ describe('init command', () => {
     mockSkillManager.addSkill.mockResolvedValue(undefined);
     mockLoadInitTemplate.mockResolvedValue({});
     mockIsInteractiveTerminal.mockReturnValue(true);
+    mockReconcileAndInstall.mockResolvedValue({
+      environments: { installed: 1, skipped: 0, failed: 0 },
+      phases: { installed: 1, skipped: 0, failed: 0 },
+      skills: { installed: 0, skipped: 0, failed: 0 },
+      mcpServers: { installed: 1, skipped: 0, conflicts: 0, failed: 0 },
+      warnings: [], items: [], complete: true
+    });
+    mockGetInstallExitCode.mockReturnValue(0);
   });
 
   afterEach(() => {
@@ -132,6 +156,27 @@ describe('init command', () => {
   });
 
   describe('template mode', () => {
+    it('applies template MCP servers through the shared project application service', async () => {
+      mockLoadInitTemplate.mockResolvedValue({
+        environments: ['codex'],
+        phases: ['requirements'],
+        mcpServers: {
+          memory: { transport: 'stdio', command: 'npx', args: ['-y', '@ai-devkit/memory'] }
+        }
+      });
+
+      await initCommand({ template: './init.yaml' });
+
+      expect(mockReconcileAndInstall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environments: ['codex'],
+          phases: ['requirements'],
+          mcpServers: expect.objectContaining({ memory: expect.any(Object) })
+        }),
+        expect.objectContaining({ overwrite: undefined, nonInteractive: false })
+      );
+      expect(mockUi.info).not.toHaveBeenCalledWith(expect.stringContaining('Run `ai-devkit install`'));
+    });
     it('uses template values and installs multiple skills from same registry without prompts', async () => {
     mockLoadInitTemplate.mockResolvedValue({
       environments: ['codex'],
@@ -149,11 +194,14 @@ describe('init command', () => {
     expect(mockPhaseSelector.selectPhases).not.toHaveBeenCalled();
     expect(mockConfirm).not.toHaveBeenCalled();
 
-    expect(mockConfigManager.setEnvironments).toHaveBeenCalledWith(['codex']);
-    expect(mockTemplateManager.copyPhaseTemplate).toHaveBeenCalledTimes(2);
-    expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(2);
-    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(1, 'codeaholicguy/ai-devkit', 'debug');
-    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(2, 'codeaholicguy/ai-devkit', 'memory');
+    expect(appliedConfig()).toEqual(expect.objectContaining({
+      environments: ['codex'],
+      phases: ['requirements', 'design'],
+      skills: [
+        { registry: 'codeaholicguy/ai-devkit', name: 'debug' },
+        { registry: 'codeaholicguy/ai-devkit', name: 'memory' }
+      ]
+    }));
   });
 
   it('uses one skill manager for a mixed-registry template', async () => {
@@ -175,7 +223,8 @@ describe('init command', () => {
     expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(3, 'codeaholicguy/ai-devkit', 'memory');
   });
 
-  it('continues on skill failures and skips duplicate registry+skill entries', async () => {
+
+  it('deduplicates template skills before shared application', async () => {
     mockLoadInitTemplate.mockResolvedValue({
       environments: ['codex'],
       phases: ['requirements'],
@@ -186,17 +235,12 @@ describe('init command', () => {
       ]
     });
 
-    mockSkillManager.addSkill
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('network failed'));
-
     await initCommand({ template: './init.yaml' });
 
-    expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(2);
-    expect(mockUi.warning).toHaveBeenCalledWith('Skipped 1 duplicate skill entry(ies) from template.');
-    expect(mockUi.warning).toHaveBeenCalledWith(
-      '1 skill install(s) failed. Continuing with warnings as configured.'
-    );
+    expect(appliedConfig().skills).toEqual([
+      { registry: 'codeaholicguy/ai-devkit', name: 'debug' },
+      { registry: 'codeaholicguy/ai-devkit', name: 'memory' }
+    ]);
   });
 
   it('falls back to interactive selection when template omits environments and phases', async () => {
@@ -208,7 +252,7 @@ describe('init command', () => {
 
     expect(mockEnvironmentSelector.selectEnvironments).toHaveBeenCalledTimes(1);
     expect(mockPhaseSelector.selectPhases).toHaveBeenCalledTimes(1);
-    expect(mockSkillManager.addSkill).toHaveBeenCalledWith('codeaholicguy/ai-devkit', 'debug');
+    expect(appliedConfig().skills).toContainEqual({ registry: 'codeaholicguy/ai-devkit', name: 'debug' });
   });
 
   it('keeps existing interactive reconfigure prompt when no template is provided', async () => {
@@ -241,10 +285,10 @@ describe('init command', () => {
 
       await initCommand({ template: './init.yaml', builtIn: true });
 
-      expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(BUILTIN_SKILL_NAMES.length + 1);
-      expect(mockSkillManager.addSkill).toHaveBeenCalledWith(BUILTIN_SKILL_REGISTRY, 'debug');
+      expect(appliedConfig().skills).toHaveLength(BUILTIN_SKILL_NAMES.length + 1);
+      expect(appliedConfig().skills).toContainEqual({ registry: BUILTIN_SKILL_REGISTRY, name: 'debug' });
       for (const skill of BUILTIN_SKILL_NAMES) {
-        expect(mockSkillManager.addSkill).toHaveBeenCalledWith(BUILTIN_SKILL_REGISTRY, skill);
+        expect(appliedConfig().skills).toContainEqual({ registry: BUILTIN_SKILL_REGISTRY, name: skill });
       }
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
@@ -258,9 +302,9 @@ describe('init command', () => {
 
       await initCommand({ template: './init.yaml', builtIn: true });
 
-      expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(BUILTIN_SKILL_NAMES.length);
+      expect(appliedConfig().skills).toHaveLength(BUILTIN_SKILL_NAMES.length);
       for (const skill of BUILTIN_SKILL_NAMES) {
-        expect(mockSkillManager.addSkill).toHaveBeenCalledWith(BUILTIN_SKILL_REGISTRY, skill);
+        expect(appliedConfig().skills).toContainEqual({ registry: BUILTIN_SKILL_REGISTRY, name: skill });
       }
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
@@ -274,10 +318,7 @@ describe('init command', () => {
 
       await initCommand({});
 
-      const builtinCalls = mockSkillManager.addSkill.mock.calls.filter(
-        (call: unknown[]) => call[0] === 'codeaholicguy/ai-devkit'
-      );
-      expect(builtinCalls.length).toBeGreaterThan(0);
+      expect(appliedConfig().skills.length).toBeGreaterThan(0);
       expect(mockConfirm).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('Install AI DevKit built-in skills'),
@@ -308,13 +349,20 @@ describe('init command', () => {
       expect(builtinPrompts).toHaveLength(0);
     });
 
-    it('continues init when built-in skill install fails', async () => {
+    it('reports incomplete init when shared skill application fails', async () => {
       mockConfirm.mockResolvedValueOnce(true);
-      mockSkillManager.addSkill.mockRejectedValue(new Error('network down'));
+      mockReconcileAndInstall.mockResolvedValue({
+        environments: { installed: 1, skipped: 0, failed: 0 },
+        phases: { installed: 1, skipped: 0, failed: 0 },
+        skills: { installed: 0, skipped: 0, failed: 1 },
+        mcpServers: { installed: 0, skipped: 0, conflicts: 0, failed: 0 },
+        warnings: ['network down'], items: [], complete: false
+      });
+      mockGetInstallExitCode.mockReturnValue(1);
 
       await expect(initCommand({})).resolves.toBeUndefined();
-      expect(mockSkillManager.addSkill).toHaveBeenCalledWith('codeaholicguy/ai-devkit', expect.any(String));
-      expect(process.exitCode).not.toBe(1);
+      expect(process.exitCode).toBe(1);
+      expect(mockUi.warning).toHaveBeenCalledWith(expect.stringContaining('setup is incomplete'));
     });
   });
 
@@ -339,10 +387,7 @@ describe('init command', () => {
 
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
-      const builtinCalls = mockSkillManager.addSkill.mock.calls.filter(
-        (call: unknown[]) => call[0] === 'codeaholicguy/ai-devkit'
-      );
-      expect(builtinCalls.length).toBeGreaterThan(0);
+      expect(appliedConfig().skills.length).toBeGreaterThan(0);
     });
 
     it('installs built-in skills without prompting when --built-in is passed in an interactive environment', async () => {
@@ -352,14 +397,21 @@ describe('init command', () => {
 
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
-      const builtinCalls = mockSkillManager.addSkill.mock.calls.filter(
-        (call: unknown[]) => call[0] === 'codeaholicguy/ai-devkit'
-      );
-      expect(builtinCalls.length).toBeGreaterThan(0);
+      expect(appliedConfig().skills.length).toBeGreaterThan(0);
     });
   });
 
   describe('non-interactive (--yes)', () => {
+    it('does not issue any prompts for a complete non-interactive run', async () => {
+      await initCommand({ yes: true, all: true, environment: 'claude' });
+
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockEnvironmentSelector.selectEnvironments).not.toHaveBeenCalled();
+      expect(mockPhaseSelector.selectPhases).toHaveBeenCalledWith(true, undefined);
+      expect(mockReconcileAndInstall).toHaveBeenCalledWith(
+        expect.any(Object), expect.objectContaining({ nonInteractive: true })
+      );
+    });
     it('exits 1 with a clear error when --yes is passed without -e (and no template)', async () => {
       await initCommand({ yes: true, all: true });
 
@@ -410,7 +462,7 @@ describe('init command', () => {
       await initCommand({ yes: true, overwrite: true, all: true, environment: 'claude' });
 
       expect(mockEnvironmentSelector.confirmOverride).not.toHaveBeenCalled();
-      expect(mockTemplateManager.setupMultipleEnvironments).toHaveBeenCalled();
+      expect(mockReconcileAndInstall).toHaveBeenCalled();
       expect(mockUi.warning).toHaveBeenCalledWith(
         expect.stringMatching(/Overwriting existing environments/)
       );
@@ -424,7 +476,10 @@ describe('init command', () => {
       const overwritePrompts = confirmCallsMatching(/already exists\. Overwrite\?/);
       expect(overwritePrompts).toHaveLength(0);
       expect(mockTemplateManager.copyPhaseTemplate).not.toHaveBeenCalled();
-      expect(mockUi.warning).toHaveBeenCalledWith(expect.stringMatching(/Skipped .* phase/));
+      expect(mockReconcileAndInstall).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+        overwrite: undefined,
+        nonInteractive: true
+      }));
     });
 
     it('overwrites existing phase files under --yes --overwrite (no prompt)', async () => {
@@ -434,7 +489,10 @@ describe('init command', () => {
 
       const overwritePrompts = confirmCallsMatching(/already exists\. Overwrite\?/);
       expect(overwritePrompts).toHaveLength(0);
-      expect(mockTemplateManager.copyPhaseTemplate).toHaveBeenCalled();
+      expect(mockReconcileAndInstall).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+        overwrite: true,
+        nonInteractive: true
+      }));
     });
 
     it('skips the built-in skills install under --yes without --built-in (TTY attached)', async () => {
@@ -452,10 +510,7 @@ describe('init command', () => {
 
       await initCommand({ yes: true, builtIn: true, all: true, environment: 'claude' });
 
-      const builtinCalls = mockSkillManager.addSkill.mock.calls.filter(
-        (call: unknown[]) => call[0] === 'codeaholicguy/ai-devkit'
-      );
-      expect(builtinCalls.length).toBeGreaterThan(0);
+      expect(appliedConfig().skills.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -204,7 +204,7 @@ describe('init command', () => {
     }));
   });
 
-  it('uses one skill manager for a mixed-registry template', async () => {
+  it('delegates mixed-registry application to the shared install service', async () => {
     mockLoadInitTemplate.mockResolvedValue({
       environments: ['codex'],
       phases: ['requirements'],
@@ -217,10 +217,12 @@ describe('init command', () => {
 
     await initCommand({ template: './init.yaml' });
 
-    expect(SkillManager).toHaveBeenCalledTimes(1);
-    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(1, 'codeaholicguy/ai-devkit', 'debug');
-    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(2, 'anthropics/skills', 'frontend-design');
-    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(3, 'codeaholicguy/ai-devkit', 'memory');
+    expect(mockReconcileAndInstall).toHaveBeenCalledTimes(1);
+    expect(appliedConfig().skills).toEqual([
+      { registry: 'codeaholicguy/ai-devkit', name: 'debug' },
+      { registry: 'anthropics/skills', name: 'frontend-design' },
+      { registry: 'codeaholicguy/ai-devkit', name: 'memory' },
+    ]);
   });
 
 
@@ -308,7 +310,6 @@ describe('init command', () => {
       }
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
-      expect(SkillManager).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/cli/src/__tests__/commands/install.test.ts
+++ b/packages/cli/src/__tests__/commands/install.test.ts
@@ -50,8 +50,10 @@ describe('install command', () => {
       environments: { installed: 1, skipped: 0, failed: 0 },
       phases: { installed: 1, skipped: 0, failed: 0 },
       skills: { installed: 1, skipped: 0, failed: 0 },
-      mcpServers: { installed: 0, skipped: 0, conflicts: 0, failed: 0 },
-      warnings: []
+      mcpServers: { installed: 0, skipped: 0, conflicts: 0, failed: 0, items: [] },
+      warnings: [],
+      items: [{ section: 'environment', name: 'codex', status: 'installed' }],
+      complete: true
     });
   });
 
@@ -111,6 +113,24 @@ describe('install command', () => {
     );
     expect(mockUi.summary).toHaveBeenCalled();
     expect(process.exitCode).toBe(0);
+  });
+
+  it('loads a custom desired config and applies it through the canonical project service', async () => {
+    mockLoadConfigFile.mockResolvedValue({
+      configPath: '/project/team.json',
+      data: {}
+    });
+    mockLoadAndValidateInstallConfig.mockReturnValue({
+      environments: ['codex'], phases: [], registries: {}, skills: [], mcpServers: {}
+    });
+
+    await installCommand({ config: './team.json' });
+
+    expect(mockLoadConfigFile).toHaveBeenCalledWith('./team.json');
+    expect(mockReconcileAndInstall).toHaveBeenCalledWith(
+      expect.objectContaining({ environments: ['codex'] }),
+      { overwrite: undefined }
+    );
   });
 
   it('fails with non-zero exit code when reconcile step throws', async () => {

--- a/packages/cli/src/__tests__/lib/SkillManager.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillManager.test.ts
@@ -224,7 +224,9 @@ describe("SkillManager", () => {
     };
 
     it("should successfully add a skill", async () => {
-      await skillManager.addSkill(mockRegistryId, mockSkillName);
+      const status = await skillManager.addSkill(mockRegistryId, mockSkillName);
+
+      expect(status).toBe("matched");
 
       expect(mockedSkillUtil.validateRegistryId).toHaveBeenCalledWith(
         mockRegistryId,
@@ -302,7 +304,6 @@ describe("SkillManager", () => {
       });
 
       await skillManager.addSkill(mockRegistryId, mockSkillName);
-
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("registry.json")
       );
@@ -555,8 +556,9 @@ describe("SkillManager", () => {
     it("should skip if skill already exists in target", async () => {
       (mockedFs.pathExists as any).mockResolvedValue(true);
 
-      await skillManager.addSkill(mockRegistryId, mockSkillName);
+      const status = await skillManager.addSkill(mockRegistryId, mockSkillName);
 
+      expect(status).toBe("matched");
       expect(mockedFs.symlink).not.toHaveBeenCalled();
       expect(mockedFs.copy).not.toHaveBeenCalled();
       expect(console.log).toHaveBeenCalledWith(

--- a/packages/cli/src/__tests__/services/install/install-report.test.ts
+++ b/packages/cli/src/__tests__/services/install/install-report.test.ts
@@ -1,0 +1,35 @@
+const mockUi = vi.hoisted(() => ({
+  summary: vi.fn(),
+  warning: vi.fn(),
+  text: vi.fn(),
+}));
+
+vi.mock('../../../util/terminal-ui.js', () => ({ ui: mockUi }));
+
+import { renderApplicationReport } from '../../../services/install/install-report.js';
+
+describe('application report renderer', () => {
+  it('renders matched states and incomplete failures truthfully', () => {
+    renderApplicationReport({
+      environments: { installed: 0, skipped: 0, failed: 0 },
+      phases: { installed: 0, skipped: 1, failed: 0 },
+      skills: { installed: 0, skipped: 1, failed: 0 },
+      mcpServers: { installed: 0, skipped: 1, conflicts: 0, failed: 1, items: [] },
+      warnings: [],
+      items: [
+        { section: 'skill', name: 'verify', status: 'matched' },
+        { section: 'mcpServer', name: 'memory', status: 'failed', message: 'bad TOML' }
+      ],
+      complete: false
+    }, 'Initialization Summary');
+
+    expect(mockUi.summary).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Initialization Summary',
+      items: expect.arrayContaining([
+        expect.objectContaining({ label: 'artifact(s) already matched', count: 1 }),
+        expect.objectContaining({ label: 'artifact(s) failed', count: 1 })
+      ])
+    }));
+    expect(mockUi.warning).toHaveBeenCalledWith(expect.stringContaining('memory: bad TOML'));
+  });
+});

--- a/packages/cli/src/__tests__/services/install/install.integration.test.ts
+++ b/packages/cli/src/__tests__/services/install/install.integration.test.ts
@@ -1,0 +1,118 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { reconcileAndInstall } from '../../../services/install/install.service.js';
+
+describe('project application integration', () => {
+  let projectRoot: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ai-devkit-install-'));
+    process.chdir(projectRoot);
+    await fs.writeJson(path.join(projectRoot, '.ai-devkit.json'), {
+      version: 'test',
+      environments: ['claude', 'github', 'codex', 'junie', 'devin', 'roo', 'kilocode', 'opencode'],
+      phases: ['requirements'],
+      createdAt: new Date(0).toISOString(),
+      mcpServers: {
+        memory: { transport: 'stdio', command: 'npx', args: ['-y', '@ai-devkit/memory'] }
+      }
+    });
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.remove(projectRoot);
+  });
+
+  it('creates project docs and MCP config, then matches without rewriting them', async () => {
+    const desired = {
+      environments: [
+        'claude' as const, 'github' as const, 'codex' as const, 'junie' as const,
+        'devin' as const, 'roo' as const, 'kilocode' as const, 'opencode' as const
+      ],
+      phases: ['requirements' as const],
+      registries: {},
+      skills: [],
+      mcpServers: {
+        memory: { transport: 'stdio' as const, command: 'npx', args: ['-y', '@ai-devkit/memory'] }
+      }
+    };
+
+    const first = await reconcileAndInstall(desired, { nonInteractive: true });
+    const phasePath = path.join(projectRoot, 'docs/ai/requirements/README.md');
+    const mcpPath = path.join(projectRoot, '.codex/config.toml');
+    const firstPhase = await fs.readFile(phasePath, 'utf8');
+    const firstMcp = await fs.readFile(mcpPath, 'utf8');
+    const mcpTargets = [
+      '.mcp.json', '.codex/config.toml', '.junie/mcp/mcp.json', '.devin/config.json',
+      '.roo/mcp.json', '.kilo/kilo.jsonc', 'opencode.json'
+    ];
+
+    const second = await reconcileAndInstall(desired, { nonInteractive: true });
+
+    expect(first.complete).toBe(true);
+    for (const target of mcpTargets) {
+      expect(await fs.pathExists(path.join(projectRoot, target))).toBe(true);
+    }
+    expect(first.mcpServers.installed).toBe(mcpTargets.length);
+    expect(first.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ section: 'phase', status: 'installed' }),
+      expect.objectContaining({ section: 'mcpServer', status: 'installed' })
+    ]));
+    expect(second.complete).toBe(true);
+    expect(second.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ section: 'phase', status: 'skipped' }),
+      expect.objectContaining({ section: 'mcpServer', status: 'matched' })
+    ]));
+    expect(await fs.readFile(phasePath, 'utf8')).toBe(firstPhase);
+    expect(await fs.readFile(mcpPath, 'utf8')).toBe(firstMcp);
+  });
+
+  it('fails malformed MCP targets without replacing them', async () => {
+    const mcpPath = path.join(projectRoot, '.codex/config.toml');
+    await fs.ensureDir(path.dirname(mcpPath));
+    await fs.writeFile(mcpPath, 'invalid [[[');
+
+    const report = await reconcileAndInstall({
+      environments: ['codex'],
+      phases: [],
+      registries: {},
+      skills: [],
+      mcpServers: { memory: { transport: 'stdio', command: 'npx' } }
+    }, { nonInteractive: true });
+
+    expect(report.complete).toBe(false);
+    expect(report.items).toContainEqual(expect.objectContaining({
+      section: 'mcpServer', status: 'failed'
+    }));
+    expect(await fs.readFile(mcpPath, 'utf8')).toBe('invalid [[[');
+  });
+
+  it('fails non-interactive MCP conflicts and resolves them with overwrite', async () => {
+    const mcpPath = path.join(projectRoot, '.codex/config.toml');
+    await fs.ensureDir(path.dirname(mcpPath));
+    await fs.writeFile(mcpPath, '[mcp_servers.memory]\ncommand = "old"\n');
+    const desired = {
+      environments: ['codex' as const],
+      phases: [],
+      registries: {},
+      skills: [],
+      mcpServers: { memory: { transport: 'stdio' as const, command: 'new' } }
+    };
+
+    const conflict = await reconcileAndInstall(desired, { nonInteractive: true });
+    expect(conflict.complete).toBe(false);
+    expect(conflict.items).toContainEqual(expect.objectContaining({ status: 'conflict' }));
+    expect(await fs.readFile(mcpPath, 'utf8')).toContain('command = "old"');
+
+    const resolved = await reconcileAndInstall(desired, {
+      nonInteractive: true,
+      overwrite: true
+    });
+    expect(resolved.complete).toBe(true);
+    expect(await fs.readFile(mcpPath, 'utf8')).toContain('command = "new"');
+  });
+});

--- a/packages/cli/src/__tests__/services/install/install.service.test.ts
+++ b/packages/cli/src/__tests__/services/install/install.service.test.ts
@@ -1,6 +1,7 @@
 
 
 const mockConfirm: any = vi.fn();
+const mockIsInteractiveTerminal: any = vi.fn();
 
 const mockConfigManager: any = {
   read: vi.fn(),
@@ -23,6 +24,10 @@ const mockSkillManager: any = {
 
 vi.mock('@inquirer/prompts', () => ({
   confirm: (...args: unknown[]) => mockConfirm(...args)
+}));
+
+vi.mock('../../../util/terminal.js', () => ({
+  isInteractiveTerminal: () => mockIsInteractiveTerminal()
 }));
 
 vi.mock('../../../lib/Config.js', () => ({
@@ -75,6 +80,7 @@ describe('install service', () => {
 
     mockSkillManager.addSkill.mockResolvedValue(undefined);
     mockConfirm.mockResolvedValue(false);
+    mockIsInteractiveTerminal.mockReturnValue(true);
   });
 
   it('installs all sections on happy path', async () => {
@@ -85,10 +91,17 @@ describe('install service', () => {
       phases: ['requirements'],
       skills: [{ registry: 'codeaholicguy/ai-devkit', name: 'debug' }],
     });
-    expect(report.environments.installed).toBe(1);
+    expect(report.environments.installed).toBe(0);
+    expect(report.environments.skipped).toBe(1);
     expect(report.phases.installed).toBe(1);
     expect(report.skills.installed).toBe(1);
     expect(report.warnings).toEqual([]);
+    expect(report.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ section: 'environment', name: 'codex', status: 'matched' }),
+      expect.objectContaining({ section: 'phase', name: 'requirements', status: 'installed' }),
+      expect.objectContaining({ section: 'skill', name: 'debug', status: 'installed' })
+    ]));
+    expect(report.complete).toBe(true);
   });
 
   it('uses one skill manager while reconciling mixed registries', async () => {
@@ -108,7 +121,8 @@ describe('install service', () => {
     expect(report.skills.installed).toBe(3);
   });
 
-  it('reinstalls existing generated artifacts without prompting for overwrite', async () => {
+
+  it('preserves existing phase documents when overwrite is declined', async () => {
     mockTemplateManager.checkEnvironmentExists
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true);
@@ -119,17 +133,31 @@ describe('install service', () => {
 
     const report = await reconcileAndInstall(installConfig, {});
 
-    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockConfirm).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('Requirements')
+    }));
     expect(mockTemplateManager.checkEnvironmentExists).not.toHaveBeenCalled();
-    expect(mockTemplateManager.fileExists).not.toHaveBeenCalled();
-    expect(report.environments.installed).toBe(1);
-    expect(report.phases.installed).toBe(1);
+    expect(mockTemplateManager.fileExists).toHaveBeenCalledWith('requirements');
+    expect(report.environments.installed).toBe(0);
+    expect(report.phases.installed).toBe(0);
+    expect(report.phases.skipped).toBe(1);
     expect(report.skills.installed).toBe(1);
     expect(mockConfigManager.update).toHaveBeenCalledWith({
       environments: ['codex'],
       phases: ['requirements'],
       skills: [{ registry: 'codeaholicguy/ai-devkit', name: 'debug' }],
     });
+  });
+
+  it('preserves existing phase documents without prompting in non-interactive mode', async () => {
+    mockIsInteractiveTerminal.mockReturnValue(false);
+    mockTemplateManager.fileExists.mockResolvedValue(true);
+
+    const report = await reconcileAndInstall(installConfig, {});
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockTemplateManager.copyPhaseTemplate).not.toHaveBeenCalled();
+    expect(report.phases.skipped).toBe(1);
   });
 
   it('auto-overwrites and does not prompt when --overwrite is set', async () => {
@@ -143,7 +171,7 @@ describe('install service', () => {
     const report = await reconcileAndInstall(installConfig, { overwrite: true });
 
     expect(mockConfirm).not.toHaveBeenCalled();
-    expect(report.environments.installed).toBe(1);
+    expect(report.environments.installed).toBe(0);
     expect(report.phases.installed).toBe(1);
   });
 
@@ -164,6 +192,21 @@ describe('install service', () => {
     );
   });
 
+  it('persists custom registries before installing skills that may consume them', async () => {
+    await reconcileAndInstall({
+      ...installConfig,
+      registries: { team: 'https://example.com/team-skills.git' },
+      skills: [{ registry: 'team', name: 'review' }]
+    }, {});
+
+    expect(mockConfigManager.update).toHaveBeenCalledWith(expect.objectContaining({
+      registries: { team: 'https://example.com/team-skills.git' }
+    }));
+    expect(mockConfigManager.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSkillManager.addSkill.mock.invocationCallOrder[0]
+    );
+  });
+
   it('reports skill failures as warnings and continues', async () => {
     mockSkillManager.addSkill.mockRejectedValue(new Error('network down'));
 
@@ -173,7 +216,14 @@ describe('install service', () => {
     expect(report.warnings).toEqual([
       'Skill codeaholicguy/ai-devkit/debug failed: network down'
     ]);
-    expect(getInstallExitCode(report)).toBe(0);
+    expect(report.items).toContainEqual(expect.objectContaining({
+      section: 'skill', name: 'debug', status: 'failed'
+    }));
+    expect(report.complete).toBe(false);
+    expect(getInstallExitCode(report)).toBe(1);
+    expect(mockConfigManager.update).toHaveBeenCalledWith(expect.objectContaining({
+      skills: installConfig.skills
+    }));
   });
 
   it('returns non-zero exit code when environment or phase failures occur', () => {
@@ -183,6 +233,20 @@ describe('install service', () => {
       skills: { installed: 0, skipped: 0, failed: 0 },
       mcpServers: { installed: 0, skipped: 0, conflicts: 0, failed: 0 },
       warnings: []
+    };
+
+    expect(getInstallExitCode(report)).toBe(1);
+  });
+
+  it('returns non-zero exit code for unresolved MCP conflicts', () => {
+    const report = {
+      environments: { installed: 0, skipped: 0, failed: 0 },
+      phases: { installed: 0, skipped: 0, failed: 0 },
+      skills: { installed: 0, skipped: 0, failed: 0 },
+      mcpServers: { installed: 0, skipped: 0, conflicts: 1, failed: 0 },
+      warnings: [],
+      items: [{ section: 'mcpServer' as const, name: 'memory', status: 'conflict' as const }],
+      complete: false
     };
 
     expect(getInstallExitCode(report)).toBe(1);

--- a/packages/cli/src/__tests__/services/install/mcp/ClaudeCodeMcpGenerator.test.ts
+++ b/packages/cli/src/__tests__/services/install/mcp/ClaudeCodeMcpGenerator.test.ts
@@ -86,7 +86,7 @@ describe('ClaudeCodeMcpGenerator', () => {
       expect(plan.skippedServers).toEqual(['notion']);
     });
 
-    it('handles malformed existing .mcp.json gracefully', async () => {
+    it('fails malformed existing .mcp.json without replacing it', async () => {
       mockFs.pathExists.mockResolvedValue(true as never);
       mockFs.readJson.mockRejectedValue(new Error('Invalid JSON'));
 
@@ -94,8 +94,8 @@ describe('ClaudeCodeMcpGenerator', () => {
         memory: { transport: 'stdio', command: 'npx' }
       };
 
-      const plan = await generator.plan(servers, projectRoot);
-      expect(plan.newServers).toEqual(['memory']);
+      await expect(generator.plan(servers, projectRoot)).rejects.toThrow('Invalid JSON');
+      expect(mockFs.writeJson).not.toHaveBeenCalled();
     });
 
     it('handles mixed new, skip, and conflict servers', async () => {

--- a/packages/cli/src/__tests__/services/install/mcp/CodexMcpGenerator.test.ts
+++ b/packages/cli/src/__tests__/services/install/mcp/CodexMcpGenerator.test.ts
@@ -67,7 +67,7 @@ command = "old-cmd"
       expect(plan.conflictServers).toEqual(['memory']);
     });
 
-    it('handles malformed existing config.toml gracefully', async () => {
+    it('fails malformed existing config.toml without replacing it', async () => {
       mockFs.pathExists.mockResolvedValue(true as never);
       mockFs.readFile.mockResolvedValue('this is not valid toml [[[' as never);
 
@@ -75,8 +75,8 @@ command = "old-cmd"
         memory: { transport: 'stdio', command: 'npx' }
       };
 
-      const plan = await generator.plan(servers, projectRoot);
-      expect(plan.newServers).toEqual(['memory']);
+      await expect(generator.plan(servers, projectRoot)).rejects.toThrow();
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/__tests__/services/install/mcp/McpConfigGenerator.test.ts
+++ b/packages/cli/src/__tests__/services/install/mcp/McpConfigGenerator.test.ts
@@ -10,8 +10,10 @@ vi.mock('@inquirer/prompts', () => ({
 }));
 
 const mockHasMcpSupport = vi.fn();
+const mockGetMcpConfigPath = vi.fn();
 vi.mock('../../../../util/env.js', () => ({
   hasMcpSupport: (...args: unknown[]) => mockHasMcpSupport(...args),
+  getMcpConfigPath: (...args: unknown[]) => mockGetMcpConfigPath(...args),
 }));
 
 const mockIsInteractiveTerminal = vi.fn();
@@ -88,6 +90,9 @@ describe('McpConfigGenerator (orchestrator)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockHasMcpSupport.mockReturnValue(true);
+    mockGetMcpConfigPath.mockImplementation((agent: EnvironmentCode) =>
+      agent === 'claude' || agent === 'github' ? '.mcp.json' : `.${agent}/mcp.json`
+    );
     mockIsInteractiveTerminal.mockReturnValue(true);
   });
 
@@ -138,6 +143,22 @@ describe('McpConfigGenerator (orchestrator)', () => {
     });
 
     const report = await installMcpServers(servers, ['github'], '/project');
+
+    expect(mockPlan).toHaveBeenCalledTimes(1);
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    expect(report.installed).toBe(1);
+  });
+
+  it('applies a shared physical MCP target once for Claude and GitHub', async () => {
+    mockPlan.mockResolvedValue({
+      agentType: 'claude',
+      newServers: ['memory'],
+      conflictServers: [],
+      skippedServers: [],
+      resolvedConflicts: [],
+    });
+
+    const report = await installMcpServers(servers, ['claude', 'github'], '/project');
 
     expect(mockPlan).toHaveBeenCalledTimes(1);
     expect(mockApply).toHaveBeenCalledTimes(1);
@@ -229,6 +250,9 @@ describe('McpConfigGenerator (orchestrator)', () => {
     expect(report.skipped).toBe(1);
     expect(report.installed).toBe(0);
     expect(mockApply).not.toHaveBeenCalled();
+    expect(report.items).toContainEqual(expect.objectContaining({
+      name: 'memory', status: 'matched'
+    }));
   });
 
   it('prompts user for conflicts in interactive mode', async () => {
@@ -280,6 +304,21 @@ describe('McpConfigGenerator (orchestrator)', () => {
     expect(report.installed).toBe(0);
   });
 
+  it('does not prompt for conflicts when the caller explicitly selects non-interactive mode', async () => {
+    mockIsInteractiveTerminal.mockReturnValue(true);
+    mockPlan.mockResolvedValue({
+      agentType: 'claude', newServers: [], conflictServers: ['memory'],
+      skippedServers: [], resolvedConflicts: [],
+    });
+
+    const report = await installMcpServers(
+      servers, ['claude'], '/project', { nonInteractive: true }
+    );
+
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(report.conflicts).toBe(1);
+  });
+
   it('overwrites conflicts in non-interactive mode with --overwrite', async () => {
     mockIsInteractiveTerminal.mockReturnValue(false);
     mockPlan.mockResolvedValue({
@@ -318,6 +357,9 @@ describe('McpConfigGenerator (orchestrator)', () => {
     const report = await installMcpServers(servers, ['claude'], '/project');
     expect(report.failed).toBe(1);
     expect(report.installed).toBe(0);
+    expect(report.items).toContainEqual(expect.objectContaining({
+      name: 'memory', status: 'failed'
+    }));
   });
 
   it('handles per-server choice in interactive mode', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,7 +30,7 @@ program
 program
   .command('init')
   .description('Initialize AI DevKit in the current directory')
-  .option('-e, --environment <env>', 'Development environment (cursor|claude|both)')
+  .option('-e, --environment <env>', 'Comma-separated supported AI environment codes')
   .option('-a, --all', 'Initialize all phases')
   .option('-p, --phases <phases>', 'Comma-separated list of phases to initialize')
   .option('-t, --template <path>', 'Initialize from template file (.yaml, .yml, .json)')

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,9 +4,10 @@ import { ConfigManager } from '../lib/Config.js';
 import { TemplateManager } from '../lib/TemplateManager.js';
 import { EnvironmentSelector } from '../lib/EnvironmentSelector.js';
 import { PhaseSelector } from '../lib/PhaseSelector.js';
-import { SkillManager } from '../lib/SkillManager.js';
 import { loadInitTemplate, InitTemplateSkill } from '../lib/InitTemplate.js';
-import { EnvironmentCode, PHASE_DISPLAY_NAMES, Phase, DEFAULT_DOCS_DIR } from '../types.js';
+import { ConfigSkill, EnvironmentCode, Phase, DEFAULT_DOCS_DIR } from '../types.js';
+import { getInstallExitCode, reconcileAndInstall } from '../services/install/install.service.js';
+import { renderApplicationReport } from '../services/install/install-report.js';
 import { isValidEnvironmentCode } from '../util/env.js';
 import { isInteractiveTerminal } from '../util/terminal.js';
 import { ui } from '../util/terminal-ui.js';
@@ -96,48 +97,18 @@ async function shouldInstallBuiltinSkills(options: InitOptions): Promise<boolean
   return Boolean(installBuiltinSkills);
 }
 
-interface TemplateSkillInstallResult {
-  registry: string;
-  skill: string;
-  status: 'installed' | 'skipped' | 'failed';
-  reason?: string;
-}
-
-async function installTemplateSkills(
-  skillManager: SkillManager,
-  skills: InitTemplateSkill[]
-): Promise<TemplateSkillInstallResult[]> {
+function normalizeSkills(skills: InitTemplateSkill[]): ConfigSkill[] {
   const seen = new Set<string>();
-  const results: TemplateSkillInstallResult[] = [];
+  const results: ConfigSkill[] = [];
 
   for (const entry of skills) {
     const dedupeKey = `${entry.registry}::${entry.skill}`;
     if (seen.has(dedupeKey)) {
-      results.push({
-        registry: entry.registry,
-        skill: entry.skill,
-        status: 'skipped',
-        reason: 'Duplicate skill entry in template'
-      });
       continue;
     }
     seen.add(dedupeKey);
 
-    try {
-      await skillManager.addSkill(entry.registry, entry.skill);
-      results.push({
-        registry: entry.registry,
-        skill: entry.skill,
-        status: 'installed'
-      });
-    } catch (error) {
-      results.push({
-        registry: entry.registry,
-        skill: entry.skill,
-        status: 'failed',
-        reason: error instanceof Error ? error.message : String(error)
-      });
-    }
+    results.push({ registry: entry.registry, name: entry.skill });
   }
 
   return results;
@@ -148,7 +119,6 @@ export async function initCommand(options: InitOptions) {
   const templateManager = new TemplateManager();
   const environmentSelector = new EnvironmentSelector();
   const phaseSelector = new PhaseSelector();
-  const skillManager = new SkillManager(configManager, environmentSelector);
   const templatePath = options.template?.trim();
   const hasTemplate = Boolean(templatePath);
   const templateConfig = hasTemplate
@@ -264,8 +234,6 @@ export async function initCommand(options: InitOptions) {
     docsDir = templateConfig.paths.docs;
   }
 
-  const phaseTemplateManager = new TemplateManager({ docsDir });
-
   ui.text('Initializing AI DevKit...', { breakline: true });
 
   let config = await configManager.read();
@@ -274,119 +242,54 @@ export async function initCommand(options: InitOptions) {
     ui.success('Created configuration file');
   }
 
-  if (docsDir !== DEFAULT_DOCS_DIR) {
-    await configManager.update({ paths: { docs: docsDir } });
-  }
-
-  await configManager.setEnvironments(selectedEnvironments);
-  ui.success('Updated configuration with selected environments');
-
-  environmentSelector.displaySelectionSummary(selectedEnvironments);
-
-  phaseSelector.displaySelectionSummary(selectedPhases);
-  if (hasTemplate && templateConfig) {
-    ui.info(`Template mode: ${templatePath}`);
-    if (templateConfig.skills?.length) {
-      ui.info(`Template skills to install: ${templateConfig.skills.length}`);
-    }
-  }
-  ui.text('Setting up environment templates...', { breakline: true });
-  const envFiles = await phaseTemplateManager.setupMultipleEnvironments(selectedEnvironments);
-  envFiles.forEach(file => {
-    ui.success(`Created ${file}`);
-  });
-
-  for (const phase of selectedPhases) {
-    const exists = await phaseTemplateManager.fileExists(phase);
-    let shouldCopy = true;
-
-    if (exists) {
-      if (hasTemplate) {
-        ui.warning(`${PHASE_DISPLAY_NAMES[phase]} already exists. Overwriting in template mode.`);
-      } else if (nonInteractive) {
-        shouldCopy = Boolean(options.overwrite);
-      } else {
-        const overwrite = await confirm({
-          message: `${PHASE_DISPLAY_NAMES[phase]} already exists. Overwrite?`,
-          default: false
-        });
-        shouldCopy = overwrite;
-      }
-    }
-
-    if (shouldCopy) {
-      await phaseTemplateManager.copyPhaseTemplate(phase);
-      await configManager.addPhase(phase);
-      ui.success(`Created ${phase} phase`);
-    } else {
-      ui.warning(`Skipped ${phase} phase`);
-    }
-  }
-
-  if (templateConfig?.registries) {
-    const registryCount = Object.keys(templateConfig.registries).length;
-    if (registryCount > 0) {
-      await configManager.update({ registries: templateConfig.registries });
-      ui.success(`Saved ${registryCount} custom registry(ies) to config.`);
-    }
-  }
-
-  if (templateConfig?.skills?.length) {
-    ui.text('Installing skills from template...', { breakline: true });
-    const skillResults = await installTemplateSkills(skillManager, templateConfig.skills);
-    const installedCount = skillResults.filter(result => result.status === 'installed').length;
-    const skippedCount = skillResults.filter(result => result.status === 'skipped').length;
-    const failedResults = skillResults.filter(result => result.status === 'failed');
-
-    if (installedCount > 0) {
-      ui.success(`Installed ${installedCount} skill(s) from template.`);
-    }
-    if (skippedCount > 0) {
-      ui.warning(`Skipped ${skippedCount} duplicate skill entry(ies) from template.`);
-    }
-    if (failedResults.length > 0) {
-      ui.warning(
-        `${failedResults.length} skill install(s) failed. Continuing with warnings as configured.`
-      );
-      failedResults.forEach(result => {
-        ui.warning(`${result.registry}/${result.skill}: ${result.reason || 'Unknown error'}`);
-      });
-    }
-  }
-
+  const desiredSkillEntries = [...(templateConfig?.skills || [])];
   if (options.builtIn || !hasTemplate) {
     const shouldInstall = await shouldInstallBuiltinSkills(options);
-
     if (shouldInstall) {
-      ui.text('Installing AI DevKit built-in skills...', { breakline: true });
-      const skillResults = await installTemplateSkills(skillManager, BUILTIN_SKILLS);
-      const installedCount = skillResults.filter(result => result.status === 'installed').length;
-      const failedResults = skillResults.filter(result => result.status === 'failed');
-
-      if (installedCount > 0) {
-        ui.success(`Installed ${installedCount} built-in skill(s).`);
-      }
-      if (failedResults.length > 0) {
-        ui.warning(
-          `${failedResults.length} built-in skill install(s) failed. Continuing with warnings.`
-        );
-        failedResults.forEach(result => {
-          ui.warning(`${result.registry}/${result.skill}: ${result.reason || 'Unknown error'}`);
-        });
-      }
+      desiredSkillEntries.push(...BUILTIN_SKILLS);
     }
   }
+  const desiredSkills = normalizeSkills(desiredSkillEntries);
 
-  if (templateConfig?.mcpServers && Object.keys(templateConfig.mcpServers).length > 0) {
-    await configManager.update({ mcpServers: templateConfig.mcpServers });
-    ui.success(`Saved ${Object.keys(templateConfig.mcpServers).length} MCP server definition(s) to config.`);
-    ui.info('Run `ai-devkit install` to generate agent-specific MCP config files.');
+  const registries = templateConfig?.registries || config.registries || {};
+  const mcpServers = templateConfig?.mcpServers || config.mcpServers || {};
+  await configManager.update({
+    environments: selectedEnvironments,
+    phases: selectedPhases,
+    ...(docsDir !== DEFAULT_DOCS_DIR ? { paths: { ...config.paths, docs: docsDir } } : {}),
+    ...(Object.keys(registries).length > 0 ? { registries } : {}),
+    ...(desiredSkills.length > 0 ? { skills: desiredSkills } : {}),
+    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {})
+  });
+
+  ui.success('Saved project configuration');
+  environmentSelector.displaySelectionSummary(selectedEnvironments);
+  phaseSelector.displaySelectionSummary(selectedPhases);
+
+  const report = await reconcileAndInstall({
+    environments: selectedEnvironments,
+    phases: selectedPhases,
+    registries,
+    skills: desiredSkills,
+    mcpServers
+  }, {
+    overwrite: options.overwrite,
+    nonInteractive
+  });
+
+  renderApplicationReport(report, 'Initialization Summary');
+  process.exitCode = getInstallExitCode(report, { overwrite: options.overwrite });
+
+  if (process.exitCode !== 0) {
+    ui.warning('Project configuration was saved, but setup is incomplete.');
+    ui.info('Resolve the errors above, then run `ai-devkit install`.');
+    return;
   }
 
-  ui.text('AI DevKit initialized successfully!', { breakline: true });
+  ui.text('AI DevKit project initialized successfully!', { breakline: true });
   ui.info('Next steps:');
   ui.text(`  • Review and customize templates in ${docsDir}/`);
-  ui.text('  • Your AI environments are ready to use with the generated configurations');
+  ui.text('  • Your selected AI environments are ready in this project');
   ui.text('  • Run `ai-devkit phase <name>` to add more phases later');
   ui.text('  • Run `ai-devkit init` again to add more environments\n');
 }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -5,6 +5,7 @@ import {
 import { loadConfigFile } from '../services/config/config.service.js';
 import { validateInstallConfig } from '../util/config.js';
 import { ui } from '../util/terminal-ui.js';
+import { renderApplicationReport } from '../services/install/install-report.js';
 
 interface InstallCommandOptions {
   config?: string;
@@ -55,35 +56,7 @@ export async function installCommand(options: InstallCommandOptions): Promise<vo
     return;
   }
 
-  ui.summary({
-    title: 'Install Summary',
-    items: [
-      { type: 'success', count: report.environments.installed, label: 'environment(s) installed' },
-      { type: 'warning', count: report.environments.skipped, label: 'environment(s) skipped' },
-      { type: 'error', count: report.environments.failed, label: 'environment(s) failed' },
-      { type: 'success', count: report.phases.installed, label: 'phase template(s) installed' },
-      { type: 'warning', count: report.phases.skipped, label: 'phase template(s) skipped' },
-      { type: 'error', count: report.phases.failed, label: 'phase template(s) failed' },
-      { type: 'success', count: report.skills.installed, label: 'skill(s) installed' },
-      { type: 'error', count: report.skills.failed, label: 'skill(s) failed' },
-      { type: 'success', count: report.mcpServers.installed, label: 'MCP server config(s) installed' },
-      { type: 'warning', count: report.mcpServers.skipped, label: 'MCP server config(s) skipped' },
-      { type: 'warning', count: report.mcpServers.conflicts, label: 'MCP server conflict(s) skipped' },
-      { type: 'error', count: report.mcpServers.failed, label: 'MCP server config(s) failed' }
-    ]
-  });
-
-  if (report.warnings.length > 0) {
-    ui.text('');
-    ui.warning('Warnings:');
-    report.warnings.forEach(warning => {
-      ui.text(`  - ${warning}`);
-    });
-
-    if (report.skills.failed > 0) {
-      ui.warning('Skill failures are reported as warnings and do not change exit code.');
-    }
-  }
+  renderApplicationReport(report);
 
   process.exitCode = getInstallExitCode(report, {
     overwrite: options.overwrite

--- a/packages/cli/src/lib/SkillManager.ts
+++ b/packages/cli/src/lib/SkillManager.ts
@@ -68,7 +68,11 @@ export class SkillManager {
   /**
    * Add a skill to the project
    */
-  async addSkill(registryId: string, skillName?: string, options: AddSkillOptions = {}): Promise<void> {
+  async addSkill(
+    registryId: string,
+    skillName?: string,
+    options: AddSkillOptions = {}
+  ): Promise<'installed' | 'matched'> {
     ui.info(`Validating registry: ${registryId}`);
     validateRegistryId(registryId);
     await ensureGitInstalled();
@@ -94,9 +98,16 @@ export class SkillManager {
     const selectedEnvironments = await this.resolveInstallEnvironments(options);
     const installContext = this.buildInstallContext(selectedEnvironments, options);
 
+    let status: 'installed' | 'matched' = 'matched';
     for (const resolvedSkillName of resolvedSkillNames) {
-      await this.installResolvedSkill(registryId, repoPath, resolvedSkillName, options, installContext);
+      const itemStatus = await this.installResolvedSkill(
+        registryId, repoPath, resolvedSkillName, options, installContext
+      );
+      if (itemStatus === 'installed') {
+        status = 'installed';
+      }
     }
+    return status;
   }
 
   /**
@@ -463,13 +474,14 @@ export class SkillManager {
     resolvedSkillName: string,
     options: AddSkillOptions,
     installContext: ResolvedInstallContext
-  ): Promise<void> {
+  ): Promise<'installed' | 'matched'> {
     ui.info(`Validating skill: ${resolvedSkillName} from ${registryId}`);
     validateSkillName(resolvedSkillName);
 
     const skillPath = await this.resolveInstallableSkillPath(repoPath, registryId, resolvedSkillName);
 
     ui.info(`Installing skill to ${installContext.installMode}...`);
+    let installed = false;
     for (const targetDir of installContext.targets) {
       const targetPath = path.join(installContext.baseDir, targetDir, resolvedSkillName);
 
@@ -483,10 +495,11 @@ export class SkillManager {
       try {
         await fs.symlink(skillPath, targetPath, 'dir');
         ui.text(`  → ${targetDir}/${resolvedSkillName} (symlinked)`);
-      } catch (error) {
+      } catch (ignoreError) {
         await fs.copy(skillPath, targetPath);
         ui.text(`  → ${targetDir}/${resolvedSkillName} (copied)`);
       }
+      installed = true;
     }
 
     if (!options.global) {
@@ -499,6 +512,7 @@ export class SkillManager {
     ui.text(`Successfully installed: ${resolvedSkillName}`);
     ui.info(`  Source: ${registryId}`);
     ui.info(`  Installed to (${installContext.installMode}): ${installContext.capableEnvironments.join(', ')}`);
+    return installed ? 'installed' : 'matched';
   }
 
   private buildInstallContext(

--- a/packages/cli/src/services/install/install-report.ts
+++ b/packages/cli/src/services/install/install-report.ts
@@ -1,0 +1,31 @@
+import { ui } from '../../util/terminal-ui.js';
+import type { InstallReport } from './install.service.js';
+
+export function renderApplicationReport(
+  report: InstallReport,
+  title = 'Install Summary'
+): void {
+  const count = (status: string) => report.items.filter(item => item.status === status).length;
+
+  ui.summary({
+    title,
+    items: [
+      { type: 'success', count: count('installed'), label: 'artifact(s) installed' },
+      { type: 'success', count: count('matched'), label: 'artifact(s) already matched' },
+      { type: 'warning', count: count('skipped'), label: 'artifact(s) preserved' },
+      { type: 'warning', count: count('conflict'), label: 'artifact conflict(s) unresolved' },
+      { type: 'error', count: count('failed'), label: 'artifact(s) failed' }
+    ]
+  });
+
+  const details = report.items.filter(item =>
+    (item.status === 'failed' || item.status === 'conflict') && item.message
+  );
+  for (const item of details) {
+    ui.warning(`${item.section} ${item.name}: ${item.message}`);
+  }
+
+  for (const warning of report.warnings) {
+    ui.warning(warning);
+  }
+}

--- a/packages/cli/src/services/install/install.service.ts
+++ b/packages/cli/src/services/install/install.service.ts
@@ -5,9 +5,13 @@ import { TemplateManager } from '../../lib/TemplateManager.js';
 import { InstallConfigData } from '../../util/config.js';
 import { installMcpServers, McpInstallReport } from './mcp/index.js';
 import type { DevKitConfig } from '../../types.js';
+import { PHASE_DISPLAY_NAMES } from '../../types.js';
+import { isInteractiveTerminal } from '../../util/terminal.js';
+import { confirm } from '@inquirer/prompts';
 
 export interface InstallRunOptions {
   overwrite?: boolean;
+  nonInteractive?: boolean;
 }
 
 interface InstallSectionReport {
@@ -16,12 +20,24 @@ interface InstallSectionReport {
   failed: number;
 }
 
+export type ApplicationStatus = 'installed' | 'matched' | 'skipped' | 'conflict' | 'failed';
+
+export interface ApplicationItemResult {
+  section: 'environment' | 'phase' | 'skill' | 'mcpServer';
+  name: string;
+  target?: string;
+  status: ApplicationStatus;
+  message?: string;
+}
+
 export interface InstallReport {
   environments: InstallSectionReport;
   phases: InstallSectionReport;
   skills: InstallSectionReport;
   mcpServers: McpInstallReport;
   warnings: string[];
+  items: ApplicationItemResult[];
+  complete: boolean;
 }
 
 export async function reconcileAndInstall(
@@ -37,8 +53,10 @@ export async function reconcileAndInstall(
     environments: { installed: 0, skipped: 0, failed: 0 },
     phases: { installed: 0, skipped: 0, failed: 0 },
     skills: { installed: 0, skipped: 0, failed: 0 },
-    mcpServers: { installed: 0, skipped: 0, conflicts: 0, failed: 0 },
-    warnings: []
+    mcpServers: { installed: 0, skipped: 0, conflicts: 0, failed: 0, items: [] },
+    warnings: [],
+    items: [],
+    complete: true
   };
 
   let projectConfig = await configManager.read();
@@ -51,47 +69,92 @@ export async function reconcileAndInstall(
     throw new Error('Failed to initialize project config for install command.');
   }
 
+  const desiredUpdates: Partial<DevKitConfig> = {};
+  if (config.environments.length > 0) desiredUpdates.environments = config.environments;
+  if (config.phases.length > 0) desiredUpdates.phases = config.phases;
+  if (Object.keys(config.registries).length > 0) desiredUpdates.registries = config.registries;
+  if (config.skills.length > 0) desiredUpdates.skills = config.skills;
+  if (Object.keys(config.mcpServers).length > 0) desiredUpdates.mcpServers = config.mcpServers;
+  await configManager.update(desiredUpdates);
+
   const successfulEnvironments: typeof config.environments = [];
-  const successfulPhases: typeof config.phases = [];
-  const successfulSkills: typeof config.skills = [];
 
   for (const envCode of config.environments) {
     try {
-      await templateManager.setupMultipleEnvironments([envCode]);
-      report.environments.installed += 1;
+      const installedFiles = await templateManager.setupMultipleEnvironments([envCode]);
+      const status = installedFiles.length > 0 ? 'installed' : 'matched';
+      if (status === 'installed') {
+        report.environments.installed += 1;
+      } else {
+        report.environments.skipped += 1;
+      }
       successfulEnvironments.push(envCode);
+      report.items.push({ section: 'environment', name: envCode, status });
     } catch (error) {
       report.environments.failed += 1;
       report.warnings.push(
         `Environment ${envCode} failed: ${error instanceof Error ? error.message : String(error)}`
       );
+      report.items.push({
+        section: 'environment', name: envCode, status: 'failed',
+        message: error instanceof Error ? error.message : String(error)
+      });
     }
   }
 
   for (const phase of config.phases) {
     try {
+      if (await templateManager.fileExists(phase) && !options.overwrite) {
+        const overwrite = !options.nonInteractive && isInteractiveTerminal()
+          ? await confirm({
+            message: `${PHASE_DISPLAY_NAMES[phase]} already exists. Overwrite?`,
+            default: false
+          })
+          : false;
+        if (!overwrite) {
+          report.phases.skipped += 1;
+          report.items.push({ section: 'phase', name: phase, status: 'skipped' });
+          continue;
+        }
+      }
       await templateManager.copyPhaseTemplate(phase);
       await configManager.addPhase(phase);
       report.phases.installed += 1;
-      successfulPhases.push(phase);
+      report.items.push({ section: 'phase', name: phase, status: 'installed' });
     } catch (error) {
       report.phases.failed += 1;
       report.warnings.push(
         `Phase ${phase} failed: ${error instanceof Error ? error.message : String(error)}`
       );
+      report.items.push({
+        section: 'phase', name: phase, status: 'failed',
+        message: error instanceof Error ? error.message : String(error)
+      });
     }
   }
 
   for (const skill of config.skills) {
     try {
-      await skillManager.addSkill(skill.registry, skill.name);
-      report.skills.installed += 1;
-      successfulSkills.push(skill);
+      const status = await skillManager.addSkill(skill.registry, skill.name);
+      if (status === 'matched') {
+        report.skills.skipped += 1;
+      } else {
+        report.skills.installed += 1;
+      }
+      report.items.push({
+        section: 'skill',
+        name: skill.name,
+        status: status === 'matched' ? 'matched' : 'installed'
+      });
     } catch (error) {
       report.skills.failed += 1;
       report.warnings.push(
         `Skill ${skill.registry}/${skill.name} failed: ${error instanceof Error ? error.message : String(error)}`
       );
+      report.items.push({
+        section: 'skill', name: skill.name, status: 'failed',
+        message: error instanceof Error ? error.message : String(error)
+      });
     }
   }
 
@@ -104,9 +167,13 @@ export async function reconcileAndInstall(
         config.mcpServers,
         allEnvironments,
         process.cwd(),
-        { overwrite: options.overwrite }
+        { overwrite: options.overwrite, nonInteractive: options.nonInteractive }
       );
       report.mcpServers = mcpReport;
+      report.items.push(...mcpReport.items.map(item => ({
+        section: 'mcpServer' as const,
+        ...item
+      })));
     } catch (error) {
       report.warnings.push(
         `MCP servers failed: ${error instanceof Error ? error.message : String(error)}`
@@ -115,34 +182,14 @@ export async function reconcileAndInstall(
     }
   }
 
-  const updates: Partial<DevKitConfig> = {};
-  if (successfulEnvironments.length > 0) {
-    updates.environments = successfulEnvironments;
-  }
-  if (successfulPhases.length > 0) {
-    updates.phases = successfulPhases;
-  }
-  if (Object.keys(config.registries).length > 0) {
-    updates.registries = config.registries;
-  }
-  if (successfulSkills.length > 0) {
-    updates.skills = successfulSkills;
-  }
-  if (config.mcpServers && Object.keys(config.mcpServers).length > 0) {
-    updates.mcpServers = config.mcpServers;
-  }
-  await configManager.update(updates);
+  report.complete = report.items.every(item => item.status !== 'failed' && item.status !== 'conflict')
+    && report.mcpServers.failed === 0
+    && report.mcpServers.conflicts === 0;
 
   return report;
 }
 
 export function getInstallExitCode(report: InstallReport, options: InstallRunOptions = {}): number {
   void options;
-
-  const requiredFailures = report.environments.failed + report.phases.failed;
-  if (requiredFailures > 0) {
-    return 1;
-  }
-
-  return 0;
+  return report.complete ? 0 : 1;
 }

--- a/packages/cli/src/services/install/mcp/ClaudeCodeMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/ClaudeCodeMcpGenerator.ts
@@ -29,13 +29,9 @@ export class ClaudeCodeMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, '.mcp.json');
-    try {
-      if (await fs.pathExists(configPath)) {
-        this.fullConfig = await fs.readJson(configPath);
-        return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file — treat as empty
+    if (await fs.pathExists(configPath)) {
+      this.fullConfig = await fs.readJson(configPath);
+      return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/CodexMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/CodexMcpGenerator.ts
@@ -30,14 +30,10 @@ export class CodexMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, '.codex', 'config.toml');
-    try {
-      if (await fs.pathExists(configPath)) {
-        const content = await fs.readFile(configPath, 'utf-8');
-        this.fullConfig = TOML.parse(content) as CodexConfig;
-        return (this.fullConfig.mcp_servers || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file — treat as empty
+    if (await fs.pathExists(configPath)) {
+      const content = await fs.readFile(configPath, 'utf-8');
+      this.fullConfig = TOML.parse(content) as CodexConfig;
+      return (this.fullConfig.mcp_servers || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/DevinMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/DevinMcpGenerator.ts
@@ -28,13 +28,9 @@ export class DevinMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, '.devin', 'config.json');
-    try {
-      if (await fs.pathExists(configPath)) {
-        this.fullConfig = await fs.readJson(configPath);
-        return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file - treat as empty.
+    if (await fs.pathExists(configPath)) {
+      this.fullConfig = await fs.readJson(configPath);
+      return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/JunieMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/JunieMcpGenerator.ts
@@ -28,13 +28,9 @@ export class JunieMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, '.junie', 'mcp', 'mcp.json');
-    try {
-      if (await fs.pathExists(configPath)) {
-        this.fullConfig = await fs.readJson(configPath);
-        return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file - treat as empty.
+    if (await fs.pathExists(configPath)) {
+      this.fullConfig = await fs.readJson(configPath);
+      return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/KiloCodeMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/KiloCodeMcpGenerator.ts
@@ -37,14 +37,10 @@ export class KiloCodeMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, '.kilo', 'kilo.jsonc');
-    try {
-      if (await fs.pathExists(configPath)) {
-        const content = await fs.readFile(configPath, 'utf8');
-        this.fullConfig = parseJsonc(content);
-        return (this.fullConfig.mcp || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file — treat as empty
+    if (await fs.pathExists(configPath)) {
+      const content = await fs.readFile(configPath, 'utf8');
+      this.fullConfig = parseJsonc(content);
+      return (this.fullConfig.mcp || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/McpConfigGenerator.ts
+++ b/packages/cli/src/services/install/mcp/McpConfigGenerator.ts
@@ -1,5 +1,5 @@
 import { EnvironmentCode, McpServerDefinition } from '../../../types.js';
-import { hasMcpSupport } from '../../../util/env.js';
+import { getMcpConfigPath, hasMcpSupport } from '../../../util/env.js';
 import { isInteractiveTerminal } from '../../../util/terminal.js';
 import { McpAgentGenerator, McpInstallReport, McpMergePlan } from './types.js';
 import { ClaudeCodeMcpGenerator } from './ClaudeCodeMcpGenerator.js';
@@ -14,6 +14,7 @@ import { confirm, select } from '@inquirer/prompts';
 
 export interface McpInstallOptions {
   overwrite?: boolean;
+  nonInteractive?: boolean;
 }
 
 const GENERATORS: McpAgentGenerator[] = [
@@ -38,21 +39,34 @@ export async function installMcpServers(
     skipped: 0,
     conflicts: 0,
     failed: 0,
+    items: [],
   };
 
   if (!servers || Object.keys(servers).length === 0) {
     return report;
   }
 
-  const activeGenerators = GENERATORS.filter(g =>
+  const selectedGenerators = GENERATORS.filter(g =>
     environments.includes(g.agentType) && hasMcpSupport(g.agentType)
   );
+  const generatorsByTarget = new Map<string, McpAgentGenerator>();
+  for (const generator of selectedGenerators) {
+    const target = getMcpConfigPath(generator.agentType) || generator.agentType;
+    if (!generatorsByTarget.has(target)) {
+      generatorsByTarget.set(target, generator);
+    }
+  }
+  const activeGenerators = [...generatorsByTarget.values()];
 
   for (const generator of activeGenerators) {
+    const target = getMcpConfigPath(generator.agentType) || generator.agentType;
     try {
       const plan = await generator.plan(servers, projectRoot);
 
       report.skipped += plan.skippedServers.length;
+      report.items.push(...plan.skippedServers.map(name => ({
+        name, target, status: 'matched' as const
+      })));
 
       if (plan.conflictServers.length > 0) {
         const resolved = resolveConflicts(plan, options);
@@ -60,15 +74,28 @@ export async function installMcpServers(
           ? (resolved === 'overwrite' ? [...plan.conflictServers] : [])
           : await resolved;
         report.conflicts += plan.conflictServers.length - plan.resolvedConflicts.length;
+        const unresolved = plan.conflictServers.filter(name => !plan.resolvedConflicts.includes(name));
+        report.items.push(...unresolved.map(name => ({
+          name, target, status: 'conflict' as const
+        })));
       }
 
       const toInstall = plan.newServers.length + plan.resolvedConflicts.length;
       if (toInstall > 0) {
         await generator.apply(plan, servers, projectRoot);
         report.installed += toInstall;
+        report.items.push(...[...plan.newServers, ...plan.resolvedConflicts].map(name => ({
+          name, target, status: 'installed' as const
+        })));
       }
-    } catch {
+    } catch (error) {
       report.failed += Object.keys(servers).length;
+      report.items.push(...Object.keys(servers).map(name => ({
+        name,
+        target,
+        status: 'failed' as const,
+        message: error instanceof Error ? error.message : String(error)
+      })));
     }
   }
 
@@ -84,7 +111,7 @@ function resolveConflicts(
   options: McpInstallOptions
 ): string | Promise<string[]> {
   if (options.overwrite) return 'overwrite';
-  if (!isInteractiveTerminal()) return 'skip';
+  if (options.nonInteractive || !isInteractiveTerminal()) return 'skip';
   return promptConflicts(plan);
 }
 

--- a/packages/cli/src/services/install/mcp/OpenCodeMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/OpenCodeMcpGenerator.ts
@@ -35,14 +35,10 @@ export class OpenCodeMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, 'opencode.json');
-    try {
-      if (await fs.pathExists(configPath)) {
-        const content = await fs.readFile(configPath, 'utf8');
-        this.fullConfig = JSON.parse(content || '{}') as OpenCodeConfig;
-        return (this.fullConfig.mcp || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file — treat as empty.
+    if (await fs.pathExists(configPath)) {
+      const content = await fs.readFile(configPath, 'utf8');
+      this.fullConfig = JSON.parse(content || '{}') as OpenCodeConfig;
+      return (this.fullConfig.mcp || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/RooCodeMcpGenerator.ts
+++ b/packages/cli/src/services/install/mcp/RooCodeMcpGenerator.ts
@@ -28,13 +28,9 @@ export class RooCodeMcpGenerator extends BaseMcpGenerator {
 
   protected async readExistingServers(projectRoot: string): Promise<Record<string, unknown>> {
     const configPath = path.join(projectRoot, '.roo', 'mcp.json');
-    try {
-      if (await fs.pathExists(configPath)) {
-        this.fullConfig = await fs.readJson(configPath);
-        return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
-      }
-    } catch {
-      // Malformed file — treat as empty
+    if (await fs.pathExists(configPath)) {
+      this.fullConfig = await fs.readJson(configPath);
+      return (this.fullConfig.mcpServers || {}) as Record<string, unknown>;
     }
     this.fullConfig = {};
     return {};

--- a/packages/cli/src/services/install/mcp/types.ts
+++ b/packages/cli/src/services/install/mcp/types.ts
@@ -34,4 +34,10 @@ export interface McpInstallReport {
   skipped: number;
   conflicts: number;
   failed: number;
+  items: Array<{
+    name: string;
+    target: string;
+    status: 'installed' | 'matched' | 'conflict' | 'failed';
+    message?: string;
+  }>;
 }


### PR DESCRIPTION
## Summary

`init` becomes complete by default by delegating artifact application to one shared project application service, the same one `install` uses.

**Command model:**
```
setup   → prepare this machine once (global skills + integrations)
init    → define AND completely initialize this project (one command, done)
install → reapply from committed config (teammates / CI / after edits)
```

**What changed:**
- Shared application service with per-item states: `installed / matched / skipped / conflict / failed`; `init` and `install` both report through it
- `init` now generates per-agent MCP files (previously saved declarations but never materialized them — template users got inert MCP config)
- Truthful completion: no more "initialized successfully" while declared artifacts are unapplied — failures exit nonzero with a resumable `install` path
- Apply order: validate → persist config → registries → env templates → docs → skills → MCP → one summary
- Malformed existing MCP target files fail instead of being silently treated as empty
- Duplicate `.mcp.json` writers (claude + github copilot) deduplicated into one coherent merge
- Template phase-doc overwrites now prompt or require `--overwrite` (previously silent)
- Stale `--environment` help fixed
- No new flags — existing interfaces preserved (`init --template/--yes/--built-in`, `install --config/--overwrite`)

## Validation

- `npm run build` — 6/6 projects passed
- Full `npm test` — all 6 projects green (agent-manager 600 tests; cli 1,071 tests)
- `npm run lint` — 0 errors (2 pre-existing warnings)
- Rebased onto latest main (MIT license commit), cli build+tests reverified after rebase

## Test coverage

Real-filesystem tests for: complete template init (config+docs+skills+all supported MCP files) · resumable desired state on install failure · idempotent reruns report matched · MCP conflicts fail non-interactive without `--overwrite` · malformed MCP targets fail without replacement · per-item install reporting.

Lifecycle docs: requirements/design/planning/implementation/testing under `docs/ai/2026-08-27-feature-init-complete.md`