### PR TITLE
feat(memory): improve full-text retrieval

### DIFF
--- a/docs/ai/design/2026-08-29-feature-memory-fts.md
+++ b/docs/ai/design/2026-08-29-feature-memory-fts.md
@@ -1,0 +1,34 @@
+---
+phase: design
+title: Memory full-text search design
+description: Staged deterministic lexical retrieval over FTS5
+---
+# Design
+
+```mermaid
+flowchart LR
+  Caller --> Handler[searchKnowledge]
+  Handler --> Tokens[Pure normalization]
+  Tokens --> Strict[AND FTS]
+  Strict -->|hit| Rank[Coverage/BM25 + existing boosts]
+  Strict -->|empty, 2+ tokens| Broad[OR FTS]
+  Broad --> Rank
+  Tokens -->|empty| Recent
+  Rank --> Result[Results + strategy]
+  Recent --> Result
+```
+
+## Contracts
+No schema change. `SearchKnowledgeResult` gains `strategy: 'strict' | 'broad' | 'recent'`. Raw candidates gain `token_coverage` in `0..1`; strict candidates use 1. Pure exported builders remain the eval seam, without a provider class, registry, flag, or speculative semantic interface.
+
+## Components
+- Normalize Unicode input into safe alphanumeric technical segments; punctuation and separators become boundaries. Compare lowercased tokens against a small stopword set, remove one-character tokens, and deduplicate in order.
+- Quote each term and place prefix `*` outside the quote. `buildFtsQuery` retains implicit AND.
+- A pure broad builder joins the same terms with `OR`. Broad SQL computes per-row matched-token coverage and orders coverage descending, BM25 ascending before a bounded limit.
+- The handler uses recent items only for no searchable tokens, executes strict first, broad only after empty strict with 2+ tokens, applies one final rank/top-k pass, and does not catch database errors.
+
+## Decisions
+Staging preserves precision while improving recall. Coverage prevents one common term from dominating broad search. The internal candidate multiplier serves the current top-k caller and is not a flag. Stopwords alone, OR-only, best-single-token, custom tokenizers, synonyms, and embeddings are rejected for this scope.
+
+## Non-functional requirements
+No network/dependency/migration. Queries stay parameterized. Candidate work is bounded for the existing 50 ms target. The only behavioral incompatibility is intentional: hidden database failures now surface.

--- a/docs/ai/implementation/2026-08-29-feature-memory-fts.md
+++ b/docs/ai/implementation/2026-08-29-feature-memory-fts.md
@@ -1,0 +1,22 @@
+---
+phase: implementation
+title: Memory full-text search implementation
+description: Implementation record for staged lexical retrieval
+---
+# Implementation
+
+## Setup and structure
+Worktree `.worktrees/feature-memory-fts`, branch `feature-memory-fts`, fetched `origin/main`; bootstrapped with `npm ci` and a successful six-project `npm run build`.
+
+Planned touchpoints: `services/search.ts` for pure builders, `handlers/search.ts` for orchestration, `services/ranker.ts` for coverage-aware scoring, `types/index.ts` for additive metadata, and focused memory tests.
+
+## Notes
+`services/search.ts` now exports deterministic token normalization plus strict and broad prefix-query builders. Unicode letter/number runs split punctuation and technical separators safely; a small English set, one-character noise, and duplicates are removed. The stopword set is the only new constant and directly serves sentence callers. Focused red evidence: 8/8 tests failed against the old builder. Green evidence: `npx vitest run tests/unit/search.test.ts`, 8/8 passed.
+
+FTS errors will propagate through existing boundaries; all expressions remain bound parameters and broad retrieval remains bounded.
+
+`services/search.ts` also exports parameterized broad SQL. Coverage uses correlated FTS rowid subqueries because SQLite rejects `MATCH` directly in the selected arithmetic expression. `handlers/search.ts` keeps one direct staged flow: strict candidates use the existing 2× pool; empty strict queries with at least two tokens use a 4× broad pool; noise-only input uses recent rows. `ranker.ts` multiplies normalized BM25 by token coverage before existing tag/scope boosts. `types/index.ts` adds required strategy metadata.
+
+No schema, dependency, CLI presentation, eval, or semantic changes were made. The design was implemented without deviations. Shared `/tmp` initially caused unrelated SQLite I/O failures; after stale fixtures were removed, the memory package passed 133/133 tests.
+
+Final review traced exported builders and result types through memory, CLI, and dashboard callers and found no blocking issues. Fresh final evidence: memory 133/133 with 100% coverage on the three changed runtime modules; workspace tests 6/6 projects; e2e 41/41; build and lint 6/6 projects; feature-doc lint clean.

--- a/docs/ai/planning/2026-08-29-feature-memory-fts.md
+++ b/docs/ai/planning/2026-08-29-feature-memory-fts.md
@@ -1,0 +1,19 @@
+---
+phase: planning
+title: Memory full-text search plan
+description: TDD plan for staged lexical retrieval
+---
+# Plan
+
+## Milestones and tasks
+- [x] Correctness: safe normalization/builders and honest FTS error propagation are complete via red/green and reverse-fix tests.
+- [x] Retrieval: broad SQL, coverage scoring, strict-first orchestration, bounded candidate expansion, no single-token retry, existing boosts, and metadata are complete via red/green tests.
+- [x] Verification and review: all required gates pass and holistic review found no blocking issues. Commit, rebase/revalidation, push, and PR remain publication steps.
+
+Every production behavior requires a focused failing test first. The eval sibling may import pure builders but this branch will not edit its harness. Future semantic fusion gets no abstraction until it has a current caller.
+
+## Risks
+OR noise is limited by requiring two terms and coverage ranking. Technical-token damage is limited by conservative preprocessing. Public compatibility is additive. Candidate cost is bounded.
+
+## Status
+Implementation and review are complete. Reverse-fix tests fail for unsafe punctuation, disabled broad fallback, and swallowed FTS errors. After stale `/tmp` fixtures were removed, the full six-project test gate passed, including CLI 1,083/1,083 and memory 133/133; e2e passed 41/41; six-project build/lint, feature-doc lint, and 100% changed-module coverage also pass. Publication remains. Task tracing is unavailable.

--- a/docs/ai/requirements/2026-08-29-feature-memory-fts.md
+++ b/docs/ai/requirements/2026-08-29-feature-memory-fts.md
@@ -1,0 +1,32 @@
+---
+phase: requirements
+title: Memory full-text search improvements
+description: Reliable local lexical retrieval for natural-language agent queries
+---
+# Requirements
+
+## Problem
+Callers submit task sentences, but every prefix token is currently required. Stopwords or one unmatched word produce zero results; punctuation such as a trailing `?` can raise FTS syntax errors that are silently converted into unrelated recent memories.
+
+## Goals
+- Safely normalize sentences, punctuation, quotes, hyphens, paths, and package names.
+- Drop a small English stopword set, one-character noise, and duplicate tokens.
+- Search strict AND first; retry empty strict searches with OR when at least two meaningful tokens remain.
+- Rank broad candidates by token coverage and BM25, then preserve existing tag/scope boosts.
+- Use a larger bounded candidate pool before top-k and return `strict`, `broad`, or `recent` metadata.
+- Keep exported pure `buildFtsQuery`/`buildSearchQuery` functions and a small lexical seam.
+- Surface FTS errors; never disguise them as recent results.
+
+## Non-goals
+Eval harnesses, embeddings/semantic fusion, single-token fallback, synonyms, tokenizer/schema changes, storage enrichment, and CLI presentation changes.
+
+## Acceptance criteria
+- All assigned normalization cases produce valid parameterized FTS queries.
+- Noise-only queries retain recent-item behavior and report `recent`.
+- Strict success never runs broad retrieval; empty strict retrieval with 2+ tokens does.
+- Broad scoring includes normalized coverage and BM25 before existing boosts.
+- Existing response fields remain compatible and strategy metadata is additive.
+- Changed code has full branch/line/function/statement coverage; six-project build, full tests, lint, and e2e pass.
+
+## Constraints and resolved questions
+SQLite FTS5 and its existing schema/tokenizer remain authoritative; there are no new runtime dependencies. English preprocessing is intentionally small. Candidate expansion is bounded. The sibling eval gates relevance and future semantic work may fuse lexical output. No material questions remain because scope and gates were explicitly assigned.

--- a/docs/ai/testing/2026-08-29-feature-memory-fts.md
+++ b/docs/ai/testing/2026-08-29-feature-memory-fts.md
@@ -1,0 +1,27 @@
+---
+phase: testing
+title: Memory full-text search testing
+description: Regression plan for staged lexical retrieval
+---
+# Testing
+
+Target: 100% statements, branches, functions, and lines for changed search modules, using temporary real SQLite databases.
+
+## Unit scenarios
+- [x] `?`, punctuation, straight/curly quotes, apostrophes, hyphens, POSIX/Windows paths, scoped packages, and dotted identifiers are safe.
+- [x] Stopwords, one-character noise, duplicates, and noise-only input are deterministic.
+- [x] Strict uses implicit AND; broad uses OR; SQL is parameterized and exposes coverage.
+- [x] Coverage, BM25, context tags, and scope affect final order as designed.
+
+## Integration scenarios
+- [x] Strict success reports `strict`; empty strict retries broad and reports `broad`.
+- [x] One meaningful token has no additional fallback; noise-only input reports `recent`.
+- [x] Database/FTS errors propagate rather than returning recent memories.
+- [x] Broad retrieval expands bounded candidates before top-k and preserves response fields.
+
+## Mutation proof and gates
+- [x] Restoring unsafe punctuation, AND-only behavior, or the swallowed-error catch fails its regression test.
+- [x] Focused TDD tests and memory coverage pass: 40 tests and 100% statements/branches/functions/lines.
+- [x] Required gates: build, full tests, lint, and e2e pass after stale shared `/tmp` fixtures were removed.
+
+Fixtures remain small and deterministic; eval and semantic fixtures are out of scope.

--- a/packages/memory/src/handlers/search.ts
+++ b/packages/memory/src/handlers/search.ts
@@ -1,5 +1,12 @@
 import { getDatabase } from '../database/index.js';
-import { buildFtsQuery, buildSearchQuery, buildSimpleQuery } from '../services/search.js';
+import {
+    buildBroadFtsQuery,
+    buildBroadSearchQuery,
+    buildFtsQuery,
+    buildSearchQuery,
+    buildSimpleQuery,
+    normalizeSearchTokens,
+} from '../services/search.js';
 import { rankResults } from '../services/ranker.js';
 import { ValidationError } from '../utils/errors.js';
 import type { SearchKnowledgeInput, SearchKnowledgeResult } from '../types/index.js';
@@ -8,6 +15,7 @@ const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 20;
 const MIN_QUERY_LENGTH = 3;
 const MAX_QUERY_LENGTH = 500;
+const BROAD_CANDIDATE_MULTIPLIER = 4;
 
 interface RawSearchRow {
     id: string;
@@ -16,6 +24,7 @@ interface RawSearchRow {
     tags: string;
     scope: string;
     bm25_score: number;
+    token_coverage?: number;
 }
 
 export function searchKnowledge(input: SearchKnowledgeInput): SearchKnowledgeResult {
@@ -24,23 +33,33 @@ export function searchKnowledge(input: SearchKnowledgeInput): SearchKnowledgeRes
     const db = getDatabase();
     const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
     const ftsQuery = buildFtsQuery(input.query);
+    const tokens = normalizeSearchTokens(input.query);
 
     let rows: RawSearchRow[];
+    let strategy: SearchKnowledgeResult['strategy'];
 
     if (ftsQuery === '') {
-        // Empty or invalid query - return recent items
+        // A query containing no searchable terms returns recent items.
         const { sql, params } = buildSimpleQuery(input.scope, limit);
         rows = db.query<RawSearchRow>(sql, params);
+        strategy = 'recent';
     } else {
         // Full-text search with BM25
         const { sql, params } = buildSearchQuery(ftsQuery, input.scope, limit * 2);
 
-        try {
-            rows = db.query<RawSearchRow>(sql, params);
-        } catch (error) {
-            // FTS query syntax error - fallback to simple query
-            const { sql: fallbackSql, params: fallbackParams } = buildSimpleQuery(input.scope, limit);
-            rows = db.query<RawSearchRow>(fallbackSql, fallbackParams);
+        rows = db.query<RawSearchRow>(sql, params);
+        strategy = 'strict';
+
+        if (rows.length === 0 && tokens.length >= 2) {
+            const broadQuery = buildBroadFtsQuery(input.query);
+            const broad = buildBroadSearchQuery(
+                broadQuery,
+                tokens,
+                input.scope,
+                limit * BROAD_CANDIDATE_MULTIPLIER,
+            );
+            rows = db.query<RawSearchRow>(broad.sql, broad.params);
+            strategy = 'broad';
         }
     }
 
@@ -57,6 +76,7 @@ export function searchKnowledge(input: SearchKnowledgeInput): SearchKnowledgeRes
         results,
         totalMatches: ranked.length,
         query: input.query,
+        strategy,
     };
 }
 

--- a/packages/memory/src/services/ranker.ts
+++ b/packages/memory/src/services/ranker.ts
@@ -7,6 +7,7 @@ interface RawSearchResult {
     tags: string;
     scope: string;
     bm25_score: number;
+    token_coverage?: number;
 }
 
 interface RankingContext {
@@ -55,7 +56,7 @@ function calculateScopeBoost(itemScope: string, queryScope?: string | null): num
 /**
  * Apply ranking formula to search results
  * 
- * Formula: final_score = bm25_score × tag_boost + scope_boost
+ * Formula: final_score = bm25_score × token_coverage × tag_boost + scope_boost
  */
 export function rankResults(
     results: RawSearchResult[],
@@ -76,7 +77,7 @@ export function rankResults(
         // We negate it to make higher values better
         const normalizedBm25 = -result.bm25_score;
 
-        const finalScore = (normalizedBm25 * tagBoost) + scopeBoost;
+        const finalScore = (normalizedBm25 * (result.token_coverage ?? 1) * tagBoost) + scopeBoost;
 
         return {
             id: result.id,

--- a/packages/memory/src/services/search.ts
+++ b/packages/memory/src/services/search.ts
@@ -3,17 +3,29 @@
  * Converts natural language queries to FTS5 match expressions
  */
 
-/**
- * Escape special FTS5 characters to prevent query syntax errors
- */
-function escapeFtsSpecialChars(text: string): string {
-    // FTS5 special characters: " * ^ - : OR AND NOT ( )
-    return text
-        .replace(/"/g, '""')  // Escape quotes by doubling
-        .replace(/[*^():-]/g, ' ')  // Replace operators with space (including hyphen)
-        .replace(/\b(AND|OR|NOT)\b/gi, '')  // Remove boolean operators
-        .trim()
-        .replace(/\s+/g, ' ');  // Collapse multiple spaces
+const STOPWORDS = new Set([
+    'a', 'an', 'and', 'are', 'as', 'at', 'be', 'been', 'but', 'by', 'do', 'does',
+    'for', 'from', 'had', 'has', 'have', 'how', 'i', 'if', 'in', 'is', 'it', 'of',
+    'on', 'or', 'should', 'that', 'the', 'their', 'this', 'to', 'was', 'what',
+    'when', 'where', 'which', 'who', 'why', 'will', 'with', 'you', 'your',
+]);
+
+export function normalizeSearchTokens(query: string): string[] {
+    const matches = query.normalize('NFKC').match(/[\p{L}\p{N}]+/gu) ?? [];
+    const seen = new Set<string>();
+
+    return matches.flatMap(token => {
+        const normalized = token.toLowerCase();
+        if (normalized.length === 1 || STOPWORDS.has(normalized) || seen.has(normalized)) {
+            return [];
+        }
+        seen.add(normalized);
+        return [normalized];
+    });
+}
+
+function buildPrefixTerms(query: string): string[] {
+    return normalizeSearchTokens(query).map(token => `"${token}"*`);
 }
 
 /**
@@ -25,16 +37,11 @@ function escapeFtsSpecialChars(text: string): string {
  * - Escape special characters
  */
 export function buildFtsQuery(query: string): string {
-    const escaped = escapeFtsSpecialChars(query);
-    const words = escaped.split(/\s+/).filter(w => w.length > 0);
+    return buildPrefixTerms(query).join(' ');
+}
 
-    if (words.length === 0) {
-        return '';
-    }
-
-    // Use prefix matching for each word
-    // This allows "api design" to match "API", "designing", etc.
-    return words.map(word => `${word}*`).join(' ');
+export function buildBroadFtsQuery(query: string): string {
+    return buildPrefixTerms(query).join(' OR ');
 }
 
 /**
@@ -57,7 +64,8 @@ export function buildSearchQuery(
       k.scope,
       k.created_at,
       k.updated_at,
-      bm25(knowledge_fts, 10.0, 5.0, 1.0) as bm25_score
+      bm25(knowledge_fts, 10.0, 5.0, 1.0) as bm25_score,
+      1.0 as token_coverage
     FROM knowledge k
     JOIN knowledge_fts fts ON k.rowid = fts.rowid
     WHERE knowledge_fts MATCH ?
@@ -75,6 +83,37 @@ export function buildSearchQuery(
     return { sql, params };
 }
 
+export function buildBroadSearchQuery(
+    ftsQuery: string,
+    tokens: string[],
+    scope?: string | null,
+    limit = 5
+): { sql: string; params: unknown[] } {
+    const tokenMatches = tokens.map(() =>
+        '(CASE WHEN k.rowid IN (SELECT rowid FROM knowledge_fts WHERE knowledge_fts MATCH ?) THEN 1 ELSE 0 END)'
+    ).join(' + ');
+    const params: unknown[] = tokens.map(token => `"${token}"*`);
+    let sql = `
+    SELECT
+      k.id, k.title, k.content, k.tags, k.scope, k.created_at, k.updated_at,
+      bm25(knowledge_fts, 10.0, 5.0, 1.0) as bm25_score,
+      CAST((${tokenMatches}) AS REAL) / ${tokens.length} as token_coverage
+    FROM knowledge k
+    JOIN knowledge_fts fts ON k.rowid = fts.rowid
+    WHERE knowledge_fts MATCH ?
+  `;
+    params.push(ftsQuery);
+
+    if (scope) {
+        sql += ` AND (k.scope = ? OR k.scope = 'global')`;
+        params.push(scope);
+    }
+
+    sql += ` ORDER BY token_coverage DESC, bm25_score LIMIT ?`;
+    params.push(limit);
+    return { sql, params };
+}
+
 /**
  * Build simple search query without FTS (fallback for empty queries)
  */
@@ -87,7 +126,8 @@ export function buildSimpleQuery(
     let sql = `
     SELECT 
       id, title, content, tags, scope, created_at, updated_at,
-      0 as bm25_score
+      0 as bm25_score,
+      1.0 as token_coverage
     FROM knowledge
   `;
 

--- a/packages/memory/src/types/index.ts
+++ b/packages/memory/src/types/index.ts
@@ -59,6 +59,7 @@ export interface SearchKnowledgeResult {
     results: SearchResultItem[];
     totalMatches: number;
     query: string;
+    strategy: 'strict' | 'broad' | 'recent';
 }
 
 export type ListKnowledgeSort = 'updated-desc' | 'created-desc' | 'title-asc';

--- a/packages/memory/tests/integration/search.test.ts
+++ b/packages/memory/tests/integration/search.test.ts
@@ -4,7 +4,7 @@ import { rmSync } from 'fs';
 import { DatabaseConnection } from '../../src/database/connection';
 import { initializeSchema } from '../../src/database/schema';
 import { ValidationError } from '../../src/utils/errors';
-import { buildFtsQuery, buildSearchQuery, buildSimpleQuery } from '../../src/services/search';
+import { buildBroadFtsQuery, buildBroadSearchQuery, buildFtsQuery, buildSearchQuery, buildSimpleQuery, normalizeSearchTokens } from '../../src/services/search';
 import { rankResults } from '../../src/services/ranker';
 import { normalizeTitle, normalizeScope, normalizeTags, hashContent } from '../../src/services/normalizer';
 import { v4 as uuidv4 } from 'uuid';
@@ -32,12 +32,13 @@ function searchKnowledgeDirect(db: DatabaseConnection, input: {
         rows = db.query(sql, params);
     } else {
         const { sql, params } = buildSearchQuery(ftsQuery, input.scope, limit * 2);
-        try {
-            rows = db.query(sql, params);
-        } catch {
-            // FTS query syntax may fail on certain inputs; fall back to simple LIKE query
-            const { sql: fallbackSql, params: fallbackParams } = buildSimpleQuery(input.scope, limit);
-            rows = db.query(fallbackSql, fallbackParams);
+        rows = db.query(sql, params);
+        const tokens = normalizeSearchTokens(input.query);
+        if (rows.length === 0 && tokens.length >= 2) {
+            const broad = buildBroadSearchQuery(
+                buildBroadFtsQuery(input.query), tokens, input.scope, limit * 4,
+            );
+            rows = db.query(broad.sql, broad.params);
         }
     }
 
@@ -132,6 +133,17 @@ describe('search handler', () => {
     });
 
     describe('ranking', () => {
+        it('executes broad SQL and exposes token coverage for partial sentence matches', () => {
+            const query = 'How should API schema migrations work';
+            const tokens = normalizeSearchTokens(query);
+            const { sql, params } = buildBroadSearchQuery(buildBroadFtsQuery(query), tokens, undefined, 10);
+
+            const rows = db.query<any>(sql, params);
+
+            expect(rows.length).toBeGreaterThan(0);
+            expect(rows.every(row => row.token_coverage > 0 && row.token_coverage <= 1)).toBe(true);
+        });
+
         it('should rank API-specific rules in top results for API queries', () => {
             const result = searchKnowledgeDirect(db, { query: 'building API endpoint' });
             const topTitles = result.results.slice(0, 3).map(r => r.title.toLowerCase());

--- a/packages/memory/tests/unit/ranker.test.ts
+++ b/packages/memory/tests/unit/ranker.test.ts
@@ -15,6 +15,7 @@ describe('ranker', () => {
         tags: '["api", "backend"]',
         scope: 'global',
         bm25_score: -1.5, // BM25 returns negative, closer to 0 = better
+        token_coverage: 1,
         ...overrides,
     });
 
@@ -77,6 +78,24 @@ describe('ranker', () => {
             expect(ranked[0].id).toBe('high');
             expect(ranked[1].id).toBe('mid');
             expect(ranked[2].id).toBe('low');
+        });
+
+        it('should prefer broader token coverage when BM25 is equal', () => {
+            const ranked = rankResults([
+                makeResult({ id: 'partial', token_coverage: 0.5 }),
+                makeResult({ id: 'broad', token_coverage: 1 }),
+            ], {});
+
+            expect(ranked.map(result => result.id)).toEqual(['broad', 'partial']);
+        });
+
+        it('should preserve legacy rows without token coverage and ignore unmatched context tags', () => {
+            const result = makeResult({ tags: '["api"]' });
+            delete (result as Partial<typeof result>).token_coverage;
+
+            const ranked = rankResults([result], { contextTags: ['frontend'] });
+
+            expect(ranked[0].score).toBe(1.7);
         });
 
         it('should prioritize project scope over global', () => {

--- a/packages/memory/tests/unit/search-handler.test.ts
+++ b/packages/memory/tests/unit/search-handler.test.ts
@@ -1,0 +1,90 @@
+import { vi } from 'vitest';
+
+const { query } = vi.hoisted(() => ({ query: vi.fn() }));
+
+vi.mock('../../src/database/index.js', () => ({
+    getDatabase: () => ({ query }),
+}));
+
+import { searchKnowledge } from '../../src/handlers/search';
+import { ValidationError } from '../../src/utils/errors';
+
+describe('searchKnowledge error handling', () => {
+    beforeEach(() => query.mockReset());
+
+    it('surfaces an FTS database error instead of returning recent items', () => {
+        const failure = new Error('malformed MATCH expression');
+        query.mockImplementationOnce(() => { throw failure; });
+        query.mockReturnValueOnce([]);
+
+        let thrown: unknown;
+        try {
+            searchKnowledge({ query: 'sqlite migration' });
+        } catch (error) {
+            thrown = error;
+        }
+        expect(thrown).toBe(failure);
+        expect(query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns strict metadata without a broad query when strict retrieval succeeds', () => {
+        query.mockReturnValueOnce([makeRow('strict')]);
+
+        const result = searchKnowledge({ query: 'sqlite migration' });
+
+        expect(result.strategy).toBe('strict');
+        expect(query).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries an empty strict search with a larger broad candidate pool', () => {
+        query.mockReturnValueOnce([]).mockReturnValueOnce([makeRow('broad', 0.5)]);
+
+        const result = searchKnowledge({ query: 'How should SQLite schema changes work?', limit: 5 });
+
+        expect(result.strategy).toBe('broad');
+        expect(result.results[0].id).toBe('broad');
+        expect(query).toHaveBeenCalledTimes(2);
+        expect(query.mock.calls[1][1].at(-1)).toBe(20);
+    });
+
+    it('does not add a fallback for a single meaningful token', () => {
+        query.mockReturnValueOnce([]);
+
+        const result = searchKnowledge({ query: 'sqlite' });
+
+        expect(result.strategy).toBe('strict');
+        expect(query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns recent metadata for a noise-only query', () => {
+        query.mockReturnValueOnce([makeRow('recent')]);
+
+        const result = searchKnowledge({ query: 'How do I do this?' });
+
+        expect(result.strategy).toBe('recent');
+        expect(query).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        [{ query: '' }, 'Query is required'],
+        [{ query: 'ab' }, 'Query must be at least 3 characters'],
+        [{ query: 'x'.repeat(501) }, 'Query must be at most 500 characters'],
+        [{ query: 'valid', limit: 0 }, 'Limit must be a positive number'],
+        [{ query: 'valid', limit: 'bad' as unknown as number }, 'Limit must be a positive number'],
+    ])('validates invalid search input %#', (input, message) => {
+        expect(() => searchKnowledge(input)).toThrow(new ValidationError(message, { errors: [message] }));
+        expect(query).not.toHaveBeenCalled();
+    });
+});
+
+function makeRow(id: string, tokenCoverage = 1) {
+    return {
+        id,
+        title: `${id} title`,
+        content: `${id} content`,
+        tags: '[]',
+        scope: 'global',
+        bm25_score: -1,
+        token_coverage: tokenCoverage,
+    };
+}

--- a/packages/memory/tests/unit/search.test.ts
+++ b/packages/memory/tests/unit/search.test.ts
@@ -1,0 +1,61 @@
+import {
+    buildBroadFtsQuery,
+    buildBroadSearchQuery,
+    buildFtsQuery,
+    buildSimpleQuery,
+    normalizeSearchTokens,
+} from '../../src/services/search';
+
+describe('search query builders', () => {
+    it.each([
+        ['How should I change SQLite migrations?', '"change"* "sqlite"* "migrations"*'],
+        ['Use “quoted values” and don\'t fail.', '"use"* "quoted"* "values"* "don"* "fail"*'],
+        ['error-handling /tmp/memory.db', '"error"* "handling"* "tmp"* "memory"* "db"*'],
+        ['C:\\repo\\node_modules\\@ai-devkit\\memory', '"repo"* "node"* "modules"* "ai"* "devkit"* "memory"*'],
+        ['@ai-devkit/memory search.ts', '"ai"* "devkit"* "memory"* "search"* "ts"*'],
+    ])('builds a safe strict query for %s', (query, expected) => {
+        expect(buildFtsQuery(query)).toBe(expected);
+    });
+
+    it('removes small English stopwords, one-character noise, and duplicate tokens', () => {
+        expect(normalizeSearchTokens('How do I use API api v2 in a project?')).toEqual([
+            'use', 'api', 'v2', 'project',
+        ]);
+    });
+
+    it('returns no terms for noise-only input', () => {
+        expect(buildFtsQuery('How do I do this?')).toBe('');
+        expect(normalizeSearchTokens('???')).toEqual([]);
+    });
+
+    it('builds an explicit OR query from the same normalized terms', () => {
+        expect(buildBroadFtsQuery('How should SQLite migrations change?')).toBe(
+            '"sqlite"* OR "migrations"* OR "change"*',
+        );
+    });
+
+    it('builds parameterized broad SQL with per-token coverage', () => {
+        const result = buildBroadSearchQuery(
+            '"sqlite"* OR "migration"*',
+            ['sqlite', 'migration'],
+            'repo:ai-devkit',
+            20,
+        );
+
+        expect(result.sql).toContain('as token_coverage');
+        expect(result.sql).toContain("AND (k.scope = ? OR k.scope = 'global')");
+        expect(result.sql).toContain('ORDER BY token_coverage DESC, bm25_score');
+        expect(result.params).toEqual([
+            '"sqlite"*', '"migration"*',
+            '"sqlite"* OR "migration"*',
+            'repo:ai-devkit',
+            20,
+        ]);
+    });
+
+    it('builds a scoped recent-items query', () => {
+        const result = buildSimpleQuery('repo:ai-devkit', 3);
+        expect(result.sql).toContain("WHERE scope = ? OR scope = 'global'");
+        expect(result.params).toEqual(['repo:ai-devkit', 3]);
+    });
+});


### PR DESCRIPTION
## Summary
- normalize natural-language queries safely across punctuation, quotes, paths, package names, stopwords, and one-character noise
- preserve strict FTS5 AND retrieval, then retry empty multi-token searches with bounded OR candidates ranked by token coverage, BM25, tags, and scope
- surface FTS errors instead of returning unrelated recent items and expose strict/broad/recent strategy metadata
- add lifecycle documentation, regression tests, and reverse-fix verification

## Validation
- npm run build (6/6 projects)
- npm test (6/6 projects; memory 133/133, CLI 1083/1083)
- npm run lint (6/6 projects; 3 unrelated existing warnings)
- npm run test:e2e (41/41)
- changed memory runtime modules: 100% statements, branches, functions, and lines
- npx ai-devkit@latest lint --feature memory-fts

## Risks
- broad fallback computes correlated FTS token-coverage subqueries; work is bounded to empty strict searches and a 4x top-k candidate pool