### PR TITLE
perf(cli): prepare skill registries once per run

### DIFF
--- a/docs/ai/design/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/design/2026-08-28-feature-registry-prep-once.md
@@ -1,0 +1,69 @@
+---
+phase: design
+title: Registry preparation memoization design
+description: Instance-scoped, concurrency-safe cache repository preparation
+---
+
+# Registry preparation memoization design
+
+## Architecture
+
+```mermaid
+flowchart LR
+  C[Multi-skill caller] --> M[SkillManager.addSkill]
+  M --> R[SkillRegistry.prepareRegistryRepository]
+  R --> P{preparedRepositories has registry ID?}
+  P -->|yes| S[Return shared promise]
+  P -->|no| F[Store refreshOrUseStaleCache promise]
+  F --> G[Clone or pull once]
+  G --> O[Fresh path, stale path, or rejection]
+  O --> S
+```
+
+`SkillManager` remains the skill orchestrator. `SkillRegistry` owns repository state, refresh/fallback behavior, memoization, and its UX messages.
+
+## Data Model and API
+
+```ts
+private readonly preparedRepositories = new Map<string, Promise<string>>();
+
+prepareRegistryRepository(registryId: string, gitUrl?: string): Promise<string>;
+private refreshOrUseStaleCache(registryId: string, gitUrl?: string): Promise<string>;
+```
+
+Public signatures do not change. The map key is registry ID only. The promise is inserted before it is awaited so sequential and concurrent callers share the same operation and outcome.
+
+## Outcomes and Freshness
+
+- Refresh succeeds: reuse the resolved repository path for later skills.
+- Refresh fails with cache: resolve once to the cached path, warn once, and do not retry in that instance.
+- Refresh fails without cache: retain and reuse the rejected promise, preventing per-skill retries.
+- Cached path is not Git: reuse the as-is result and message once.
+- Different registry IDs: maintain independent promises and outcomes.
+- New `SkillRegistry` instance: starts empty and performs a fresh attempt.
+
+No TTL is used. A command installs from one coherent registry snapshot, while a later command creates a new manager/registry and refreshes again.
+
+## UX
+
+Remove `Checking local cache...` from `SkillManager`. On the first preparation only, `SkillRegistry` emits:
+
+- Start: `Refreshing registry <id>...`
+- Success: `Registry <id> refreshed.`
+- Stale fallback: `Could not refresh registry <id>: <error>. Using cached registry contents for this run.`
+
+Clone and non-Git details may remain, but no preparation messages repeat for memoized calls.
+
+## Alternatives Rejected
+
+- Batch `addSkills`: larger caller and result-contract change with no current need beyond deduplication.
+- Command preparation pass: leaks cache coordination across multiple command/service callers.
+- TTL or process-global state: changes cross-command freshness and complicates URLs, tests, and retries.
+- Prepared handles or split public APIs: adds a temporal protocol without an independent caller.
+
+## Non-functional Considerations
+
+- Performance: repository network/disk work is O(unique registries), not O(skills).
+- Reliability: all skills from one registry use one consistent snapshot and fallback decision.
+- Security: registry/skill validation and Git URL handling remain unchanged.
+- Removal cost: delete one map and inline one private helper to restore prior behavior.

--- a/docs/ai/implementation/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/implementation/2026-08-28-feature-registry-prep-once.md
@@ -23,7 +23,7 @@ description: Record code changes, decisions, deviations, and verification
 - Promise retained for all outcomes, including rejection, to enforce one attempt per registry per instance.
 - Registry ID is the only key; no current caller mutates its URL within one instance.
 - No TTL, flags, batch API, or public signature change.
-- Fetch-catalog memoization is optional and must be a separate testable commit.
+- Fetch-catalog memoization uses a separate instance promise and private loader, with no public signature change.
 
 ## Implementation Record
 
@@ -32,6 +32,7 @@ description: Record code changes, decisions, deviations, and verification
 - Moved the generic manager cache message to registry-specific start/success/stale messages.
 - Strengthened init, install-service, and built-in skill command tests to show multi-skill callers retain one manager instance; existing setup tests cover the single built-in installer boundary.
 - Regression gate: the sequential test passed with the fix, failed with two pulls when memoization was temporarily removed, and passed after restoration.
+- Independently memoized `fetchMergedRegistry`; one shared promise now replaces repeated default-registry fetches and project/global config reads within the same instance.
 
 ## Deviations
 

--- a/docs/ai/implementation/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/implementation/2026-08-28-feature-registry-prep-once.md
@@ -1,0 +1,38 @@
+---
+phase: implementation
+title: Registry preparation implementation notes
+description: Record code changes, decisions, deviations, and verification
+---
+
+# Registry preparation implementation notes
+
+## Setup
+
+- Worktree: `.worktrees/feature-registry-prep-once`
+- Branch/base: `feature-registry-prep-once` from fetched `origin/main` at `2b7dd5e`
+- Bootstrap: `npm ci`; workspace artifacts built with `npm run build`
+
+## Intended Changes
+
+- `SkillRegistry`: own an instance-scoped map of preparation promises and the extracted refresh/stale fallback operation.
+- `SkillManager`: stop emitting the generic per-skill cache-check line.
+- Tests: verify public behavior at Git, filesystem, UI, manager, service, and command boundaries.
+
+## Decisions
+
+- Promise retained for all outcomes, including rejection, to enforce one attempt per registry per instance.
+- Registry ID is the only key; no current caller mutates its URL within one instance.
+- No TTL, flags, batch API, or public signature change.
+- Fetch-catalog memoization is optional and must be a separate testable commit.
+
+## Implementation Record
+
+- Added seven registry preparation tests covering sequential, concurrent, mixed, stale, terminal failure, new-instance, and non-Git outcomes.
+- Added the instance map and extracted `refreshOrUseStaleCache`; the promise is retained before awaiting and for success, fallback, and rejection.
+- Moved the generic manager cache message to registry-specific start/success/stale messages.
+- Strengthened init, install-service, and built-in skill command tests to show multi-skill callers retain one manager instance; existing setup tests cover the single built-in installer boundary.
+- Regression gate: the sequential test passed with the fix, failed with two pulls when memoization was temporarily removed, and passed after restoration.
+
+## Deviations
+
+None from the approved core design. Lower-level clone/update detail messages remain for compatibility; the new preparation-level start and outcome are emitted only once.

--- a/docs/ai/implementation/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/implementation/2026-08-28-feature-registry-prep-once.md
@@ -37,3 +37,12 @@ description: Record code changes, decisions, deviations, and verification
 ## Deviations
 
 None from the approved core design. Lower-level clone/update detail messages remain for compatibility; the new preparation-level start and outcome are emitted only once.
+
+## Verification and Review
+
+- Build completed for all 6 projects.
+- Full workspace suite passed 159 files and 2,061 tests.
+- Lint passed all 6 projects with three pre-existing unused-catch warnings and no new warning.
+- Feature docs lint passed.
+- E2E passed 1 file and 41 tests.
+- Final design/caller review found no blocking issues, public contract changes, or PR #202 conflict.

--- a/docs/ai/planning/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/planning/2026-08-28-feature-registry-prep-once.md
@@ -20,9 +20,9 @@ description: TDD task breakdown for one preparation per registry instance
 
 ## Milestone 3: Lifecycle completion
 
-- [ ] Reconcile implementation/testing docs and verify design alignment.
-- [ ] Run focused tests, build (6 projects), full tests, lint, feature lint, and e2e.
-- [ ] Complete final review, create logical conventional commits, rebase on fetched `origin/main`, push, and open a PR.
+- [x] Reconcile implementation/testing docs and verify design alignment.
+- [x] Run focused tests, build (6 projects), full tests, lint, feature lint, and e2e.
+- [ ] Complete final review, rebase on fetched `origin/main`, push, and open a PR.
 
 ## Dependencies and Risks
 
@@ -33,4 +33,4 @@ description: TDD task breakdown for one preparation per registry instance
 
 ## Progress Summary
 
-Implementation and caller coverage are complete. Next: full validation and review.
+Implementation, tests, documentation, and local review are complete with no blocking findings. Next: final remote sync, push, and PR.

--- a/docs/ai/planning/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/planning/2026-08-28-feature-registry-prep-once.md
@@ -1,0 +1,36 @@
+---
+phase: planning
+title: Registry preparation implementation plan
+description: TDD task breakdown for one preparation per registry instance
+---
+
+# Registry preparation implementation plan
+
+## Milestone 1: Core behavior
+
+- [x] Add failing sequential same-registry and concurrent preparation tests. Evidence: 6 of 7 new tests failed before production changes because operations repeated.
+- [x] Add `preparedRepositories`, storing the promise before await, and extract `refreshOrUseStaleCache`. Evidence: focused registry/manager suites pass 80 tests.
+- [x] Cover independent registries, stale fallback, terminal no-cache failure, second-instance freshness, and non-Git cache reuse. Evidence: registry suite passes 7 tests.
+
+## Milestone 2: UX and command coverage
+
+- [x] Move cache-check messaging from `SkillManager` into the first registry preparation and assert start/success/stale output once.
+- [x] Add or strengthen command/service coverage for init built-ins, mixed-registry templates, mixed-registry install, `skill add --built-in`, and setup. Evidence: four caller suites pass 79 tests.
+- [ ] Evaluate `fetchMergedRegistry` instance memoization independently; implement in a separate commit only if a focused red/green test and clear failure semantics remain isolated.
+
+## Milestone 3: Lifecycle completion
+
+- [ ] Reconcile implementation/testing docs and verify design alignment.
+- [ ] Run focused tests, build (6 projects), full tests, lint, feature lint, and e2e.
+- [ ] Complete final review, create logical conventional commits, rebase on fetched `origin/main`, push, and open a PR.
+
+## Dependencies and Risks
+
+- Reuse existing Git/filesystem mocks in `SkillManager.test.ts`.
+- Retaining rejected promises is intentional and must not cause unhandled rejections.
+- PR #202 may later redirect init through install; registry-local behavior requires no caller migration.
+- Command mocks may not exercise real Git calls; unit tests provide exact operation-count evidence.
+
+## Progress Summary
+
+Core implementation and caller coverage are complete. Next: independently evaluate merged-catalog memoization, then full validation and review.

--- a/docs/ai/planning/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/planning/2026-08-28-feature-registry-prep-once.md
@@ -16,7 +16,7 @@ description: TDD task breakdown for one preparation per registry instance
 
 - [x] Move cache-check messaging from `SkillManager` into the first registry preparation and assert start/success/stale output once.
 - [x] Add or strengthen command/service coverage for init built-ins, mixed-registry templates, mixed-registry install, `skill add --built-in`, and setup. Evidence: four caller suites pass 79 tests.
-- [ ] Evaluate `fetchMergedRegistry` instance memoization independently; implement in a separate commit only if a focused red/green test and clear failure semantics remain isolated.
+- [x] Memoize `fetchMergedRegistry` independently. Its focused test observed 3 fetch/config reads red and 1 green; implementation is one instance promise plus one private loader.
 
 ## Milestone 3: Lifecycle completion
 
@@ -33,4 +33,4 @@ description: TDD task breakdown for one preparation per registry instance
 
 ## Progress Summary
 
-Core implementation and caller coverage are complete. Next: independently evaluate merged-catalog memoization, then full validation and review.
+Implementation and caller coverage are complete. Next: full validation and review.

--- a/docs/ai/requirements/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/requirements/2026-08-28-feature-registry-prep-once.md
@@ -1,0 +1,50 @@
+---
+phase: requirements
+title: Prepare each skill registry once per command
+description: Remove duplicate registry refreshes during multi-skill installation
+---
+
+# Prepare each skill registry once per command
+
+## Problem Statement
+
+`SkillManager.addSkill()` asks `SkillRegistry` to prepare its cache repository for every skill. Multi-skill flows such as `init --built-in`, template init, install reconciliation, `skill add --built-in`, and setup therefore pull the same registry repeatedly. The built-in set contains 20 skills, causing 20 refresh attempts and repeated cache messages in one command.
+
+## Goals
+
+- Prepare each distinct registry once per `SkillRegistry` instance, including concurrent requests.
+- Keep `SkillManager` responsible for skill orchestration and `SkillRegistry` responsible for cache repositories.
+- Preserve one fresh-cache attempt per command, stale-cache fallback, public signatures, per-skill installation, and mixed-registry isolation.
+- Print one registry-specific refresh start and outcome instead of one generic cache check per skill.
+
+## Non-goals
+
+- Cross-process or time-based cache freshness, TTLs, new flags, or persisted timestamps.
+- A batch skill API or changes to public method signatures.
+- Retrying a failed refresh for later skills in the same run.
+
+## User Stories
+
+- As a user installing many skills from one registry, I wait for one repository refresh.
+- As a user with a stale cache during a network failure, I see one warning and all eligible skills use the same cached snapshot.
+- As a user installing from mixed registries, each registry is prepared independently once.
+
+## Success Criteria
+
+- Same-registry sequential and concurrent calls share one preparation promise.
+- A successful refresh, stale fallback, terminal no-cache failure, and non-Git cache result are reused for the instance.
+- A second `SkillRegistry` instance refreshes again.
+- Registry ID alone is the memoization key.
+- `SkillManager` no longer prints `Checking local cache...`; `SkillRegistry` prints one start and one success or stale outcome.
+- Existing command behavior and full validation suites remain green.
+
+## Constraints and Assumptions
+
+- Store the promise before awaiting it to deduplicate concurrent work.
+- The first result defines the registry snapshot for that instance; later skills do not retry after stale fallback or terminal failure.
+- Current callers do not change a registry URL while reusing one `SkillRegistry` instance.
+- PR #202 is not in fetched `origin/main`; the registry-local design avoids conflict with its init/install consolidation.
+
+## Open Items
+
+None. Option A and its freshness policy are approved.

--- a/docs/ai/testing/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/testing/2026-08-28-feature-registry-prep-once.md
@@ -20,6 +20,7 @@ Cover 100% of new branches and all approved freshness/failure semantics. Mock Gi
 - [x] A second `SkillRegistry`/`SkillManager` instance refreshes again.
 - [x] A non-Git cached registry is accepted and reported once.
 - [x] Refresh start/success outcomes appear once and `Checking local cache...` is absent.
+- [x] Sequential and concurrent merged-catalog requests share one network/config-read promise per instance.
 
 ## Command and Service Tests
 
@@ -45,4 +46,4 @@ Reuse temporary cache paths and mocked `pullRepository`, `cloneRepository`, `isG
 
 ## Results
 
-Focused registry/manager suites: 80 passed. Caller suites: 79 passed. Full validation remains pending.
+Focused registry/manager suites: 81 passed. Caller suites: 79 passed. Full validation remains pending.

--- a/docs/ai/testing/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/testing/2026-08-28-feature-registry-prep-once.md
@@ -1,0 +1,48 @@
+---
+phase: testing
+title: Registry preparation testing strategy
+description: Unit, command, integration, and regression evidence
+---
+
+# Registry preparation testing strategy
+
+## Coverage Goal
+
+Cover 100% of new branches and all approved freshness/failure semantics. Mock Git and filesystem boundaries for deterministic operation counts; retain command/service tests for caller integration.
+
+## Unit Tests
+
+- [x] Two sequential skills from one registry cause one pull.
+- [x] Concurrent preparations share one in-flight pull.
+- [x] Two registries prepare independently once each.
+- [x] Failed refresh with an existing cache warns once and reuses stale contents without retry.
+- [x] Failed clone without a cache rejects later calls without retry.
+- [x] A second `SkillRegistry`/`SkillManager` instance refreshes again.
+- [x] A non-Git cached registry is accepted and reported once.
+- [x] Refresh start/success outcomes appear once and `Checking local cache...` is absent.
+
+## Command and Service Tests
+
+- [x] `init --built-in` uses one `SkillManager` for the curated set.
+- [x] Template init with repeated and mixed registries uses one manager; registry tests prove per-ID preparation.
+- [x] Install reconciliation with mixed registries uses one manager; registry tests prove per-ID preparation.
+- [x] `skill add --built-in` uses one manager and reuses its registry preparation.
+- [x] Setup invokes one built-in installer per agent; its manager loop inherits the registry guarantee.
+
+## Regression and E2E
+
+- [ ] Focused CLI tests pass.
+- [ ] `npm run build` succeeds for 6 projects.
+- [ ] Full `npm test` passes.
+- [ ] `npm run lint` passes.
+- [ ] `npx ai-devkit@latest lint --feature registry-prep-once` passes.
+- [ ] `npx vitest run --config e2e/vitest.config.ts` passes.
+- [x] Regression proof: core test passes with fix, fails with two pulls when the fix is reverted, and passes after restoration.
+
+## Fixtures
+
+Reuse temporary cache paths and mocked `pullRepository`, `cloneRepository`, `isGitRepository`, filesystem, and terminal UI from existing CLI tests. No live registry mutation or network timing benchmark is required.
+
+## Results
+
+Focused registry/manager suites: 80 passed. Caller suites: 79 passed. Full validation remains pending.

--- a/docs/ai/testing/2026-08-28-feature-registry-prep-once.md
+++ b/docs/ai/testing/2026-08-28-feature-registry-prep-once.md
@@ -32,12 +32,12 @@ Cover 100% of new branches and all approved freshness/failure semantics. Mock Gi
 
 ## Regression and E2E
 
-- [ ] Focused CLI tests pass.
-- [ ] `npm run build` succeeds for 6 projects.
-- [ ] Full `npm test` passes.
-- [ ] `npm run lint` passes.
-- [ ] `npx ai-devkit@latest lint --feature registry-prep-once` passes.
-- [ ] `npx vitest run --config e2e/vitest.config.ts` passes.
+- [x] Focused CLI tests pass (159 tests across 6 selected files before full validation).
+- [x] `npm run build` succeeds for 6 projects.
+- [x] Full `npm test` passes (159 files, 2,061 tests).
+- [x] `npm run lint` passes all 6 projects; three pre-existing warnings remain.
+- [x] `npx ai-devkit@latest lint --feature registry-prep-once` passes.
+- [x] `npx vitest run --config e2e/vitest.config.ts` passes (1 file, 41 tests).
 - [x] Regression proof: core test passes with fix, fails with two pulls when the fix is reverted, and passes after restoration.
 
 ## Fixtures
@@ -46,4 +46,4 @@ Reuse temporary cache paths and mocked `pullRepository`, `cloneRepository`, `isG
 
 ## Results
 
-Focused registry/manager suites: 81 passed. Caller suites: 79 passed. Full validation remains pending.
+All requested validation passed. No coverage gaps or blocking review findings remain for the changed behavior.

--- a/packages/cli/src/__tests__/commands/init.test.ts
+++ b/packages/cli/src/__tests__/commands/init.test.ts
@@ -90,6 +90,7 @@ vi.mock('../../util/terminal.js', () => ({
 
 import { initCommand } from '../../commands/init.js';
 import { BUILTIN_SKILL_NAMES, BUILTIN_SKILL_REGISTRY } from '../../constants.js';
+import { SkillManager } from '../../lib/SkillManager.js';
 
 function confirmCallsMatching(pattern: RegExp): any[] {
   return mockConfirm.mock.calls.filter(([config]: any[]) =>
@@ -153,6 +154,25 @@ describe('init command', () => {
     expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(2);
     expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(1, 'codeaholicguy/ai-devkit', 'debug');
     expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(2, 'codeaholicguy/ai-devkit', 'memory');
+  });
+
+  it('uses one skill manager for a mixed-registry template', async () => {
+    mockLoadInitTemplate.mockResolvedValue({
+      environments: ['codex'],
+      phases: ['requirements'],
+      skills: [
+        { registry: 'codeaholicguy/ai-devkit', skill: 'debug' },
+        { registry: 'anthropics/skills', skill: 'frontend-design' },
+        { registry: 'codeaholicguy/ai-devkit', skill: 'memory' },
+      ],
+    });
+
+    await initCommand({ template: './init.yaml' });
+
+    expect(SkillManager).toHaveBeenCalledTimes(1);
+    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(1, 'codeaholicguy/ai-devkit', 'debug');
+    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(2, 'anthropics/skills', 'frontend-design');
+    expect(mockSkillManager.addSkill).toHaveBeenNthCalledWith(3, 'codeaholicguy/ai-devkit', 'memory');
   });
 
   it('continues on skill failures and skips duplicate registry+skill entries', async () => {
@@ -244,6 +264,7 @@ describe('init command', () => {
       }
       const builtinPrompts = confirmCallsMatching(/Install AI DevKit built-in skills/);
       expect(builtinPrompts).toHaveLength(0);
+      expect(SkillManager).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/cli/src/__tests__/commands/skill.test.ts
+++ b/packages/cli/src/__tests__/commands/skill.test.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import { registerSkillCommand } from '../../commands/skill.js';
 import { ui } from '../../util/terminal-ui.js';
+import { SkillManager } from '../../lib/SkillManager.js';
 
 const mockRemoveCache = vi.hoisted(() => vi.fn());
 
@@ -338,6 +339,7 @@ describe('skill command', () => {
       global: undefined,
       environments: undefined,
     });
+    expect(SkillManager).toHaveBeenCalledTimes(1);
   });
 
   it('exits when skill add has neither registry nor --built-in', async () => {

--- a/packages/cli/src/__tests__/lib/SkillRegistry.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillRegistry.test.ts
@@ -1,0 +1,140 @@
+import type { Mocked } from 'vitest';
+import fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
+import { SkillRegistry, SKILL_CACHE_DIR } from '../../lib/SkillRegistry.js';
+import { ConfigManager } from '../../lib/Config.js';
+import { GlobalConfigManager } from '../../lib/GlobalConfig.js';
+import * as gitUtil from '../../util/git.js';
+
+const mockUi = vi.hoisted(() => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  text: vi.fn(),
+  error: vi.fn(),
+  summary: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(),
+    ensureDir: vi.fn(),
+  },
+}));
+
+vi.mock('../../util/git.js', () => ({
+  ensureGitInstalled: vi.fn(),
+  cloneRepository: vi.fn(),
+  isGitRepository: vi.fn(),
+  pullRepository: vi.fn(),
+}));
+
+vi.mock('../../util/terminal-ui.js', () => ({ ui: mockUi }));
+
+const mockedFs = fs as Mocked<typeof fs>;
+const mockedGit = gitUtil as Mocked<typeof gitUtil>;
+
+function createRegistry(): SkillRegistry {
+  return new SkillRegistry({} as ConfigManager, {} as GlobalConfigManager);
+}
+
+describe('SkillRegistry repository preparation', () => {
+  const registryId = 'example/skills';
+  const secondRegistryId = 'other/skills';
+  const gitUrl = 'https://github.com/example/skills.git';
+  const cachedPath = path.join(SKILL_CACHE_DIR, registryId);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFs.pathExists.mockResolvedValue(true);
+    mockedFs.ensureDir.mockResolvedValue(undefined);
+    mockedGit.isGitRepository.mockResolvedValue(true);
+    mockedGit.pullRepository.mockResolvedValue(undefined);
+  });
+
+  it('refreshes one registry once for sequential preparations', async () => {
+    const registry = createRegistry();
+
+    await registry.prepareRegistryRepository(registryId, gitUrl);
+    await registry.prepareRegistryRepository(registryId, gitUrl);
+
+    expect(mockedGit.pullRepository).toHaveBeenCalledTimes(1);
+    expect(mockUi.info).toHaveBeenCalledWith(`Refreshing registry ${registryId}...`);
+    expect(mockUi.success).toHaveBeenCalledWith(`Registry ${registryId} refreshed.`);
+  });
+
+  it('shares one in-flight refresh between concurrent preparations', async () => {
+    let finishPull: (() => void) | undefined;
+    mockedGit.pullRepository.mockImplementation(() => new Promise<void>(resolve => {
+      finishPull = resolve;
+    }));
+    const registry = createRegistry();
+
+    const first = registry.prepareRegistryRepository(registryId, gitUrl);
+    const second = registry.prepareRegistryRepository(registryId, gitUrl);
+    await vi.waitFor(() => expect(mockedGit.pullRepository).toHaveBeenCalledTimes(1));
+    finishPull?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([cachedPath, cachedPath]);
+    expect(mockedGit.pullRepository).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes different registries independently', async () => {
+    const registry = createRegistry();
+
+    await registry.prepareRegistryRepository(registryId, gitUrl);
+    await registry.prepareRegistryRepository(secondRegistryId, 'https://github.com/other/skills.git');
+    await registry.prepareRegistryRepository(secondRegistryId, 'ignored-url');
+
+    expect(mockedGit.pullRepository).toHaveBeenCalledTimes(2);
+    expect(mockedGit.pullRepository).toHaveBeenCalledWith(path.join(SKILL_CACHE_DIR, secondRegistryId));
+  });
+
+  it('reuses stale cache after one failed refresh without retrying', async () => {
+    mockedGit.pullRepository.mockRejectedValue(new Error('network down'));
+    const registry = createRegistry();
+
+    await expect(registry.prepareRegistryRepository(registryId, gitUrl)).resolves.toBe(cachedPath);
+    await expect(registry.prepareRegistryRepository(registryId, gitUrl)).resolves.toBe(cachedPath);
+
+    expect(mockedGit.pullRepository).toHaveBeenCalledTimes(1);
+    expect(mockUi.warning).toHaveBeenCalledTimes(1);
+    expect(mockUi.warning).toHaveBeenCalledWith(
+      `Could not refresh registry ${registryId}: network down. Using cached registry contents for this run.`,
+    );
+  });
+
+  it('reuses a failed no-cache preparation without retrying', async () => {
+    mockedFs.pathExists.mockResolvedValue(false);
+    mockedGit.cloneRepository.mockRejectedValue(new Error('clone failed'));
+    const registry = createRegistry();
+
+    await expect(registry.prepareRegistryRepository(registryId, gitUrl)).rejects.toThrow('clone failed');
+    await expect(registry.prepareRegistryRepository(registryId, gitUrl)).rejects.toThrow('clone failed');
+
+    expect(mockedGit.cloneRepository).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes again for a second registry instance', async () => {
+    await createRegistry().prepareRegistryRepository(registryId, gitUrl);
+    await createRegistry().prepareRegistryRepository(registryId, gitUrl);
+
+    expect(mockedGit.pullRepository).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses a non-git cached registry without repeating its outcome', async () => {
+    mockedGit.isGitRepository.mockResolvedValue(false);
+    const registry = createRegistry();
+
+    await registry.prepareRegistryRepository(registryId, gitUrl);
+    await registry.prepareRegistryRepository(registryId, gitUrl);
+
+    expect(mockedGit.isGitRepository).toHaveBeenCalledTimes(1);
+    expect(mockedGit.pullRepository).not.toHaveBeenCalled();
+    expect(mockUi.warning).toHaveBeenCalledTimes(1);
+    expect(mockUi.warning).toHaveBeenCalledWith(
+      `Cached registry ${registryId} is not a git repository, using as-is.`,
+    );
+  });
+});

--- a/packages/cli/src/__tests__/lib/SkillRegistry.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillRegistry.test.ts
@@ -1,7 +1,6 @@
 import type { Mocked } from 'vitest';
 import fs from 'fs-extra';
 import * as path from 'path';
-import * as os from 'os';
 import { SkillRegistry, SKILL_CACHE_DIR } from '../../lib/SkillRegistry.js';
 import { ConfigManager } from '../../lib/Config.js';
 import { GlobalConfigManager } from '../../lib/GlobalConfig.js';

--- a/packages/cli/src/__tests__/lib/SkillRegistry.test.ts
+++ b/packages/cli/src/__tests__/lib/SkillRegistry.test.ts
@@ -39,6 +39,39 @@ function createRegistry(): SkillRegistry {
   return new SkillRegistry({} as ConfigManager, {} as GlobalConfigManager);
 }
 
+describe('SkillRegistry merged catalog', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches and merges the catalog once per instance', async () => {
+    const fetchRegistry = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ registries: { 'default/skills': 'default-url' } }),
+    });
+    vi.stubGlobal('fetch', fetchRegistry);
+    const configManager = {
+      getSkillRegistries: vi.fn().mockResolvedValue({ 'project/skills': 'project-url' }),
+    } as unknown as ConfigManager;
+    const globalConfigManager = {
+      getSkillRegistries: vi.fn().mockResolvedValue({ 'global/skills': 'global-url' }),
+    } as unknown as GlobalConfigManager;
+    const registry = new SkillRegistry(configManager, globalConfigManager);
+
+    const [first, second] = await Promise.all([
+      registry.fetchMergedRegistry(),
+      registry.fetchMergedRegistry(),
+    ]);
+    const third = await registry.fetchMergedRegistry();
+
+    expect(first).toEqual(second);
+    expect(second).toEqual(third);
+    expect(fetchRegistry).toHaveBeenCalledTimes(1);
+    expect(globalConfigManager.getSkillRegistries).toHaveBeenCalledTimes(1);
+    expect(configManager.getSkillRegistries).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('SkillRegistry repository preparation', () => {
   const registryId = 'example/skills';
   const secondRegistryId = 'other/skills';

--- a/packages/cli/src/__tests__/services/install/install.service.test.ts
+++ b/packages/cli/src/__tests__/services/install/install.service.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../../lib/SkillManager.js', () => ({
 }));
 
 import { getInstallExitCode, reconcileAndInstall } from '../../../services/install/install.service.js';
+import { SkillManager } from '../../../lib/SkillManager.js';
 
 describe('install service', () => {
   const installConfig = {
@@ -88,6 +89,23 @@ describe('install service', () => {
     expect(report.phases.installed).toBe(1);
     expect(report.skills.installed).toBe(1);
     expect(report.warnings).toEqual([]);
+  });
+
+  it('uses one skill manager while reconciling mixed registries', async () => {
+    const mixedRegistryConfig = {
+      ...installConfig,
+      skills: [
+        { registry: 'codeaholicguy/ai-devkit', name: 'debug' },
+        { registry: 'anthropics/skills', name: 'frontend-design' },
+        { registry: 'codeaholicguy/ai-devkit', name: 'memory' },
+      ],
+    };
+
+    const report = await reconcileAndInstall(mixedRegistryConfig, {});
+
+    expect(SkillManager).toHaveBeenCalledTimes(1);
+    expect(mockSkillManager.addSkill).toHaveBeenCalledTimes(3);
+    expect(report.skills.installed).toBe(3);
   });
 
   it('reinstalls existing generated artifacts without prompting for overwrite', async () => {

--- a/packages/cli/src/lib/SkillManager.ts
+++ b/packages/cli/src/lib/SkillManager.ts
@@ -86,7 +86,6 @@ export class SkillManager {
       );
     }
 
-    ui.info('Checking local cache...');
     const repoPath = await this.registry.prepareRegistryRepository(registryId, gitUrl);
 
     const resolvedSkillNames = skillName

--- a/packages/cli/src/lib/SkillRegistry.ts
+++ b/packages/cli/src/lib/SkillRegistry.ts
@@ -31,6 +31,8 @@ export interface UpdateSummary {
 }
 
 export class SkillRegistry {
+  private readonly preparedRepositories = new Map<string, Promise<string>>();
+
   constructor(
     private configManager: ConfigManager,
     private globalConfigManager: GlobalConfigManager
@@ -97,13 +99,27 @@ export class SkillRegistry {
   }
 
   async prepareRegistryRepository(registryId: string, gitUrl?: string): Promise<string> {
+    const preparedRepository = this.preparedRepositories.get(registryId);
+    if (preparedRepository) {
+      return preparedRepository;
+    }
+
+    const preparation = this.refreshOrUseStaleCache(registryId, gitUrl);
+    this.preparedRepositories.set(registryId, preparation);
+    return preparation;
+  }
+
+  private async refreshOrUseStaleCache(registryId: string, gitUrl?: string): Promise<string> {
     const cachedPath = path.join(SKILL_CACHE_DIR, registryId);
+    ui.info(`Refreshing registry ${registryId}...`);
 
     try {
-      return await this.cloneRepositoryToCache(registryId, gitUrl);
+      const repositoryPath = await this.cloneRepositoryToCache(registryId, gitUrl);
+      ui.success(`Registry ${registryId} refreshed.`);
+      return repositoryPath;
     } catch (error: unknown) {
       if (await fs.pathExists(cachedPath)) {
-        ui.warning(`Failed to refresh ${registryId}: ${getErrorMessage(error)}. Using cached registry contents.`);
+        ui.warning(`Could not refresh registry ${registryId}: ${getErrorMessage(error)}. Using cached registry contents for this run.`);
         return cachedPath;
       }
 

--- a/packages/cli/src/lib/SkillRegistry.ts
+++ b/packages/cli/src/lib/SkillRegistry.ts
@@ -31,6 +31,7 @@ export interface UpdateSummary {
 }
 
 export class SkillRegistry {
+  private mergedRegistry?: Promise<SkillRegistryData>;
   private readonly preparedRepositories = new Map<string, Promise<string>>();
 
   constructor(
@@ -48,7 +49,15 @@ export class SkillRegistry {
     return response.json() as Promise<SkillRegistryData>;
   }
 
-  async fetchMergedRegistry(): Promise<SkillRegistryData> {
+  fetchMergedRegistry(): Promise<SkillRegistryData> {
+    if (!this.mergedRegistry) {
+      this.mergedRegistry = this.loadMergedRegistry();
+    }
+
+    return this.mergedRegistry;
+  }
+
+  private async loadMergedRegistry(): Promise<SkillRegistryData> {
     let defaultRegistries: Record<string, string> = {};
 
     try {


### PR DESCRIPTION
## Summary

Multi-skill commands (`init --built-in`, templates, `install`, `skill add --built-in`, agent `setup`) previously refreshed the registry cache repository **once per skill** — 20 skills from one registry meant 20 sequential clone-or-fetch rounds and 20 "Checking local cache..." lines.

**Fix: per-instance promise memoization in `SkillRegistry.prepareRegistryRepository()`** — one preparation per registry per command run, concurrency-safe (the promise is stored before awaiting, so concurrent callers share one pull). Public signatures unchanged, zero caller changes, `SkillRegistry` keeps sole ownership of cache state and Git operations.

**Freshness/failure policy:** first refresh result — fresh, stale-fallback, or terminal failure — is reused for the whole run. Stale-cache fallback now happens once per registry ("Using cached registry contents for this run"), never per-skill, so one command can't install skills from mixed repository states. Keyed by registry ID only; no TTL (instances are per-command, so cross-command freshness semantics are unchanged).

**UX:** the generic per-skill "Checking local cache..." moves out of `SkillManager`; the registry prints one start line (`Refreshing registry X...`) and one outcome line.

**Second commit:** `fetchMergedRegistry()` catalog lookups are also memoized per instance — the independently-verified duplicate work — kept as a separate, independently-tested commit.

## Validation

- `npm run build` — 6/6 projects
- Full `npm test` — 2,061 tests across 159 files (includes 81 focused post-rebase re-run)
- `npm run lint` + feature lint — clean (pre-existing warnings only)
- E2E suite — 41/41 passed

## Test coverage

Same-registry dedup (pull exactly once) · concurrent callers share one pull · multi-registry prepares each once · stale-fallback fires once per run · no-cache failure rejects once without retries · second manager instance refreshes again (instance-scope proof) · non-git cached registry handled once · command-level: `init --built-in` (1 preparation for 20 skills), template with mixed registries + duplicate skill, `install` mixed registries, `skill add --built-in`, agent `setup`.

Lifecycle docs: `docs/ai/*2026-08-28-feature-registry-prep-once.md` (requirements/design/planning/implementation/testing).