### PR TITLE
docs(skill): extend brainstorm self-review to guards

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -14,7 +14,7 @@ Run a compact diverge-to-converge loop.
 3. Diverge: distinct options across practical, high-leverage, and unusual angles.
 4. Challenge: weak assumptions, failure modes, tradeoffs, rejections. Always: reject speculative generality (each abstraction, layer, flag, and data copy needs a current caller) and verify load-bearing "needed" claims in the consuming code, not doc assertions.
 5. Compare: only relevant criteria, plus deletion cost (how easily the option can be removed later). Ties go to the smaller option.
-6. Converge: strongest 3 picks with rationale and a next step. Self-review first: for each new constant, object, layer, and flag ask "why do we need this?" Cut answers that are only messaging or future-proofing.
+6. Converge: strongest 3 picks with rationale and a next step. Self-review first: for each new constant, object, layer, flag, and guard (retry, fallback, timeout) ask "what demonstrated trigger does this answer?" Cut answers that are only messaging, future-proofing, or hardening without a concrete trigger scenario.
 
 ## Formats
 


### PR DESCRIPTION
## Summary

Extends the brainstorm skill's converge self-review gate to cover **guards** (retries, fallbacks, timeouts):

- Before: "for each new constant, object, layer, and flag ask 'why do we need this?'"
- After: adds **guards** to the list and sharpens the question to **"what demonstrated trigger does this answer?"** — a guard justifies itself by a concrete, checkable trigger scenario, not by general prudence.

## Rationale

The noun list had a real blind spot: a retry is a *behavior*, not a named artifact, so speculative hardening passed the very gate designed to catch it. Observed in the WAL concurrency fix (#206): a 50ms Atomics-based retry entered the implementation spec as 'belt-and-suspenders,' survived implementation and first review, and was cut only after owner challenge — the trigger scenario it guarded (simultaneous fresh-DB creation) was checkable and, in the affected caller, provably unreachable (the bench serializes its first store).

Same doctrine, extended by one noun: additions justify themselves by current caller; guards by demonstrated trigger.

Docs-only change; no code affected.