### PR TITLE
feat(status): add adapter readiness checks

### DIFF
--- a/docs/ai/design/2026-09-02-feature-status-agent-readiness.md
+++ b/docs/ai/design/2026-09-02-feature-status-agent-readiness.md
@@ -1,0 +1,103 @@
+---
+phase: design
+title: System Design & Architecture
+description: Define the technical architecture, components, and data models
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+**What is the high-level system structure?**
+
+```mermaid
+graph TD
+  StatusCommand[status command] --> StatusService[CLI status service]
+  StatusService --> VersionCheck[AI DevKit version check]
+  StatusService --> ProjectCheck[Project config check]
+  StatusService --> TmuxCheck[Shared tmux util]
+  StatusService --> RegistryInfo[Registry info]
+  StatusService --> ChannelInfo[Channel info]
+  StatusService --> AgentReadiness[agent-manager readiness]
+  AgentReadiness --> AgentsRegistry[AGENTS registry]
+  AgentReadiness --> ReadinessList[readiness-supported adapter list]
+  AgentReadiness --> GenericChecks[executable/config/built-in skills]
+  AgentReadiness --> SpecificChecks[Codex/Claude/Pi auth + integration]
+  StatusService --> Renderer[status renderer]
+```
+
+- `packages/agent-manager/src/readiness/AgentReadiness.ts` owns adapter readiness.
+- Readiness uses an explicit supported-adapter list and omits `gemini_cli` while that adapter is pending removal.
+- `packages/cli/src/services/status/status.service.ts` orchestrates the full CLI report.
+- `packages/cli/src/commands/status/render.ts` renders executable agents from the report for human output, while JSON keeps the full report.
+- Existing TypeScript/Vitest stack remains unchanged.
+
+## Data Models
+**What data do we need to manage?**
+
+- `AgentReadinessReport`:
+  - `type`
+  - `executable`
+  - `globalConfig`
+  - `builtInSkills`
+  - optional `auth`
+  - optional `integration`
+  - aggregate `status`
+- `AuthReadinessCheck` includes `provider` and `availableProviders`, with no credential values.
+- `IntegrationReadinessCheck` has a generic `label`, `installed`, and structured `details`.
+- CLI `StatusReport.agents` becomes a record keyed by all startable adapter types.
+
+## API Design
+**How do components communicate?**
+
+- `getAgentReadinessReports(options)` returns readiness reports for all startable adapters.
+- `getAgentReadinessReport(agent, options)` supports focused testing and future consumers.
+- `worstReadinessStatus(statuses)` provides shared aggregation.
+- CLI passes:
+  - `homeDir`
+  - `path`
+  - `assetRoot`
+  - `builtInSkillNames`
+  - per-agent `skillRoots`
+  - injectable file/command/auth helpers for tests.
+
+## Component Breakdown
+**What are the major building blocks?**
+
+- Generic readiness checks:
+  - executable lookup through `PATH`
+  - global config directory readability
+  - AI DevKit built-in skill presence, where missing skills warn instead of fail
+- Specific readiness checks:
+  - Codex auth via existing capacity report hook.
+  - Codex AI DevKit hook script, registration, and session mapping file.
+  - Claude auth via local credentials/config file evidence.
+  - Claude AI DevKit hook script and registration.
+  - Pi auth provider parsing from `~/.pi/agent/auth.json`.
+  - Pi AI DevKit plugin/session tracker via `pi list` plus mapping validation.
+  - OpenCode auth provider parsing from `opencode auth list`.
+- CLI-owned checks:
+  - package version
+  - project config
+  - registries
+  - channels
+  - tmux
+
+## Design Decisions
+**Why did we choose this approach?**
+
+- Adapter readiness belongs to `agent-manager` because that package already owns adapter metadata and provider-specific behavior.
+- Built-in skill names and paths stay injected from the CLI because they depend on CLI environment mapping.
+- Generic adapters omit `auth`/`integration` until there is reliable non-interactive evidence to check.
+- OpenCode has reliable non-interactive auth evidence through `opencode auth list`, so it participates in auth readiness without a hook/plugin integration.
+- Missing built-in skills are warning-level because an adapter can still run without them; the warning prompts setup or install follow-up without classifying the adapter as unusable.
+- Human output omits adapters without an executable to avoid noisy follow-up checks for tools the user does not have installed.
+- Top-level status checks use `Promise.all` because they are independent filesystem/process probes.
+- Pi stale mapping entries are informational; stale files can remain after sessions end and must not fail plugin readiness.
+
+## Non-Functional Requirements
+**How should the system perform?**
+
+- Keep status latency bounded by the slowest independent probe instead of the sum of probes.
+- Avoid serial filesystem checks inside built-in skill and mapping checks.
+- Do not expose auth token, API key, base URL, or model values in reports.
+- Preserve deterministic ordering in rendered output.

--- a/docs/ai/implementation/2026-09-02-feature-status-agent-readiness.md
+++ b/docs/ai/implementation/2026-09-02-feature-status-agent-readiness.md
@@ -1,0 +1,102 @@
+---
+phase: implementation
+title: Implementation Guide
+description: Technical implementation notes, patterns, and code guidelines
+---
+
+# Implementation Guide
+
+## Scope
+
+- Add an `agent-manager` readiness module that can report readiness for every startable adapter.
+- Migrate CLI status agent checks to the new module.
+- Keep CLI-owned checks in the CLI service.
+- Keep rendering dynamic and status scoring limited to checks that have real pass/warn/fail meaning.
+
+## Implementation Notes
+
+- Existing in-progress status changes already made registries/channels informational and consolidated tmux inspection.
+- Missing project `.ai-devkit.json` is warning-level because a directory can still be usable outside an initialized AI DevKit project; malformed project config remains failure-level.
+- Added `packages/agent-manager/src/readiness/AgentReadiness.ts`.
+- Exported `getAgentReadinessReport`, `getAgentReadinessReports`, readiness types, and `worstReadinessStatus` from `@ai-devkit/agent-manager`.
+- Removed CLI-local adapter readiness checks from `packages/cli/src/services/status/status.service.ts`.
+- `status.service.ts` now passes CLI-owned built-in skill names and per-adapter skill roots into `agent-manager`.
+- `render.ts` now iterates executable `report.agents` dynamically and renders optional `auth` and `integration` checks only when present.
+- Removed separate console warning lines for missing built-in skills.
+- Pi plugin detection accepts both `@ai-devkit/pi-session-tracker` and `session tracker` display names from `pi list`.
+- AI DevKit built-in skill counts are informational and do not affect readiness scoring.
+- Human status output renders `pass` as `ready` and `warn` as `not ready`; JSON keeps the canonical status values.
+- Copilot auth now uses the read-only GitHub CLI probe `gh auth status --hostname github.com` because Copilot can authenticate through `gh`.
+- OpenCode auth now runs `opencode auth list`, strips ANSI output, and reports credential/environment names as available providers.
+- `gemini_cli` is omitted from readiness reports while the adapter is pending removal.
+- Adapters without an executable remain available in raw diagnostics, but are excluded from scored readiness totals and human status tables.
+- Adapter-specific auth and integration dispatch uses lookup maps so adding or removing checks does not require branching in the generic readiness flow.
+- OpenCode ANSI output normalization uses a small shared regex-backed helper.
+- Built status smoke output confirms Pi auth providers `anthropic` and `litellm` are reported without credential values.
+
+## Verification
+
+- Passed: `npm test --workspace=@ai-devkit/agent-manager -- --run src/__tests__/readiness/AgentReadiness.test.ts`
+- Passed: `npm test --workspace=ai-devkit -- --run src/__tests__/commands/status.test.ts src/__tests__/services/status/status.service.test.ts`
+- Passed: `npm run build --workspace=@ai-devkit/agent-manager`
+- Passed: `npm run build --workspace=ai-devkit`
+- Passed: `npm run lint --workspace=@ai-devkit/agent-manager`
+- Passed with three pre-existing warnings outside touched files: `npm run lint --workspace=ai-devkit`
+- Passed smoke: `node packages/cli/dist/cli.js status`
+
+## Development Setup
+**How do we get started?**
+
+- Prerequisites and dependencies
+- Environment setup steps
+- Configuration needed
+
+## Code Structure
+**How is the code organized?**
+
+- Directory structure
+- Module organization
+- Naming conventions
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Core Features
+- Feature 1: Implementation approach
+- Feature 2: Implementation approach
+- Feature 3: Implementation approach
+
+### Patterns & Best Practices
+- Design patterns being used
+- Code style guidelines
+- Common utilities/helpers
+
+## Integration Points
+**How do pieces connect?**
+
+- API integration details
+- Database connections
+- Third-party service setup
+
+## Error Handling
+**How do we handle failures?**
+
+- Error handling strategy
+- Logging approach
+- Retry/fallback mechanisms
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- Optimization strategies
+- Caching approach
+- Query optimization
+- Resource management
+
+## Security Notes
+**What security measures are in place?**
+
+- Authentication/authorization
+- Input validation
+- Data encryption
+- Secrets management

--- a/docs/ai/planning/2026-09-02-feature-status-agent-readiness.md
+++ b/docs/ai/planning/2026-09-02-feature-status-agent-readiness.md
@@ -1,0 +1,59 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+**What are the major checkpoints?**
+
+- [x] Milestone 1: Capture requirements/design/test plan for all-adapter readiness.
+- [x] Milestone 2: Move agent checks into `agent-manager` and update CLI orchestration.
+- [x] Milestone 3: Verify tests, builds, feature lint, and final review.
+
+## Task Breakdown
+**What specific work needs to be done?**
+
+### Phase 1: Foundation
+- [x] Task 1.1: Add `agent-manager` readiness API and tests for all startable adapters.
+- [x] Task 1.2: Export readiness API from `@ai-devkit/agent-manager`.
+
+### Phase 2: Core Features
+- [x] Task 2.1: Replace CLI-local agent readiness code with `agent-manager` readiness calls.
+- [x] Task 2.2: Render agent checks dynamically while preserving labels for hooks, plugin, built-in skills, and Pi providers.
+
+### Phase 3: Integration & Polish
+- [x] Task 3.1: Remove obsolete CLI-local tests and add focused coverage for the new contract.
+- [x] Task 3.2: Run targeted tests, package builds, feature lint, and final diff review.
+
+## Progress Summary
+
+Implementation completed on 2026-09-02. The CLI now delegates adapter readiness to `@ai-devkit/agent-manager`, renders all startable adapters dynamically, and keeps unsupported auth/integration checks absent rather than warning.
+
+## Dependencies
+**What needs to happen in what order?**
+
+- Task 2.1 depends on Task 1.1 API shape.
+- Task 2.2 depends on `StatusReport.agents` becoming dynamic.
+- No external services are required except optional local CLI probes used in tests through injection.
+
+## Timeline & Estimates
+**When will things be done?**
+
+- Target date: 2026-09-02.
+- Expected effort: one focused implementation pass plus targeted validation.
+
+## Risks & Mitigation
+**What could go wrong?**
+
+- Risk: expanding `agents` breaks strict tests or downstream JSON consumers. Mitigation: keep Codex/Pi/Claude keys stable and update types/tests intentionally.
+- Risk: generic adapters get misleading failures. Mitigation: omit unsupported auth/integration checks.
+- Risk: status remains slow because `pi list` dominates. Mitigation: parallelize independent probes without adding cache or new commands.
+
+## Resources Needed
+**What do we need to succeed?**
+
+- Codex agent implements and verifies.
+- User reviews final outcome before push.

--- a/docs/ai/requirements/2026-09-02-feature-status-agent-readiness.md
+++ b/docs/ai/requirements/2026-09-02-feature-status-agent-readiness.md
@@ -1,0 +1,68 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+description: Clarify the problem space, gather requirements, and define success criteria
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+**What problem are we solving?**
+
+- `ai-devkit status` currently owns agent-specific readiness logic in the CLI service and only reports first-class agent checks for Codex, Pi, and Claude.
+- Users need the status command to cover every startable adapter consistently while preserving adapter-specific checks where they exist.
+- The current CLI-local implementation makes status harder to extend when new adapters are added and duplicates knowledge already owned by `@ai-devkit/agent-manager`.
+
+## Goals & Objectives
+**What do we want to achieve?**
+
+- Report readiness for supported active adapters in `@ai-devkit/agent-manager`; exclude `gemini_cli` because that adapter is scheduled for removal.
+- Move adapter-specific readiness checks into `packages/agent-manager`, leaving the CLI status service to assemble CLI-specific checks and render output.
+- Preserve current semantics:
+  - registries and channels are informational only.
+  - missing built-in skills are warnings, not failures.
+  - Codex and Claude check the AI DevKit hook.
+  - Pi checks the AI DevKit plugin/session tracker, not a hook.
+  - Pi auth reads configured providers from `~/.pi/agent/auth.json` without leaking secrets.
+  - OpenCode auth uses `opencode auth list` and reports configured provider names.
+  - adapters without a real hook/plugin integration do not receive fake integration failures.
+- Improve status latency by running independent checks concurrently.
+- Non-goals:
+  - no new cache.
+  - no new command.
+  - no auth probing that requires interactive login.
+  - no behavior changes to setup beyond shared utility reuse already agreed.
+
+## User Stories & Use Cases
+**How will users interact with the solution?**
+
+- As an AI DevKit user, I want `ai-devkit status` to show Codex, Claude, Pi, Copilot, Gemini CLI, Grok CLI, and OpenCode readiness so I can see the state of every supported adapter.
+- As a maintainer, I want adapter readiness behavior in `agent-manager` so new adapters can add readiness logic near adapter metadata and providers.
+- As a Pi user, I want to see whether Pi has any configured model provider and which provider names are available, without exposing credential values.
+- As a status command user, I want informational counts such as registries and channels to stay outside pass/warn/fail scoring.
+
+## Success Criteria
+**How will we know when we're done?**
+
+- `StatusReport.agents` includes readiness-supported adapters and intentionally omits `gemini_cli`.
+- The CLI status renderer lists executable adapters dynamically and omits adapters whose executable is unavailable from the human agent/check tables.
+- Human output does not print separate missing built-in skill warning lines; the built-in skill row carries the warning status and count.
+- Adapter-specific auth/integration logic lives in `packages/agent-manager/src/readiness`.
+- Status service uses `Promise.all` for independent top-level checks and agent readiness checks.
+- Existing status output semantics for Codex, Claude, and Pi are preserved.
+- Tests cover all adapters, Pi provider auth parsing, optional integrations, and CLI rendering.
+- Missing built-in skills produce `warn` on the built-in skills check and aggregate adapter status unless a stronger failure exists.
+- Targeted CLI and agent-manager tests pass, and both affected packages build.
+
+## Constraints & Assumptions
+**What limitations do we need to work within?**
+
+- Use existing repository patterns, TypeScript types, and Vitest coverage.
+- Keep public JSON shape additive where possible; consumers should continue to find Codex/Pi/Claude fields under `agents`.
+- Built-in skill roots remain CLI environment knowledge and are passed into `agent-manager` readiness as options.
+- Agent auth checks are only implemented where non-interactive local evidence already exists.
+
+## Questions & Open Items
+**What do we still need to clarify?**
+
+- None for this implementation pass. User will review final outcome before push.

--- a/docs/ai/testing/2026-09-02-feature-status-agent-readiness.md
+++ b/docs/ai/testing/2026-09-02-feature-status-agent-readiness.md
@@ -1,0 +1,80 @@
+---
+phase: testing
+title: Testing Strategy
+description: Define testing approach, test cases, and quality assurance
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+**What level of testing do we aim for?**
+
+- Unit coverage for new readiness API behavior and CLI status integration.
+- Integration scope covers report assembly and terminal rendering with all adapters.
+- No browser or deployment E2E is needed.
+- Performance validation is structural: independent checks run concurrently via `Promise.all`.
+
+## Unit Tests
+**What individual components need testing?**
+
+### Agent Readiness
+- [x] Reports readiness-supported adapters and omits `gemini_cli`.
+- [x] Checks executable, global config, and built-in skills for every adapter.
+- [x] Reports built-in skill counts as informational readiness.
+- [x] Includes Codex and Claude hook integration checks only for those adapters.
+- [x] Includes Pi plugin/session tracker integration check only for Pi.
+- [x] Parses Pi configured providers without leaking auth values.
+- [x] Parses OpenCode auth list output into available provider names.
+- [x] Reports Copilot auth when GitHub CLI authentication is active.
+- [x] Treats stale Pi mapping entries as non-failing.
+- [x] Covers OpenCode auth parsing with colored CLI output.
+
+### CLI Status
+- [x] Assembles dynamic agent readiness reports from `agent-manager`.
+- [x] Counts only pass/warn/fail checks in aggregate totals.
+- [x] Renders human `pass` statuses as `ready` and `warn` statuses as `not ready`.
+- [x] Reports missing project `.ai-devkit.json` as warning-level readiness.
+- [x] Renders `Agents:` and `Checks:` tables for all reported adapters.
+- [x] Omits adapters without executables from human `Agents:` and `Checks:` tables.
+- [x] Excludes adapters without executables from scored readiness totals.
+- [x] Does not print separate missing built-in skill warning lines in human output.
+- [x] Keeps registries and channels informational.
+
+## Integration Tests
+**How do we test component interactions?**
+
+- [x] Status service accepts injected file/command/auth helpers and produces deterministic reports.
+- [x] Status renderer displays Pi providers as an informational row.
+- [x] CLI status service tests avoid duplicating provider-specific adapter assertions owned by `agent-manager`.
+
+## End-to-End Tests
+**What user flows need validation?**
+
+- [x] Manual smoke: `node packages/cli/dist/cli.js status` ran against the local environment after build.
+
+## Test Data
+**What data do we use for testing?**
+
+- In-memory `readFile`, `access`, and `runCommand` fakes.
+- Fixture home paths for adapter config directories, built-in skills, hooks, and Pi auth.
+
+## Test Reporting & Coverage
+**How do we verify and communicate test results?**
+
+- Targeted Vitest commands and package builds are sufficient for this refactor.
+- Feature lint must pass after docs are updated.
+
+## Manual Testing
+**What requires human validation?**
+
+- Review terminal output shape manually from renderer tests or local CLI output.
+
+## Performance Testing
+**How do we validate performance?**
+
+- Confirm top-level status service checks and per-agent readiness checks are parallelized.
+
+## Bug Tracking
+**How do we manage issues?**
+
+- Any failing targeted test blocks completion until fixed.

--- a/packages/agent-manager/src/__tests__/readiness/AgentReadiness.test.ts
+++ b/packages/agent-manager/src/__tests__/readiness/AgentReadiness.test.ts
@@ -1,0 +1,194 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    AGENTS,
+    getAgentReadinessReport,
+    getAgentReadinessReports,
+    type AgentReadinessOptions,
+    type ReadinessAgentType,
+} from '../../index.js';
+
+type Files = Record<string, string>;
+
+const builtInSkillNames = ['agent-management', 'memory', 'verify'];
+const skillRoots: Record<ReadinessAgentType, string> = {
+    claude: '.claude/skills',
+    codex: '.codex/skills',
+    copilot: '.copilot/skills',
+    grok_cli: '.grok/skills',
+    opencode: '.config/opencode/skill',
+    pi: '.pi/agent/skills',
+};
+
+function fixture(overrides: Partial<AgentReadinessOptions> = {}) {
+    const homeDir = '/home/test';
+    const assetRoot = '/assets';
+    const files: Files = {
+        [path.join(homeDir, '.codex', 'hooks', 'codex-session-mapping.cjs')]: 'codex-hook',
+        [path.join(assetRoot, 'codex', 'codex-session-mapping.cjs')]: 'codex-hook',
+        [path.join(homeDir, '.codex', 'hooks.json')]: JSON.stringify({ hooks: { SessionStart: [{ hooks: [
+            { type: 'command', command: 'node ~/.codex/hooks/codex-session-mapping.cjs' },
+        ] }] } }),
+        [path.join(homeDir, '.codex', 'ai-devkit', 'sessions.json')]: JSON.stringify({ '123': '/sessions/codex.jsonl' }),
+        '/sessions/codex.jsonl': '',
+        [path.join(homeDir, '.claude', 'hooks', 'claude-prompt-hook.js')]: 'claude-hook',
+        [path.join(assetRoot, 'claude', 'claude-prompt-hook.js')]: 'claude-hook',
+        [path.join(homeDir, '.claude', 'settings.json')]: JSON.stringify({ hooks: { PreToolUse: [{ hooks: [
+            { type: 'command', command: 'node ~/.claude/hooks/claude-prompt-hook.js' },
+        ] }] } }),
+        [path.join(homeDir, '.pi', 'agent', 'sessions.json')]: JSON.stringify({ '456': '/sessions/missing-pi.jsonl' }),
+        [path.join(homeDir, '.pi', 'agent', 'auth.json')]: JSON.stringify({
+            anthropic: { access: 'access-secret', refresh: 'refresh-secret' },
+            litellm: { key: 'litellm-secret', env: { LITELLM_BASE_URL: 'https://litellm.example.test' } },
+        }),
+    };
+    for (const directory of ['.claude', '.codex', '.copilot', '.grok', '.config/opencode', '.pi']) {
+        files[path.join(homeDir, directory)] = '<dir>';
+    }
+    for (const root of Object.values(skillRoots)) {
+        for (const skill of builtInSkillNames) {
+            files[path.join(homeDir, root, skill, 'SKILL.md')] = '# skill';
+        }
+    }
+    const executablePaths = Object.values(AGENTS).map(agent => path.join('/bin', agent.command));
+    const options: AgentReadinessOptions = {
+        homeDir,
+        path: '/bin',
+        assetRoot,
+        builtInSkillNames,
+        skillRoots,
+        readFile: async target => {
+            if (!(target in files)) throw new Error('missing');
+            return files[target];
+        },
+        access: async target => {
+            if (executablePaths.includes(target) || target in files) return;
+            throw new Error('missing');
+        },
+        runCommand: vi.fn(async command => {
+            if (command === 'pi') return { stdout: 'npm:@ai-devkit/pi-session-tracker\n', stderr: '' };
+            if (command === 'claude') return { stdout: JSON.stringify({ loggedIn: true }), stderr: '' };
+            if (command === 'gh') return { stdout: 'github.com\n  Logged in to github.com account test-user\n', stderr: '' };
+            if (command === 'opencode') return { stdout: '●  litellm api\n●  OpenAI oauth\n', stderr: '' };
+            throw new Error(`unexpected command ${command}`);
+        }),
+        codexAuth: async () => true,
+        ...overrides,
+    };
+    return { options, files };
+}
+
+describe('agent readiness', () => {
+    it('reports every readiness-supported adapter with generic checks and only real integrations', async () => {
+        const { options } = fixture();
+
+        const reports = await getAgentReadinessReports(options);
+
+        expect(Object.keys(reports)).toEqual(['claude', 'codex', 'copilot', 'grok_cli', 'opencode', 'pi']);
+        expect(reports).not.toHaveProperty('gemini_cli');
+        for (const [agent, report] of Object.entries(reports) as Array<[ReadinessAgentType, typeof reports[ReadinessAgentType]]>) {
+            expect(report.type).toBe(agent);
+            expect(report.executable.status).toBe('pass');
+            expect(report.globalConfig.status).toBe('pass');
+            expect(report.builtInSkills).toMatchObject({ status: 'info', present: 3, required: 3 });
+        }
+        expect(reports.codex.integration).toMatchObject({ label: 'ai-devkit hook', installed: true, status: 'pass' });
+        expect(reports.claude.integration).toMatchObject({ label: 'ai-devkit hook', installed: true, status: 'pass' });
+        expect(reports.pi.integration).toMatchObject({ label: 'ai-devkit plugin', installed: true, status: 'pass' });
+        expect(reports.copilot.integration).toBeUndefined();
+        expect(reports.grok_cli.integration).toBeUndefined();
+        expect(reports.opencode.integration).toBeUndefined();
+    });
+
+    it('parses Pi provider names without returning credential values', async () => {
+        const { options } = fixture();
+
+        const report = await getAgentReadinessReport('pi', options);
+        const serialized = JSON.stringify(report);
+
+        expect(report.auth).toMatchObject({
+            state: 'authenticated',
+            provider: null,
+            availableProviders: ['anthropic', 'litellm'],
+            status: 'pass',
+        });
+        expect(serialized).not.toContain('access-secret');
+        expect(serialized).not.toContain('refresh-secret');
+        expect(serialized).not.toContain('litellm-secret');
+        expect(serialized).not.toContain('litellm.example.test');
+    });
+
+    it('accepts Pi session tracker display names from pi list output', async () => {
+        const { options } = fixture({
+            runCommand: vi.fn(async command => {
+                if (command === 'pi') return { stdout: 'session tracker\n', stderr: '' };
+                if (command === 'claude') return { stdout: JSON.stringify({ loggedIn: true }), stderr: '' };
+                throw new Error(`unexpected command ${command}`);
+            }),
+        });
+
+        const report = await getAgentReadinessReport('pi', options);
+
+        expect(report.integration).toMatchObject({ label: 'ai-devkit plugin', installed: true, status: 'pass' });
+    });
+
+    it('reports missing built-in skills as informational readiness', async () => {
+        const { options, files } = fixture();
+        delete files[path.join(options.homeDir!, skillRoots.codex, 'verify', 'SKILL.md')];
+
+        const report = await getAgentReadinessReport('codex', options);
+
+        expect(report.builtInSkills).toMatchObject({
+            status: 'info',
+            present: 2,
+            required: 3,
+            missing: ['verify'],
+        });
+        expect(report.status).toBe('pass');
+    });
+
+    it('checks OpenCode auth from auth list output', async () => {
+        const { options } = fixture({
+            runCommand: vi.fn(async command => {
+                if (command === 'opencode') {
+                    return { stdout: '\x1B[32m●\x1B[0m  litellm api\n●  OpenAI oauth\n●  GitLab Duo GITLAB_TOKEN\n', stderr: '' };
+                }
+                if (command === 'pi') return { stdout: 'npm:@ai-devkit/pi-session-tracker\n', stderr: '' };
+                if (command === 'claude') return { stdout: JSON.stringify({ loggedIn: true }), stderr: '' };
+                throw new Error(`unexpected command ${command}`);
+            }),
+        });
+
+        const report = await getAgentReadinessReport('opencode', options);
+
+        expect(report.auth).toMatchObject({
+            state: 'authenticated',
+            source: 'opencode auth list',
+            provider: null,
+            availableProviders: ['GitLab Duo', 'OpenAI', 'litellm'],
+            status: 'pass',
+        });
+    });
+
+    it('checks Copilot auth through GitHub CLI authentication', async () => {
+        const { options } = fixture({
+            runCommand: vi.fn(async command => {
+                if (command === 'gh') return { stdout: 'github.com\n  Logged in to github.com account test-user\n', stderr: '' };
+                if (command === 'pi') return { stdout: 'npm:@ai-devkit/pi-session-tracker\n', stderr: '' };
+                if (command === 'claude') return { stdout: JSON.stringify({ loggedIn: true }), stderr: '' };
+                if (command === 'opencode') return { stdout: '●  litellm api\n', stderr: '' };
+                throw new Error(`unexpected command ${command}`);
+            }),
+        });
+
+        const report = await getAgentReadinessReport('copilot', options);
+
+        expect(report.auth).toMatchObject({
+            state: 'authenticated',
+            source: 'gh auth status --hostname github.com',
+            provider: 'github',
+            availableProviders: ['GitHub'],
+            status: 'pass',
+        });
+    });
+});

--- a/packages/agent-manager/src/index.ts
+++ b/packages/agent-manager/src/index.ts
@@ -5,6 +5,24 @@ export type {
     CapacityReport,
     CapacityWindow,
 } from './capacity/index.js';
+export {
+    getAgentReadinessReport,
+    getAgentReadinessReports,
+    worstReadinessStatus,
+} from './readiness/AgentReadiness.js';
+export type {
+    AgentReadinessOptions,
+    AgentReadinessReport,
+    AuthReadinessCheck,
+    BuiltInSkillsReadinessCheck,
+    DirectoryReadinessCheck,
+    ExecutableReadinessCheck,
+    IntegrationReadinessCheck,
+    ReadinessAgentType,
+    ReadinessAuthState,
+    ReadinessCheck,
+    ReadinessStatus,
+} from './readiness/AgentReadiness.js';
 
 export { ClaudeCodeAdapter } from './providers/claude/ClaudeCodeAdapter.js';
 export { CodexAdapter } from './adapters/CodexAdapter.js';

--- a/packages/agent-manager/src/readiness/AgentReadiness.ts
+++ b/packages/agent-manager/src/readiness/AgentReadiness.ts
@@ -1,0 +1,655 @@
+import { constants } from 'node:fs';
+import { access as fsAccess, readFile as fsReadFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { delimiter, join } from 'node:path';
+import { promisify } from 'node:util';
+import { getCodexCapacityReport } from '../capacity/index.js';
+import { AGENTS, type StartableAgentType } from '../utils/agents.js';
+
+const execFileAsync = promisify(execFile);
+const READINESS_AGENT_TYPES = ['claude', 'codex', 'copilot', 'grok_cli', 'opencode', 'pi'] as const;
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
+
+export type ReadinessStatus = 'pass' | 'warn' | 'fail';
+export type ReadinessAuthState = 'authenticated' | 'unauthenticated' | 'unknown';
+export type ReadinessAgentType = Exclude<StartableAgentType, 'gemini_cli'>;
+type ReadinessInfoStatus = ReadinessStatus | 'info';
+
+type CommandResult = { stdout: string; stderr: string };
+type ReadFile = (target: string) => Promise<string>;
+type Access = (target: string, mode?: number) => Promise<void>;
+type RunCommand = (command: string, args: string[]) => Promise<CommandResult>;
+
+export interface ReadinessCheck<S extends ReadinessInfoStatus = ReadinessStatus> {
+    status: S;
+    errors: string[];
+}
+
+export interface ExecutableReadinessCheck extends ReadinessCheck {
+    command: string;
+    path: string | null;
+}
+
+export interface DirectoryReadinessCheck extends ReadinessCheck {
+    path: string;
+    present: boolean;
+    readable: boolean;
+}
+
+export interface BuiltInSkillsReadinessCheck extends ReadinessCheck<'info'> {
+    path: string | null;
+    required: number;
+    present: number;
+    missing: string[];
+}
+
+export interface AuthReadinessCheck extends ReadinessCheck {
+    state: ReadinessAuthState;
+    source: string;
+    provider: string | null;
+    availableProviders: string[];
+}
+
+export interface IntegrationReadinessCheck extends ReadinessCheck {
+    label: string;
+    installed: boolean;
+    details?: Record<string, unknown>;
+}
+
+export interface AgentReadinessReport {
+    type: ReadinessAgentType;
+    executable: ExecutableReadinessCheck;
+    globalConfig: DirectoryReadinessCheck;
+    builtInSkills: BuiltInSkillsReadinessCheck;
+    auth?: AuthReadinessCheck;
+    integration?: IntegrationReadinessCheck;
+    status: ReadinessStatus;
+}
+
+export interface AgentReadinessOptions {
+    homeDir?: string;
+    path?: string;
+    assetRoot?: string;
+    builtInSkillNames?: readonly string[];
+    skillRoots?: Partial<Record<ReadinessAgentType, string>>;
+    readFile?: ReadFile;
+    access?: Access;
+    runCommand?: RunCommand;
+    codexAuth?: () => Promise<boolean | null>;
+}
+
+type Runtime = Required<Omit<AgentReadinessOptions, 'assetRoot' | 'builtInSkillNames' | 'skillRoots'>> & {
+    assetRoot: string | null;
+    builtInSkillNames: readonly string[];
+    skillRoots: Partial<Record<ReadinessAgentType, string>>;
+};
+
+const AGENT_HOME_DIRS: Record<ReadinessAgentType, string> = {
+    claude: '.claude',
+    codex: '.codex',
+    copilot: '.copilot',
+    grok_cli: '.grok',
+    opencode: '.config/opencode',
+    pi: '.pi',
+};
+
+function runtime(options: AgentReadinessOptions): Runtime {
+    return {
+        homeDir: options.homeDir ?? process.env.HOME ?? '',
+        path: options.path ?? process.env.PATH ?? '',
+        assetRoot: options.assetRoot ?? null,
+        builtInSkillNames: options.builtInSkillNames ?? [],
+        skillRoots: options.skillRoots ?? {},
+        readFile: options.readFile ?? (target => fsReadFile(target, 'utf8')),
+        access: options.access ?? ((target, mode = constants.R_OK) => fsAccess(target, mode)),
+        runCommand: options.runCommand ?? defaultRunCommand,
+        codexAuth: options.codexAuth ?? (async () => (await getCodexCapacityReport()).authenticated),
+    };
+}
+
+async function defaultRunCommand(command: string, args: string[]): Promise<CommandResult> {
+    const result = await execFileAsync(command, args, {
+        encoding: 'utf8',
+        timeout: 5000,
+        maxBuffer: 1024 * 1024,
+    });
+    return { stdout: result.stdout, stderr: result.stderr };
+}
+
+function statusRank(status: ReadinessStatus): number {
+    return status === 'fail' ? 2 : status === 'warn' ? 1 : 0;
+}
+
+export function worstReadinessStatus(statuses: ReadinessStatus[]): ReadinessStatus {
+    return statuses.reduce<ReadinessStatus>((worst, current) =>
+        statusRank(current) > statusRank(worst) ? current : worst, 'pass');
+}
+
+function displayHome(target: string, homeDir: string): string {
+    return target === homeDir ? '~' : target.startsWith(`${homeDir}/`) ? `~${target.slice(homeDir.length)}` : target;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown> : null;
+}
+
+function nonEmpty(value: unknown): boolean {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+async function accessible(target: string, rt: Runtime, mode = constants.R_OK): Promise<boolean> {
+    try {
+        await rt.access(target, mode);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function resolveExecutable(command: string, rt: Runtime): Promise<string | null> {
+    const candidates = rt.path.split(delimiter).filter(Boolean).map(directory => join(directory, command));
+    const checks = await Promise.all(candidates.map(async target => ({
+        target,
+        available: await accessible(target, rt, constants.X_OK),
+    })));
+    return checks.find(check => check.available)?.target ?? null;
+}
+
+async function executableCheck(agent: ReadinessAgentType, rt: Runtime): Promise<ExecutableReadinessCheck> {
+    const command = AGENTS[agent].command;
+    const resolvedPath = await resolveExecutable(command, rt);
+    return {
+        command,
+        path: resolvedPath,
+        status: resolvedPath ? 'pass' : 'fail',
+        errors: resolvedPath ? [] : [`${command} was not found on PATH`],
+    };
+}
+
+async function directoryCheck(agent: ReadinessAgentType, rt: Runtime): Promise<DirectoryReadinessCheck> {
+    const target = join(rt.homeDir, AGENT_HOME_DIRS[agent]);
+    const readable = await accessible(target, rt);
+    return {
+        path: displayHome(target, rt.homeDir),
+        present: readable,
+        readable,
+        status: readable ? 'pass' : 'fail',
+        errors: readable ? [] : ['global configuration directory is unavailable'],
+    };
+}
+
+async function builtInSkillsCheck(agent: ReadinessAgentType, rt: Runtime): Promise<BuiltInSkillsReadinessCheck> {
+    const relativeRoot = rt.skillRoots[agent];
+    if (!relativeRoot) {
+        return {
+            path: null,
+            required: rt.builtInSkillNames.length,
+            present: 0,
+            missing: [...rt.builtInSkillNames],
+            status: 'info',
+            errors: [],
+        };
+    }
+    const root = join(rt.homeDir, relativeRoot);
+    const checks = await Promise.all(rt.builtInSkillNames.map(async name => ({
+        name,
+        present: await accessible(join(root, name, 'SKILL.md'), rt),
+    })));
+    const present = checks.filter(check => check.present).map(check => check.name);
+    const missing = rt.builtInSkillNames.filter(name => !present.includes(name));
+    return {
+        path: displayHome(root, rt.homeDir),
+        required: rt.builtInSkillNames.length,
+        present: present.length,
+        missing: [...missing],
+        status: 'info',
+        errors: [],
+    };
+}
+
+async function scriptCheck(installed: string, bundled: string, rt: Runtime): Promise<ReadinessCheck & {
+    path: string;
+    present: boolean;
+    readable: boolean;
+    matchesBundledAsset: boolean;
+}> {
+    let installedText: string;
+    try {
+        installedText = await rt.readFile(installed);
+    } catch {
+        return {
+            path: displayHome(installed, rt.homeDir),
+            present: false,
+            readable: false,
+            matchesBundledAsset: false,
+            status: 'fail',
+            errors: ['hook script is unavailable'],
+        };
+    }
+    try {
+        const bundledText = await rt.readFile(bundled);
+        const matches = installedText === bundledText;
+        return {
+            path: displayHome(installed, rt.homeDir),
+            present: true,
+            readable: true,
+            matchesBundledAsset: matches,
+            status: matches ? 'pass' : 'fail',
+            errors: matches ? [] : ['hook script differs from the bundled AI DevKit asset'],
+        };
+    } catch {
+        return {
+            path: displayHome(installed, rt.homeDir),
+            present: true,
+            readable: true,
+            matchesBundledAsset: false,
+            status: 'fail',
+            errors: ['bundled hook asset is unavailable'],
+        };
+    }
+}
+
+function containsHook(root: unknown, event: string, command: string): boolean {
+    const hooks = record(record(root)?.hooks);
+    const entries = hooks?.[event];
+    if (!Array.isArray(entries)) return false;
+    return entries.some(entry => {
+        const commands = record(entry)?.hooks;
+        return Array.isArray(commands) && commands.some(hook => {
+            const item = record(hook);
+            return item?.type === 'command' && item.command === command;
+        });
+    });
+}
+
+async function registrationCheck(
+    target: string,
+    event: string,
+    command: string,
+    rt: Runtime,
+): Promise<ReadinessCheck & { path: string; event: string; command: string; present: boolean; valid: boolean }> {
+    try {
+        const parsed = JSON.parse(await rt.readFile(target));
+        const valid = containsHook(parsed, event, command);
+        return {
+            path: displayHome(target, rt.homeDir),
+            event,
+            command,
+            present: true,
+            valid,
+            status: valid ? 'pass' : 'fail',
+            errors: valid ? [] : ['required hook registration is missing'],
+        };
+    } catch {
+        return {
+            path: displayHome(target, rt.homeDir),
+            event,
+            command,
+            present: false,
+            valid: false,
+            status: 'fail',
+            errors: ['hook configuration is missing or invalid'],
+        };
+    }
+}
+
+async function mappingCheck(target: string, rt: Runtime): Promise<ReadinessCheck & {
+    path: string;
+    present: boolean;
+    valid: boolean;
+    invalidEntries: number;
+    staleEntries: number;
+}> {
+    let text: string;
+    try {
+        text = await rt.readFile(target);
+    } catch {
+        return {
+            path: displayHome(target, rt.homeDir),
+            present: false,
+            valid: false,
+            invalidEntries: 0,
+            staleEntries: 0,
+            status: 'warn',
+            errors: ['session mapping has not been created'],
+        };
+    }
+    let parsed: Record<string, unknown> | null = null;
+    try {
+        parsed = record(JSON.parse(text));
+    } catch {
+        // Fixed safe error below.
+    }
+    if (!parsed) {
+        return {
+            path: displayHome(target, rt.homeDir),
+            present: true,
+            valid: false,
+            invalidEntries: 0,
+            staleEntries: 0,
+            status: 'fail',
+            errors: ['session mapping is invalid'],
+        };
+    }
+    const entries = await Promise.all(Object.entries(parsed).map(async ([pid, sessionPath]) => {
+        if (!/^\d+$/.test(pid) || typeof sessionPath !== 'string' || !sessionPath) {
+            return { valid: false, stale: false };
+        }
+        return { valid: true, stale: !await accessible(sessionPath, rt) };
+    }));
+    const invalidEntries = entries.filter(entry => !entry.valid).length;
+    const staleEntries = entries.filter(entry => entry.stale).length;
+    const valid = invalidEntries === 0;
+    return {
+        path: displayHome(target, rt.homeDir),
+        present: true,
+        valid,
+        invalidEntries,
+        staleEntries,
+        status: !valid ? 'fail' : staleEntries ? 'warn' : 'pass',
+        errors: !valid ? ['session mapping contains invalid entries'] : staleEntries ? ['session mapping contains stale entries'] : [],
+    };
+}
+
+async function codexAuthCheck(rt: Runtime): Promise<AuthReadinessCheck> {
+    try {
+        const value = await rt.codexAuth();
+        return {
+            state: value === true ? 'authenticated' : value === false ? 'unauthenticated' : 'unknown',
+            source: displayHome(join(rt.homeDir, '.codex', 'auth.json'), rt.homeDir),
+            provider: null,
+            availableProviders: [],
+            status: value === true ? 'pass' : value === false ? 'fail' : 'warn',
+            errors: value === true ? [] : [value === false ? 'Codex is not authenticated' : 'Codex authentication is unknown'],
+        };
+    } catch {
+        return {
+            state: 'unknown',
+            source: '~/.codex/auth.json',
+            provider: null,
+            availableProviders: [],
+            status: 'warn',
+            errors: ['Codex authentication probe failed'],
+        };
+    }
+}
+
+async function claudeAuthCheck(rt: Runtime): Promise<AuthReadinessCheck> {
+    try {
+        const result = await rt.runCommand('claude', ['auth', 'status', '--json']);
+        const parsed = record(JSON.parse(result.stdout));
+        const authenticated = parsed?.loggedIn === true || parsed?.authenticated === true;
+        const unauthenticated = parsed?.loggedIn === false || parsed?.authenticated === false;
+        return {
+            state: authenticated ? 'authenticated' : unauthenticated ? 'unauthenticated' : 'unknown',
+            source: 'claude auth status --json',
+            provider: null,
+            availableProviders: [],
+            status: authenticated ? 'pass' : unauthenticated ? 'fail' : 'warn',
+            errors: authenticated ? [] : [unauthenticated ? 'Claude is not authenticated' : 'Claude authentication is unknown'],
+        };
+    } catch {
+        return {
+            state: 'unknown',
+            source: 'claude auth status --json',
+            provider: null,
+            availableProviders: [],
+            status: 'warn',
+            errors: ['Claude authentication probe failed'],
+        };
+    }
+}
+
+function piProviderNames(parsed: Record<string, unknown>): string[] {
+    const names = new Set<string>();
+    if (nonEmpty(parsed.provider)) names.add((parsed.provider as string).trim());
+    const providers = record(parsed.providers);
+    if (providers) {
+        for (const name of Object.keys(providers)) {
+            if (name.trim()) names.add(name);
+        }
+    }
+    for (const [name, value] of Object.entries(parsed)) {
+        if (name === 'provider' || name === 'providers') continue;
+        if (record(value) && name.trim()) names.add(name);
+    }
+    return [...names].sort();
+}
+
+async function piAuthCheck(rt: Runtime): Promise<AuthReadinessCheck> {
+    const sourcePath = join(rt.homeDir, '.pi', 'agent', 'auth.json');
+    try {
+        const parsed = record(JSON.parse(await rt.readFile(sourcePath)));
+        if (!parsed) throw new Error('invalid');
+        const availableProviders = piProviderNames(parsed);
+        const provider = nonEmpty(parsed.provider) ? (parsed.provider as string).trim() : null;
+        const authenticated = availableProviders.length > 0;
+        return {
+            state: authenticated ? 'authenticated' : 'unauthenticated',
+            source: displayHome(sourcePath, rt.homeDir),
+            provider,
+            availableProviders,
+            status: authenticated ? 'pass' : 'fail',
+            errors: authenticated ? [] : ['Pi credential file has no configured model provider'],
+        };
+    } catch {
+        return {
+            state: 'unauthenticated',
+            source: displayHome(sourcePath, rt.homeDir),
+            provider: null,
+            availableProviders: [],
+            status: 'fail',
+            errors: ['Pi credential file is missing or invalid'],
+        };
+    }
+}
+
+async function opencodeAuthCheck(rt: Runtime): Promise<AuthReadinessCheck> {
+    try {
+        const result = await rt.runCommand('opencode', ['auth', 'list']);
+        const availableProviders = opencodeAuthProviderNames(result.stdout);
+        const authenticated = availableProviders.length > 0;
+        return {
+            state: authenticated ? 'authenticated' : 'unauthenticated',
+            source: 'opencode auth list',
+            provider: null,
+            availableProviders,
+            status: authenticated ? 'pass' : 'fail',
+            errors: authenticated ? [] : ['OpenCode has no configured credentials'],
+        };
+    } catch {
+        return {
+            state: 'unknown',
+            source: 'opencode auth list',
+            provider: null,
+            availableProviders: [],
+            status: 'warn',
+            errors: ['OpenCode authentication probe failed'],
+        };
+    }
+}
+
+async function copilotAuthCheck(rt: Runtime): Promise<AuthReadinessCheck> {
+    try {
+        await rt.runCommand('gh', ['auth', 'status', '--hostname', 'github.com']);
+        return {
+            state: 'authenticated',
+            source: 'gh auth status --hostname github.com',
+            provider: 'github',
+            availableProviders: ['GitHub'],
+            status: 'pass',
+            errors: [],
+        };
+    } catch {
+        return {
+            state: 'unknown',
+            source: 'gh auth status --hostname github.com',
+            provider: null,
+            availableProviders: ['GitHub'],
+            status: 'warn',
+            errors: ['Copilot authentication could not be verified through GitHub CLI'],
+        };
+    }
+}
+
+function opencodeAuthProviderNames(output: string): string[] {
+    const names = new Set<string>();
+    for (const line of stripAnsi(output).split(/\r?\n/)) {
+        const match = /^\s*[●*+-]\s+(.+?)\s*$/.exec(line);
+        if (!match) continue;
+        const name = match[1].replace(/\s+(?:api|oauth|[\w-]*token|[A-Z][A-Z0-9_]+)$/i, '').trim();
+        if (name && !/^\d+\s+(?:credentials?|environment variables?)$/i.test(name)) names.add(name);
+    }
+    return [...names].sort();
+}
+
+function stripAnsi(value: string): string {
+    return value.replace(ANSI_ESCAPE_PATTERN, '');
+}
+
+async function codexIntegrationCheck(rt: Runtime): Promise<IntegrationReadinessCheck> {
+    const script = await scriptCheck(
+        join(rt.homeDir, '.codex', 'hooks', 'codex-session-mapping.cjs'),
+        join(rt.assetRoot ?? '', 'codex', 'codex-session-mapping.cjs'),
+        rt,
+    );
+    const registration = await registrationCheck(
+        join(rt.homeDir, '.codex', 'hooks.json'),
+        'SessionStart',
+        'node ~/.codex/hooks/codex-session-mapping.cjs',
+        rt,
+    );
+    const mappingFile = await mappingCheck(join(rt.homeDir, '.codex', 'ai-devkit', 'sessions.json'), rt);
+    const installed = script.status === 'pass' && registration.status === 'pass';
+    return {
+        label: 'ai-devkit hook',
+        installed,
+        status: worstReadinessStatus([script.status, registration.status, mappingFile.status]),
+        errors: [...script.errors, ...registration.errors, ...mappingFile.errors],
+        details: { sessionMappingScript: script, registration, mappingFile },
+    };
+}
+
+async function claudeIntegrationCheck(rt: Runtime): Promise<IntegrationReadinessCheck> {
+    const script = await scriptCheck(
+        join(rt.homeDir, '.claude', 'hooks', 'claude-prompt-hook.js'),
+        join(rt.assetRoot ?? '', 'claude', 'claude-prompt-hook.js'),
+        rt,
+    );
+    const registration = await registrationCheck(
+        join(rt.homeDir, '.claude', 'settings.json'),
+        'PreToolUse',
+        'node ~/.claude/hooks/claude-prompt-hook.js',
+        rt,
+    );
+    const installed = script.status === 'pass' && registration.status === 'pass';
+    return {
+        label: 'ai-devkit hook',
+        installed,
+        status: worstReadinessStatus([script.status, registration.status]),
+        errors: [...script.errors, ...registration.errors],
+        details: { promptScript: script, registration },
+    };
+}
+
+async function piIntegrationCheck(rt: Runtime): Promise<IntegrationReadinessCheck> {
+    let installed = false;
+    try {
+        const result = await rt.runCommand('pi', ['list']);
+        installed = isPiSessionTrackerListed(result.stdout);
+    } catch {
+        // Safe fixed result below.
+    }
+    const mapping = await mappingCheck(join(rt.homeDir, '.pi', 'agent', 'sessions.json'), rt);
+    const mappingStatus: ReadinessStatus = mapping.valid || !mapping.present ? 'pass' : 'fail';
+    const status = worstReadinessStatus([installed ? 'pass' : 'fail', mappingStatus]);
+    return {
+        label: 'ai-devkit plugin',
+        installed,
+        status,
+        errors: [
+            ...(!installed ? ['Pi session tracker is not registered'] : []),
+            ...(mappingStatus === 'fail' ? mapping.errors : []),
+        ],
+        details: {
+            package: '@ai-devkit/pi-session-tracker',
+            registryPath: mapping.path,
+            registryValid: mapping.valid,
+            invalidEntries: mapping.invalidEntries,
+            staleEntries: mapping.staleEntries,
+        },
+    };
+}
+
+function isPiSessionTrackerListed(output: string): boolean {
+    const normalized = output.toLowerCase();
+    return normalized.includes('@ai-devkit/pi-session-tracker') || /\bsession[\s-]+tracker\b/.test(normalized);
+}
+
+type AuthCheck = (rt: Runtime) => Promise<AuthReadinessCheck>;
+type IntegrationCheck = (rt: Runtime) => Promise<IntegrationReadinessCheck>;
+
+const AUTH_CHECKS: Partial<Record<ReadinessAgentType, AuthCheck>> = {
+    claude: claudeAuthCheck,
+    codex: codexAuthCheck,
+    copilot: copilotAuthCheck,
+    opencode: opencodeAuthCheck,
+    pi: piAuthCheck,
+};
+
+const INTEGRATION_CHECKS: Partial<Record<ReadinessAgentType, IntegrationCheck>> = {
+    claude: claudeIntegrationCheck,
+    codex: codexIntegrationCheck,
+    pi: piIntegrationCheck,
+};
+
+async function authCheck(agent: ReadinessAgentType, rt: Runtime): Promise<AuthReadinessCheck | undefined> {
+    return AUTH_CHECKS[agent]?.(rt);
+}
+
+async function integrationCheck(agent: ReadinessAgentType, rt: Runtime): Promise<IntegrationReadinessCheck | undefined> {
+    return INTEGRATION_CHECKS[agent]?.(rt);
+}
+
+export async function getAgentReadinessReport(
+    agent: ReadinessAgentType,
+    options: AgentReadinessOptions = {},
+): Promise<AgentReadinessReport> {
+    return agentReadiness(agent, runtime(options));
+}
+
+async function agentReadiness(agent: ReadinessAgentType, rt: Runtime): Promise<AgentReadinessReport> {
+    const [executable, globalConfig, builtInSkills, auth, integration] = await Promise.all([
+        executableCheck(agent, rt),
+        directoryCheck(agent, rt),
+        builtInSkillsCheck(agent, rt),
+        authCheck(agent, rt),
+        integrationCheck(agent, rt),
+    ]);
+    return {
+        type: agent,
+        executable,
+        globalConfig,
+        builtInSkills,
+        auth,
+        integration,
+        status: worstReadinessStatus([
+            executable.status,
+            globalConfig.status,
+            ...(auth ? [auth.status] : []),
+            ...(integration ? [integration.status] : []),
+        ]),
+    };
+}
+
+export async function getAgentReadinessReports(
+    options: AgentReadinessOptions = {},
+): Promise<Record<ReadinessAgentType, AgentReadinessReport>> {
+    const rt = runtime(options);
+    const entries = await Promise.all(READINESS_AGENT_TYPES.map(async agent => [
+        agent,
+        await agentReadiness(agent, rt),
+    ] as const));
+    return Object.fromEntries(entries) as Record<ReadinessAgentType, AgentReadinessReport>;
+}

--- a/packages/cli/src/__tests__/commands/status.test.ts
+++ b/packages/cli/src/__tests__/commands/status.test.ts
@@ -10,14 +10,27 @@ vi.mock('../../util/terminal-ui.js', () => ({
 }));
 
 const base = { status: 'pass' as const, errors: [] as string[] };
-function agent(status: 'pass' | 'warn' | 'fail') {
+function agent(status: 'pass' | 'warn' | 'fail', options: {
+  auth?: boolean;
+  integration?: { label: string; installed: boolean };
+  executablePath?: string | null;
+  builtInSkills?: { status: 'info'; present: number; required: number; missing: string[] };
+} = {}) {
   return {
+    type: 'codex',
     status,
-    executable: { ...base, command: 'agent', path: '/bin/agent' },
+    executable: {
+      status: options.executablePath === null ? 'fail' : 'pass',
+      errors: options.executablePath === null ? ['agent was not found on PATH'] : [],
+      command: 'agent',
+      path: options.executablePath === undefined ? '/bin/agent' : options.executablePath,
+    },
     globalConfig: { ...base, path: '~/.agent', present: true, readable: true },
-    auth: { ...base, state: 'authenticated', source: 'test' },
-    builtInSkills: { ...base, path: '~/.agent/skills', required: 20, present: 20, missing: [] },
-    hooks: { status: 'pass' },
+    builtInSkills: options.builtInSkills
+      ? { status: options.builtInSkills.status, errors: ['required built-in skills are missing'], path: '~/.agent/skills', ...options.builtInSkills }
+      : { status: 'info' as const, errors: [], path: '~/.agent/skills', required: 20, present: 20, missing: [] },
+    ...(options.auth ? { auth: { ...base, state: 'authenticated', source: 'test', provider: null, availableProviders: [] } } : {}),
+    ...(options.integration ? { integration: { ...base, ...options.integration } } : {}),
   };
 }
 const report = {
@@ -26,11 +39,27 @@ const report = {
   aiDevkit: { ...base, installedVersion: '0.55.0', latestVersion: '0.56.0', updateAvailable: true, latestVersionSource: 'npm' },
   project: { cwd: '/repo', config: { ...base, path: '/repo/.ai-devkit.json', present: true, valid: true, version: '0.55.0', environments: ['codex'] } },
   agents: {
-    codex: agent('pass'), pi: agent('warn'), claude: agent('fail'),
+    codex: { ...agent('pass', { auth: true, integration: { label: 'ai-devkit hook', installed: true } }), type: 'codex' },
+    pi: {
+      ...agent('warn', { auth: true, integration: { label: 'ai-devkit plugin', installed: true } }),
+      type: 'pi',
+      auth: { ...base, state: 'authenticated', source: 'test', provider: null, availableProviders: ['anthropic'] },
+    },
+    claude: { ...agent('fail', { auth: true, integration: { label: 'ai-devkit hook', installed: true } }), type: 'claude' },
+    copilot: { ...agent('pass'), type: 'copilot' },
+    grok_cli: { ...agent('fail', { executablePath: null }), type: 'grok_cli' },
+    opencode: {
+      ...agent('pass', {
+        auth: true,
+        builtInSkills: { status: 'info', present: 19, required: 20, missing: ['verify'] },
+      }),
+      type: 'opencode',
+      auth: { ...base, state: 'authenticated', source: 'opencode auth list', provider: null, availableProviders: ['OpenAI', 'litellm'] },
+    },
   },
   tmux: { ...base, path: '/bin/tmux', available: true, version: '3.4' },
-  registries: { project: { ...base, source: '/repo/.ai-devkit.json', configured: {} }, global: { ...base, source: '~/.ai-devkit/.ai-devkit.json', configured: {} }, status: 'pass' },
-  channels: { config: { ...base, path: '~/.ai-devkit/channels.json', present: true, validJson: true, validSchema: true }, connections: [], readyCount: 0, status: 'pass' },
+  registries: { project: { source: '/repo/.ai-devkit.json', configured: {}, errors: [] }, global: { source: '~/.ai-devkit/.ai-devkit.json', configured: {}, errors: [] } },
+  channels: { config: { path: '~/.ai-devkit/channels.json', present: true, validJson: true, validSchema: true, errors: [] }, connections: [], readyCount: 0 },
   checks: { passed: 20, warnings: 1, failed: 1 },
 } as unknown as StatusReport;
 
@@ -48,10 +77,33 @@ describe('status command', () => {
   it('renders human status with shared terminal tables', () => {
     renderStatusReport(report);
     expect(ui.text).toHaveBeenCalledWith('AI DevKit Status:', { breakline: true });
+    expect(ui.text).toHaveBeenCalledWith('Checks:', { breakline: true });
     expect(ui.table).toHaveBeenCalledWith(expect.objectContaining({
       headers: ['Agent', 'Status'],
-      rows: [['codex', 'pass'], ['pi', 'warn'], ['claude', 'fail']],
+      rows: [
+        ['codex', 'ready'],
+        ['pi', 'not ready'],
+        ['claude', 'fail'],
+        ['copilot', 'ready'],
+        ['opencode', 'ready'],
+      ],
     }));
+    expect(ui.table).toHaveBeenCalledWith(expect.objectContaining({
+      headers: ['Check', 'Status', 'Evidence'],
+      rows: expect.arrayContaining([
+        ['codex: ai-devkit built-in skills', 'info', '20/20'],
+        ['codex: ai-devkit hook', 'ready', 'installed'],
+        ['pi: ai-devkit plugin', 'ready', 'installed'],
+        ['pi: providers', 'info', 'anthropic'],
+        ['opencode: ai-devkit built-in skills', 'info', '19/20'],
+        ['opencode: auth', 'ready', 'authenticated'],
+        ['opencode: providers', 'info', 'OpenAI, litellm'],
+      ]),
+    }));
+    const checkRows = (vi.mocked(ui.table).mock.calls[2][0].rows ?? []) as Array<[string, string, string]>;
+    expect(checkRows.some(([label]) => label.startsWith('grok_cli:'))).toBe(false);
+    expect(checkRows).not.toContainEqual(['codex: ai-devkit built-in skills', 'pass', '20/20']);
+    expect(ui.warning).not.toHaveBeenCalledWith(expect.stringContaining('missing built-in skills'));
   });
 
   it('registers the top-level status command and passes json intent', async () => {

--- a/packages/cli/src/__tests__/services/status/status.service.test.ts
+++ b/packages/cli/src/__tests__/services/status/status.service.test.ts
@@ -50,17 +50,28 @@ function fixture(overrides: Partial<StatusServiceOptions> = {}) {
     '/sessions/pi.jsonl': '',
     [path.join(homeDir, '.pi', 'agent', 'auth.json')]: JSON.stringify({ provider: 'anthropic' }),
   };
-  for (const directory of ['.codex', '.pi', '.claude']) files[path.join(homeDir, directory)] = '<dir>';
+  for (const directory of ['.codex', '.pi', '.claude', '.copilot', '.gemini', '.grok', '.config/opencode']) {
+    files[path.join(homeDir, directory)] = '<dir>';
+  }
   for (const [agent, skillRoot] of [
     ['codex', path.join(homeDir, '.codex', 'skills')],
     ['pi', path.join(homeDir, '.pi', 'agent', 'skills')],
     ['claude', path.join(homeDir, '.claude', 'skills')],
+    ['copilot', path.join(homeDir, '.copilot', 'skills')],
+    ['grok_cli', path.join(homeDir, '.grok', 'skills')],
+    ['opencode', path.join(homeDir, '.config', 'opencode', 'skills')],
   ] as const) {
     void agent;
     for (const skill of builtIns) files[path.join(skillRoot, skill, 'SKILL.md')] = '# skill';
   }
   const executablePaths: Record<string, string> = {
-    codex: '/bin/codex', pi: '/bin/pi', claude: '/bin/claude', tmux: '/bin/tmux',
+    codex: '/bin/codex',
+    pi: '/bin/pi',
+    claude: '/bin/claude',
+    copilot: '/bin/copilot',
+    grok_cli: '/bin/grok',
+    opencode: '/bin/opencode',
+    tmux: '/bin/tmux',
   };
   const options: StatusServiceOptions = {
     cwd,
@@ -82,6 +93,8 @@ function fixture(overrides: Partial<StatusServiceOptions> = {}) {
       if (command === 'tmux') return { stdout: 'tmux 3.4\n', stderr: '' };
       if (command === 'pi') return { stdout: '@ai-devkit/pi-session-tracker\n', stderr: '' };
       if (command === 'claude') return { stdout: JSON.stringify({ loggedIn: true }), stderr: '' };
+      if (command === 'gh') return { stdout: 'github.com\n  Logged in to github.com account test-user\n', stderr: '' };
+      if (command === 'opencode') return { stdout: '●  litellm api\n●  OpenAI oauth\n', stderr: '' };
       if (command === 'npm') return { stdout: '0.56.0\n', stderr: '' };
       throw new Error(`unexpected command ${command} ${args.join(' ')}`);
     }),
@@ -99,12 +112,15 @@ describe('getStatusReport', () => {
     expect(report.generatedAt).toBe('2026-08-23T00:00:00.000Z');
     expect(report.agents.codex.executable.path).toBe('/bin/codex');
     expect(report.agents.codex.auth.state).toBe('authenticated');
-    expect(report.agents.codex.builtInSkills.missing).toEqual([]);
-    expect(report.agents.codex.hooks.mappingFile).toMatchObject({ valid: true, staleEntries: 0 });
-    expect(report.agents.pi.hooks.sessionTracker).toMatchObject({ installed: true, registryValid: true });
-    expect(report.agents.pi.auth).toMatchObject({ state: 'unknown', status: 'warn' });
-    expect(report.agents.claude.hooks.registration).toMatchObject({ present: true, valid: true });
-    expect(report.tmux).toMatchObject({ path: '/bin/tmux', available: true, version: '3.4' });
+    expect(report.agents.codex.integration).toMatchObject({ label: 'ai-devkit hook', installed: true, status: 'pass' });
+    expect(report.agents.pi.integration).toMatchObject({ label: 'ai-devkit plugin', installed: true, status: 'pass' });
+    expect(report.agents.claude.integration).toMatchObject({ label: 'ai-devkit hook', installed: true, status: 'pass' });
+    expect(Object.keys(report.agents)).toEqual(['claude', 'codex', 'copilot', 'grok_cli', 'opencode', 'pi']);
+    expect(report.agents.copilot.integration).toBeUndefined();
+    expect(report.agents).not.toHaveProperty('gemini_cli');
+    expect(report.agents.opencode.auth?.status).toBe('pass');
+    expect(report.agents.copilot.auth?.status).toBe('pass');
+    expect(report.tmux).toMatchObject({ path: 'tmux', available: true, version: '3.4' });
     expect(report.registries.project.configured).toMatchObject({ project: 'https://example.test/project.git' });
     expect(report.registries.global.configured).toEqual({ global: 'https://example.test/global.git' });
     expect(report.aiDevkit).toMatchObject({ installedVersion: '0.55.0', latestVersion: '0.56.0', updateAvailable: true });
@@ -113,10 +129,85 @@ describe('getStatusReport', () => {
       expect.objectContaining({ name: 'telegram', ready: true }),
       expect.objectContaining({ name: 'slack', ready: true }),
     ]));
-    expect(report.checks.warnings).toBeGreaterThan(0);
+    expect(report.checks.warnings).toBe(0);
     expect(report.registries.project.configured.private).toBe('https://example.test/private.git');
     expect(JSON.stringify(report)).not.toContain('registry-secret');
     expect(JSON.stringify(report)).not.toContain('query-secret');
+  });
+
+  it('checks built-in skills concurrently across each agent skill root', async () => {
+    const { options } = fixture();
+    let activeSkillChecks = 0;
+    let maxActiveSkillChecks = 0;
+    const baseAccess = options.access!;
+    const access: StatusServiceOptions['access'] = async (target, mode) => {
+      if (!target.endsWith('SKILL.md')) return baseAccess(target, mode);
+      activeSkillChecks += 1;
+      maxActiveSkillChecks = Math.max(maxActiveSkillChecks, activeSkillChecks);
+      await new Promise(resolve => setTimeout(resolve, 1));
+      try {
+        await baseAccess(target, mode);
+      } finally {
+        activeSkillChecks -= 1;
+      }
+    };
+
+    await getStatusReport({ ...options, access });
+
+    expect(maxActiveSkillChecks).toBeGreaterThan(3);
+  });
+
+  it('uses the shared tmux inspection without a PATH preflight', async () => {
+    const { options } = fixture({
+      path: '',
+      runCommand: vi.fn(async (command, args) => {
+        if (command === 'tmux') return { stdout: 'tmux 3.5\n', stderr: '' };
+        if (command === 'pi') return { stdout: '@ai-devkit/pi-session-tracker\n', stderr: '' };
+        if (command === 'claude') return { stdout: JSON.stringify({ loggedIn: true }), stderr: '' };
+        if (command === 'gh') return { stdout: 'github.com\n  Logged in to github.com account test-user\n', stderr: '' };
+        if (command === 'opencode') return { stdout: '●  litellm api\n', stderr: '' };
+        if (command === 'npm') return { stdout: '0.56.0\n', stderr: '' };
+        throw new Error(`unexpected command ${command} ${args.join(' ')}`);
+      }),
+    });
+
+    const report = await getStatusReport(options);
+
+    expect(report.tmux).toMatchObject({ path: 'tmux', available: true, version: '3.5', status: 'pass' });
+  });
+
+  it('excludes adapters without executables from scored readiness checks', async () => {
+    const { options } = fixture();
+    const baseAccess = options.access!;
+    const access: StatusServiceOptions['access'] = async (target, mode) => {
+      if (target === '/bin/grok' || target === path.join(options.homeDir!, '.grok')) {
+        throw new Error('missing');
+      }
+      return baseAccess(target, mode);
+    };
+
+    const report = await getStatusReport({ ...options, access });
+
+    expect(report.agents.grok_cli.executable).toMatchObject({ path: null, status: 'fail' });
+    expect(report.agents.grok_cli.globalConfig.status).toBe('fail');
+    expect(report.overall).toBe('pass');
+    expect(report.checks.failed).toBe(0);
+  });
+
+  it('warns when project configuration is missing', async () => {
+    const { options, files } = fixture();
+    delete files[path.join(options.cwd!, '.ai-devkit.json')];
+
+    const report = await getStatusReport(options);
+
+    expect(report.project.config).toMatchObject({
+      present: false,
+      valid: false,
+      status: 'warn',
+      errors: ['project configuration is missing'],
+    });
+    expect(report.overall).toBe('warn');
+    expect(report.checks.failed).toBe(0);
   });
 
   it('returns independent findings when files, commands, auth, and npm are unavailable', async () => {
@@ -147,19 +238,23 @@ describe('getStatusReport', () => {
 
     const report = await getStatusReport(options);
     const serialized = JSON.stringify(report);
-    expect(report.agents.codex.hooks.mappingFile.status).toBe('fail');
-    expect(report.channels.config).toMatchObject({ present: true, validJson: false, validSchema: false, status: 'fail' });
+    expect(report.agents.codex.integration?.details?.mappingFile).toMatchObject({ status: 'fail' });
+    expect(report.channels.config).toMatchObject({ present: true, validJson: false, validSchema: false });
     expect(serialized).not.toContain('token-secret');
     expect(serialized).not.toContain('channel-secret');
   });
 
-  it('marks the channel schema invalid when an entry is structurally incomplete', async () => {
+  it('reports channel schema as informational when an entry is structurally incomplete', async () => {
     const { options, files } = fixture();
     files[path.join(options.homeDir!, '.ai-devkit', 'channels.json')] = JSON.stringify({
       channels: { broken: { type: 'slack', enabled: true, config: { appToken: 'xapp-secret' } } },
     });
     const report = await getStatusReport(options);
-    expect(report.channels.config).toMatchObject({ validJson: true, validSchema: false, status: 'fail' });
-    expect(report.channels.connections[0]).toMatchObject({ ready: false, status: 'fail' });
+    expect(report.channels.config).toMatchObject({ validJson: true, validSchema: false });
+    expect(report.channels.connections[0]).toMatchObject({ ready: false, errors: ['channel configuration is not ready'] });
+    expect(report.registries).not.toHaveProperty('status');
+    expect(report.channels).not.toHaveProperty('status');
+    expect(report.channels.connections[0]).not.toHaveProperty('status');
   });
+
 });

--- a/packages/cli/src/commands/status/render.ts
+++ b/packages/cli/src/commands/status/render.ts
@@ -1,13 +1,32 @@
 import chalk from 'chalk';
+import type { AgentReadinessReport, ReadinessAgentType } from '@ai-devkit/agent-manager';
 import { ui } from '../../util/terminal-ui.js';
 import type { CheckStatus, StatusReport } from '../../services/status/status.service.js';
 
 function statusStyle(text: string): string {
-  return text === 'pass' ? chalk.green(text) : text === 'warn' ? chalk.yellow(text) : chalk.red(text);
+  if (text === 'ready' || text === 'pass') return chalk.green(text);
+  if (text === 'not ready' || text === 'warn') return chalk.yellow(text);
+  if (text === 'fail') return chalk.red(text);
+  return chalk.dim(text);
 }
 
-function yesNo(value: boolean): string {
-  return value ? 'yes' : 'no';
+function statusLabel(status: CheckStatus | 'info'): string {
+  if (status === 'pass') return 'ready';
+  if (status === 'warn') return 'not ready';
+  return status;
+}
+
+function installed(value: boolean): string {
+  return value ? 'installed' : 'not installed';
+}
+
+function authEvidence(auth: NonNullable<AgentReadinessReport['auth']>): string {
+  return auth.provider ?? auth.state;
+}
+
+function agentEntries(report: StatusReport): Array<[ReadinessAgentType, AgentReadinessReport]> {
+  return (Object.entries(report.agents) as Array<[ReadinessAgentType, AgentReadinessReport]>)
+    .filter(([, agent]) => agent.executable.path !== null);
 }
 
 export function renderStatusReport(report: StatusReport, options: { json?: boolean } = {}): void {
@@ -20,15 +39,15 @@ export function renderStatusReport(report: StatusReport, options: { json?: boole
   ui.table({
     headers: ['Scope', 'Status', 'Details'],
     rows: [
-      ['overall', report.overall, `${report.checks.passed} pass · ${report.checks.warnings} warn · ${report.checks.failed} fail`],
-      ['ai-devkit', report.aiDevkit.status, report.aiDevkit.latestVersion
+      ['overall', statusLabel(report.overall), `${report.checks.passed} ready · ${report.checks.warnings} not ready · ${report.checks.failed} fail`],
+      ['ai-devkit', statusLabel(report.aiDevkit.status), report.aiDevkit.latestVersion
         ? `${report.aiDevkit.installedVersion} (latest ${report.aiDevkit.latestVersion})`
         : `${report.aiDevkit.installedVersion} (latest unknown)`],
-      ['project', report.project.config.status, report.project.config.path],
-      ['tmux', report.tmux.status, report.tmux.available ? `${report.tmux.path} · ${report.tmux.version ?? 'unknown'}` : 'unavailable'],
-      ['registries', report.registries.status,
+      ['project', statusLabel(report.project.config.status), report.project.config.path],
+      ['tmux', statusLabel(report.tmux.status), report.tmux.available ? `${report.tmux.path} · ${report.tmux.version ?? 'unknown'}` : 'unavailable'],
+      ['registries', 'info',
         `${Object.keys(report.registries.project.configured).length} project · ${Object.keys(report.registries.global.configured).length} global`],
-      ['channels', report.channels.status, `${report.channels.readyCount}/${report.channels.connections.length} ready`],
+      ['channels', 'info', `${report.channels.readyCount}/${report.channels.connections.length} ready`],
     ],
     maxWidth: process.stdout.columns ?? 120,
     columnStyles: [chalk.cyan, statusStyle, chalk.dim],
@@ -37,30 +56,32 @@ export function renderStatusReport(report: StatusReport, options: { json?: boole
   ui.text('Agents:', { breakline: true });
   ui.table({
     headers: ['Agent', 'Status'],
-    rows: (['codex', 'pi', 'claude'] as const).map(agent => [agent, report.agents[agent].status]),
+    rows: agentEntries(report).map(([agent, item]) => [agent, statusLabel(item.status)]),
     maxWidth: process.stdout.columns ?? 120,
     columnStyles: [chalk.cyan, statusStyle],
   });
 
-  const details: Array<[string, CheckStatus, string]> = [];
-  for (const agent of ['codex', 'pi', 'claude'] as const) {
-    const item = report.agents[agent];
+  ui.text('Checks:', { breakline: true });
+  const details: Array<[string, string, string]> = [];
+  for (const [agent, item] of agentEntries(report)) {
     details.push(
-      [`${agent}: executable`, item.executable.status, item.executable.path ?? 'not found'],
-      [`${agent}: config`, item.globalConfig.status, item.globalConfig.path],
-      [`${agent}: auth`, item.auth.status, item.auth.state],
-      [`${agent}: skills`, item.builtInSkills.status, `${item.builtInSkills.present}/${item.builtInSkills.required}`],
-      [`${agent}: hooks`, item.hooks.status, yesNo(item.hooks.status === 'pass')],
+      [`${agent}: executable`, statusLabel(item.executable.status), item.executable.path ?? 'not found'],
+      [`${agent}: config`, statusLabel(item.globalConfig.status), item.globalConfig.path],
+      [`${agent}: ai-devkit built-in skills`, statusLabel(item.builtInSkills.status), `${item.builtInSkills.present}/${item.builtInSkills.required}`],
     );
+    if (item.auth) {
+      details.push([`${agent}: auth`, statusLabel(item.auth.status), authEvidence(item.auth)]);
+      if (item.auth.availableProviders.length) {
+        details.push([`${agent}: providers`, 'info', item.auth.availableProviders.join(', ')]);
+      }
+    }
+    if (item.integration) {
+      details.push([`${agent}: ${item.integration.label}`, statusLabel(item.integration.status), installed(item.integration.installed)]);
+    }
   }
   ui.table({
     headers: ['Check', 'Status', 'Evidence'], rows: details,
     maxWidth: process.stdout.columns ?? 120,
     columnStyles: [chalk.cyan, statusStyle, chalk.dim],
   });
-
-  for (const agent of ['codex', 'pi', 'claude'] as const) {
-    const missing = report.agents[agent].builtInSkills.missing;
-    if (missing.length) ui.warning(`${agent} missing built-in skills: ${missing.join(', ')}`);
-  }
 }

--- a/packages/cli/src/services/status/status.service.ts
+++ b/packages/cli/src/services/status/status.service.ts
@@ -1,82 +1,34 @@
 import { constants, existsSync } from 'node:fs';
 import { access as fsAccess, readFile as fsReadFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
-import { dirname, delimiter, join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { AGENTS, getCodexCapacityReport } from '@ai-devkit/agent-manager';
+import {
+  getAgentReadinessReports,
+  getCodexCapacityReport,
+  worstReadinessStatus,
+  type AgentReadinessOptions,
+  type AgentReadinessReport,
+  type ReadinessAgentType,
+  type ReadinessStatus,
+} from '@ai-devkit/agent-manager';
 import { BUILTIN_SKILL_NAMES } from '../../constants.js';
 import { filterStringRecord } from '../../util/config.js';
 import { getGlobalSkillPath, isValidEnvironmentCode } from '../../util/env.js';
+import { inspectTmux } from '../../util/tmux.js';
 import packageJson from '../../../package.json' with { type: 'json' };
 
 const execFileAsync = promisify(execFile);
 
-export type CheckStatus = 'pass' | 'warn' | 'fail';
-export type AuthState = 'authenticated' | 'unauthenticated' | 'unknown';
-type AgentKey = 'codex' | 'pi' | 'claude';
+export type CheckStatus = ReadinessStatus;
 type CommandResult = { stdout: string; stderr: string };
 type ReadFile = (target: string) => Promise<string>;
 type Access = (target: string, mode?: number) => Promise<void>;
 type RunCommand = (command: string, args: string[]) => Promise<CommandResult>;
 
 interface CheckBase { status: CheckStatus; errors: string[] }
-interface ExecutableCheck extends CheckBase { command: string; path: string | null }
-interface DirectoryCheck extends CheckBase { path: string; present: boolean; readable: boolean }
-interface AuthCheck extends CheckBase { state: AuthState; source: string }
-interface SkillsCheck extends CheckBase {
-  path: string;
-  required: number;
-  present: number;
-  missing: string[];
-}
-interface ScriptCheck extends CheckBase {
-  path: string;
-  present: boolean;
-  readable: boolean;
-  matchesBundledAsset: boolean;
-}
-interface RegistrationCheck extends CheckBase {
-  path: string;
-  event: string;
-  command: string;
-  present: boolean;
-  valid: boolean;
-}
-interface MappingCheck extends CheckBase {
-  path: string;
-  present: boolean;
-  valid: boolean;
-  invalidEntries: number;
-  staleEntries: number;
-}
-interface TrackerCheck extends CheckBase {
-  package: string;
-  installed: boolean;
-  registryPath: string;
-  registryValid: boolean;
-  invalidEntries: number;
-  staleEntries: number;
-}
-interface HookGroupBase { status: CheckStatus }
-interface CodexHooks extends HookGroupBase {
-  sessionMappingScript: ScriptCheck;
-  registration: RegistrationCheck;
-  mappingFile: MappingCheck;
-}
-interface ClaudeHooks extends HookGroupBase {
-  promptScript: ScriptCheck;
-  registration: RegistrationCheck;
-}
-interface PiHooks extends HookGroupBase { sessionTracker: TrackerCheck }
-interface AgentCheck<H extends HookGroupBase> {
-  executable: ExecutableCheck;
-  globalConfig: DirectoryCheck;
-  auth: AuthCheck;
-  builtInSkills: SkillsCheck;
-  hooks: H;
-  status: CheckStatus;
-}
+interface InfoBase { errors: string[] }
 interface ProjectConfigCheck extends CheckBase {
   path: string;
   present: boolean;
@@ -84,14 +36,13 @@ interface ProjectConfigCheck extends CheckBase {
   version: string | null;
   environments: string[];
 }
-interface RegistryScopeCheck extends CheckBase {
+interface RegistryScopeCheck extends InfoBase {
   source: string;
   configured: Record<string, string>;
 }
 interface RegistriesCheck {
   project: RegistryScopeCheck;
   global: RegistryScopeCheck;
-  status: CheckStatus;
 }
 interface VersionCheck extends CheckBase {
   installedVersion: string;
@@ -104,7 +55,7 @@ interface TmuxCheck extends CheckBase {
   available: boolean;
   version: string | null;
 }
-interface ChannelConnection extends CheckBase {
+interface ChannelConnection extends InfoBase {
   name: string;
   type: string;
   enabled: boolean;
@@ -112,7 +63,7 @@ interface ChannelConnection extends CheckBase {
   authorized: boolean | null;
   ready: boolean;
 }
-interface ChannelConfigCheck extends CheckBase {
+interface ChannelConfigCheck extends InfoBase {
   path: string;
   present: boolean;
   validJson: boolean;
@@ -122,7 +73,6 @@ interface ChannelsCheck {
   config: ChannelConfigCheck;
   connections: ChannelConnection[];
   readyCount: number;
-  status: CheckStatus;
 }
 
 export interface StatusReport {
@@ -130,11 +80,7 @@ export interface StatusReport {
   overall: CheckStatus;
   aiDevkit: VersionCheck;
   project: { cwd: string; config: ProjectConfigCheck };
-  agents: {
-    codex: AgentCheck<CodexHooks>;
-    pi: AgentCheck<PiHooks>;
-    claude: AgentCheck<ClaudeHooks>;
-  };
+  agents: Record<ReadinessAgentType, AgentReadinessReport>;
   tmux: TmuxCheck;
   registries: RegistriesCheck;
   channels: ChannelsCheck;
@@ -156,19 +102,17 @@ export interface StatusServiceOptions {
 
 type Runtime = Required<StatusServiceOptions>;
 
-const AGENT_META: Record<AgentKey, { dotDir: string; skillEnv: 'codex' | 'pi' | 'claude' }> = {
-  codex: { dotDir: '.codex', skillEnv: 'codex' },
-  pi: { dotDir: '.pi', skillEnv: 'pi' },
-  claude: { dotDir: '.claude', skillEnv: 'claude' },
+const STATUS_SKILL_ROOTS: Record<ReadinessAgentType, string> = {
+  claude: getGlobalSkillPath('claude') ?? '.claude/skills',
+  codex: getGlobalSkillPath('codex') ?? '.codex/skills',
+  copilot: getGlobalSkillPath('github') ?? '.copilot/skills',
+  grok_cli: getGlobalSkillPath('grok') ?? '.grok/skills',
+  opencode: getGlobalSkillPath('opencode') ?? '.config/opencode/skills',
+  pi: getGlobalSkillPath('pi') ?? '.pi/agent/skills',
 };
 
-function statusRank(status: CheckStatus): number {
-  return status === 'fail' ? 2 : status === 'warn' ? 1 : 0;
-}
-
 export function worstStatus(statuses: CheckStatus[]): CheckStatus {
-  return statuses.reduce<CheckStatus>((worst, current) =>
-    statusRank(current) > statusRank(worst) ? current : worst, 'pass');
+  return worstReadinessStatus(statuses);
 }
 
 function displayHome(target: string, homeDir: string): string {
@@ -208,247 +152,13 @@ function runtime(options: StatusServiceOptions): Runtime {
   };
 }
 
-async function accessible(target: string, rt: Runtime, mode = constants.R_OK): Promise<boolean> {
-  try { await rt.access(target, mode); return true; } catch { return false; }
-}
-
-async function resolveExecutable(command: string, rt: Runtime): Promise<string | null> {
-  for (const directory of rt.path.split(delimiter).filter(Boolean)) {
-    const target = join(directory, command);
-    if (await accessible(target, rt, constants.X_OK)) return target;
-  }
-  return null;
-}
-
-async function executableCheck(command: string, rt: Runtime): Promise<ExecutableCheck> {
-  const resolvedPath = await resolveExecutable(command, rt);
-  return {
-    command, path: resolvedPath, status: resolvedPath ? 'pass' : 'fail',
-    errors: resolvedPath ? [] : [`${command} was not found on PATH`],
-  };
-}
-
-async function directoryCheck(agent: AgentKey, rt: Runtime): Promise<DirectoryCheck> {
-  const target = join(rt.homeDir, AGENT_META[agent].dotDir);
-  const readable = await accessible(target, rt);
-  return {
-    path: displayHome(target, rt.homeDir), present: readable, readable,
-    status: readable ? 'pass' : 'fail', errors: readable ? [] : ['global configuration directory is unavailable'],
-  };
-}
-
-async function builtInSkillsCheck(agent: AgentKey, rt: Runtime): Promise<SkillsCheck> {
-  const relativeRoot = getGlobalSkillPath(AGENT_META[agent].skillEnv) ?? '';
-  const root = join(rt.homeDir, relativeRoot);
-  const present: string[] = [];
-  for (const name of BUILTIN_SKILL_NAMES) {
-    if (await accessible(join(root, name, 'SKILL.md'), rt)) present.push(name);
-  }
-  const missing = BUILTIN_SKILL_NAMES.filter(name => !present.includes(name));
-  return {
-    path: displayHome(root, rt.homeDir), required: BUILTIN_SKILL_NAMES.length,
-    present: present.length, missing: [...missing], status: missing.length ? 'fail' : 'pass',
-    errors: missing.length ? ['required built-in skills are missing'] : [],
-  };
-}
-
-async function scriptCheck(installed: string, bundled: string, rt: Runtime): Promise<ScriptCheck> {
-  let installedText: string;
-  try { installedText = await rt.readFile(installed); } catch {
-    return {
-      path: displayHome(installed, rt.homeDir), present: false, readable: false,
-      matchesBundledAsset: false, status: 'fail', errors: ['hook script is unavailable'],
-    };
-  }
-  try {
-    const bundledText = await rt.readFile(bundled);
-    const matches = installedText === bundledText;
-    return {
-      path: displayHome(installed, rt.homeDir), present: true, readable: true,
-      matchesBundledAsset: matches, status: matches ? 'pass' : 'fail',
-      errors: matches ? [] : ['hook script differs from the bundled AI DevKit asset'],
-    };
-  } catch {
-    return {
-      path: displayHome(installed, rt.homeDir), present: true, readable: true,
-      matchesBundledAsset: false, status: 'fail', errors: ['bundled hook asset is unavailable'],
-    };
-  }
-}
-
-function containsHook(root: unknown, event: string, command: string): boolean {
-  const hooks = record(record(root)?.hooks);
-  const entries = hooks?.[event];
-  if (!Array.isArray(entries)) return false;
-  return entries.some(entry => {
-    const commands = record(entry)?.hooks;
-    return Array.isArray(commands) && commands.some(hook => {
-      const item = record(hook);
-      return item?.type === 'command' && item.command === command;
-    });
-  });
-}
-
-async function registrationCheck(
-  target: string, event: string, command: string, rt: Runtime,
-): Promise<RegistrationCheck> {
-  try {
-    const parsed = JSON.parse(await rt.readFile(target));
-    const valid = containsHook(parsed, event, command);
-    return {
-      path: displayHome(target, rt.homeDir), event, command, present: true, valid,
-      status: valid ? 'pass' : 'fail', errors: valid ? [] : ['required hook registration is missing'],
-    };
-  } catch {
-    return {
-      path: displayHome(target, rt.homeDir), event, command, present: false, valid: false,
-      status: 'fail', errors: ['hook configuration is missing or invalid'],
-    };
-  }
-}
-
-async function mappingCheck(target: string, rt: Runtime): Promise<MappingCheck> {
-  let text: string;
-  try { text = await rt.readFile(target); } catch {
-    return {
-      path: displayHome(target, rt.homeDir), present: false, valid: false,
-      invalidEntries: 0, staleEntries: 0, status: 'warn', errors: ['session mapping has not been created'],
-    };
-  }
-  let parsed: Record<string, unknown> | null = null;
-  try { parsed = record(JSON.parse(text)); } catch { /* fixed safe error below */ }
-  if (!parsed) {
-    return {
-      path: displayHome(target, rt.homeDir), present: true, valid: false,
-      invalidEntries: 0, staleEntries: 0, status: 'fail', errors: ['session mapping is invalid'],
-    };
-  }
-  let invalidEntries = 0;
-  let staleEntries = 0;
-  for (const [pid, sessionPath] of Object.entries(parsed)) {
-    if (!/^\d+$/.test(pid) || typeof sessionPath !== 'string' || !sessionPath) {
-      invalidEntries += 1;
-      continue;
-    }
-    if (!await accessible(sessionPath, rt)) staleEntries += 1;
-  }
-  const valid = invalidEntries === 0;
-  return {
-    path: displayHome(target, rt.homeDir), present: true, valid, invalidEntries, staleEntries,
-    status: !valid ? 'fail' : staleEntries ? 'warn' : 'pass',
-    errors: !valid ? ['session mapping contains invalid entries'] : staleEntries ? ['session mapping contains stale entries'] : [],
-  };
-}
-
-async function codexHooks(rt: Runtime): Promise<CodexHooks> {
-  const script = await scriptCheck(
-    join(rt.homeDir, '.codex', 'hooks', 'codex-session-mapping.cjs'),
-    join(rt.assetRoot, 'codex', 'codex-session-mapping.cjs'), rt,
-  );
-  const registration = await registrationCheck(
-    join(rt.homeDir, '.codex', 'hooks.json'), 'SessionStart',
-    'node ~/.codex/hooks/codex-session-mapping.cjs', rt,
-  );
-  const mappingFile = await mappingCheck(join(rt.homeDir, '.codex', 'ai-devkit', 'sessions.json'), rt);
-  return { sessionMappingScript: script, registration, mappingFile, status: worstStatus([script.status, registration.status, mappingFile.status]) };
-}
-
-async function claudeHooks(rt: Runtime): Promise<ClaudeHooks> {
-  const script = await scriptCheck(
-    join(rt.homeDir, '.claude', 'hooks', 'claude-prompt-hook.js'),
-    join(rt.assetRoot, 'claude', 'claude-prompt-hook.js'), rt,
-  );
-  const registration = await registrationCheck(
-    join(rt.homeDir, '.claude', 'settings.json'), 'PreToolUse',
-    'node ~/.claude/hooks/claude-prompt-hook.js', rt,
-  );
-  return { promptScript: script, registration, status: worstStatus([script.status, registration.status]) };
-}
-
-async function piHooks(rt: Runtime): Promise<PiHooks> {
-  let installed = false;
-  try {
-    const result = await rt.runCommand('pi', ['list']);
-    installed = result.stdout.includes('@ai-devkit/pi-session-tracker');
-  } catch { /* safe fixed result */ }
-  const mapping = await mappingCheck(join(rt.homeDir, '.pi', 'agent', 'sessions.json'), rt);
-  const status = worstStatus([installed ? 'pass' : 'fail', mapping.status]);
-  return { sessionTracker: {
-    package: '@ai-devkit/pi-session-tracker', installed,
-    registryPath: mapping.path, registryValid: mapping.valid,
-    invalidEntries: mapping.invalidEntries, staleEntries: mapping.staleEntries,
-    status, errors: [
-      ...(!installed ? ['Pi session tracker is not registered'] : []), ...mapping.errors,
-    ],
-  }, status };
-}
-
-async function codexAuthCheck(rt: Runtime): Promise<AuthCheck> {
-  try {
-    const value = await rt.codexAuth();
-    return {
-      state: value === true ? 'authenticated' : value === false ? 'unauthenticated' : 'unknown',
-      source: displayHome(join(rt.homeDir, '.codex', 'auth.json'), rt.homeDir),
-      status: value === true ? 'pass' : value === false ? 'fail' : 'warn',
-      errors: value === true ? [] : [value === false ? 'Codex is not authenticated' : 'Codex authentication is unknown'],
-    };
-  } catch {
-    return { state: 'unknown', source: '~/.codex/auth.json', status: 'warn', errors: ['Codex authentication probe failed'] };
-  }
-}
-
-async function claudeAuthCheck(rt: Runtime): Promise<AuthCheck> {
-  try {
-    const result = await rt.runCommand('claude', ['auth', 'status', '--json']);
-    const parsed = record(JSON.parse(result.stdout));
-    const authenticated = parsed?.loggedIn === true || parsed?.authenticated === true;
-    const unauthenticated = parsed?.loggedIn === false || parsed?.authenticated === false;
-    return {
-      state: authenticated ? 'authenticated' : unauthenticated ? 'unauthenticated' : 'unknown',
-      source: 'claude auth status --json', status: authenticated ? 'pass' : unauthenticated ? 'fail' : 'warn',
-      errors: authenticated ? [] : [unauthenticated ? 'Claude is not authenticated' : 'Claude authentication is unknown'],
-    };
-  } catch {
-    return { state: 'unknown', source: 'claude auth status --json', status: 'warn', errors: ['Claude authentication probe failed'] };
-  }
-}
-
-async function piAuthCheck(rt: Runtime): Promise<AuthCheck> {
-  const sourcePath = join(rt.homeDir, '.pi', 'agent', 'auth.json');
-  try {
-    const parsed = record(JSON.parse(await rt.readFile(sourcePath)));
-    if (!parsed) throw new Error('invalid');
-    return {
-      state: 'unknown', source: displayHome(sourcePath, rt.homeDir), status: 'warn',
-      errors: ['Pi credential file is present but current authentication cannot be verified'],
-    };
-  } catch {
-    return {
-      state: 'unauthenticated', source: displayHome(sourcePath, rt.homeDir), status: 'fail',
-      errors: ['Pi credential file is missing or invalid'],
-    };
-  }
-}
-
-async function agentCheck<H extends HookGroupBase>(
-  agent: AgentKey, hooks: Promise<H>, auth: Promise<AuthCheck>, rt: Runtime,
-): Promise<AgentCheck<H>> {
-  const [executable, globalConfig, builtInSkills, hookResult, authResult] = await Promise.all([
-    executableCheck(AGENTS[agent].command, rt), directoryCheck(agent, rt), builtInSkillsCheck(agent, rt), hooks, auth,
-  ]);
-  return {
-    executable, globalConfig, auth: authResult, builtInSkills, hooks: hookResult,
-    status: worstStatus([executable.status, globalConfig.status, authResult.status, builtInSkills.status, hookResult.status]),
-  };
-}
-
 async function projectConfigCheck(rt: Runtime): Promise<{ check: ProjectConfigCheck; raw: Record<string, unknown> | null }> {
   const target = join(rt.cwd, '.ai-devkit.json');
   let text: string;
   try { text = await rt.readFile(target); } catch {
     return { raw: null, check: {
       path: target, present: false, valid: false, version: null, environments: [],
-      status: 'fail', errors: ['project configuration is missing'],
+      status: 'warn', errors: ['project configuration is missing'],
     } };
   }
   let parsed: Record<string, unknown> | null = null;
@@ -474,10 +184,10 @@ async function globalRegistries(rt: Runtime): Promise<RegistryScopeCheck> {
   try {
     const parsed = record(JSON.parse(await rt.readFile(source)));
     if (!parsed) throw new Error('invalid');
-    return { source: displayHome(source, rt.homeDir), configured: safeRegistries(parsed.registries), status: 'pass', errors: [] };
+    return { source: displayHome(source, rt.homeDir), configured: safeRegistries(parsed.registries), errors: [] };
   } catch {
     return {
-      source: displayHome(source, rt.homeDir), configured: {}, status: 'warn',
+      source: displayHome(source, rt.homeDir), configured: {},
       errors: ['global AI DevKit configuration is missing or invalid'],
     };
   }
@@ -485,8 +195,8 @@ async function globalRegistries(rt: Runtime): Promise<RegistryScopeCheck> {
 
 function projectRegistries(raw: Record<string, unknown> | null, source: string): RegistryScopeCheck {
   return raw
-    ? { source, configured: safeRegistries(raw.registries), status: 'pass', errors: [] }
-    : { source, configured: {}, status: 'fail', errors: ['project registries are unavailable because project configuration is invalid'] };
+    ? { source, configured: safeRegistries(raw.registries), errors: [] }
+    : { source, configured: {}, errors: ['project registries are unavailable because project configuration is invalid'] };
 }
 
 function safeRegistries(raw: unknown): Record<string, string> {
@@ -538,17 +248,24 @@ async function versionCheck(rt: Runtime): Promise<VersionCheck> {
 }
 
 async function tmuxCheck(rt: Runtime): Promise<TmuxCheck> {
-  const executable = await resolveExecutable('tmux', rt);
-  if (!executable) return {
-    path: null, available: false, version: null, status: 'fail', errors: ['tmux was not found on PATH'],
-  };
-  try {
-    const result = await rt.runCommand('tmux', ['-V']);
-    const version = result.stdout.trim().replace(/^tmux\s+/i, '') || null;
-    return { path: executable, available: true, version, status: 'pass', errors: [] };
-  } catch {
-    return { path: executable, available: false, version: null, status: 'fail', errors: ['tmux version probe failed'] };
+  const inspection = await inspectTmux({
+    run: (command, args) => rt.runCommand(command, [...args]),
+    platform: process.platform,
+    readOsRelease: async () => '',
+    releaseText: '',
+    which: async () => false,
+  });
+  if (inspection.state === 'available') {
+    return { path: 'tmux', available: true, version: inspection.version, status: 'pass', errors: [] };
   }
+  if (inspection.state === 'missing') {
+    return {
+      path: null, available: false, version: null, status: 'fail', errors: ['tmux was not found on PATH'],
+    };
+  }
+  return {
+    path: 'tmux', available: false, version: null, status: 'fail', errors: ['tmux version probe failed'],
+  };
 }
 
 function nonEmpty(value: unknown): boolean {
@@ -579,7 +296,6 @@ function channelConnection(name: string, value: unknown): ChannelConnection {
   const ready = enabled && schemaValid && (authorized !== false);
   return {
     name, type, enabled, credentialsPresent, authorized, ready,
-    status: ready ? 'pass' : enabled ? 'fail' : 'warn',
     errors: ready ? [] : [enabled ? 'channel configuration is not ready' : 'channel is disabled'],
   };
 }
@@ -590,9 +306,9 @@ async function channelsCheck(rt: Runtime): Promise<ChannelsCheck> {
   try { text = await rt.readFile(target); } catch {
     const config: ChannelConfigCheck = {
       path: displayHome(target, rt.homeDir), present: false, validJson: false, validSchema: false,
-      status: 'warn', errors: ['channel configuration has not been created'],
+      errors: ['channel configuration has not been created'],
     };
-    return { config, connections: [], readyCount: 0, status: config.status };
+    return { config, connections: [], readyCount: 0 };
   }
   let parsed: Record<string, unknown> | null = null;
   try { parsed = record(JSON.parse(text)); } catch { /* fixed safe error below */ }
@@ -600,55 +316,59 @@ async function channelsCheck(rt: Runtime): Promise<ChannelsCheck> {
   if (!parsed || !channelRecord) {
     const config: ChannelConfigCheck = {
       path: displayHome(target, rt.homeDir), present: true, validJson: parsed !== null,
-      validSchema: false, status: 'fail', errors: ['channel configuration is invalid'],
+      validSchema: false, errors: ['channel configuration is invalid'],
     };
-    return { config, connections: [], readyCount: 0, status: 'fail' };
+    return { config, connections: [], readyCount: 0 };
   }
   const connections = Object.entries(channelRecord).map(([name, entry]) => channelConnection(name, entry));
-  const validSchema = connections.every(item => item.status !== 'fail');
+  const validSchema = connections.every(item => item.ready || !item.enabled);
   const config: ChannelConfigCheck = {
     path: displayHome(target, rt.homeDir), present: true, validJson: true, validSchema: true,
-    status: validSchema ? 'pass' : 'fail', errors: validSchema ? [] : ['one or more channel entries are invalid'],
+    errors: validSchema ? [] : ['one or more channel entries are invalid'],
   };
   config.validSchema = validSchema;
   return {
     config, connections, readyCount: connections.filter(item => item.ready).length,
-    status: worstStatus([config.status, ...connections.map(item => item.status)]),
   };
 }
 
 function leafStatuses(report: Omit<StatusReport, 'overall' | 'checks'>): CheckStatus[] {
-  const { codex, pi, claude } = report.agents;
-  return [
-    report.aiDevkit.status, report.project.config.status,
-    codex.executable.status, codex.globalConfig.status, codex.auth.status, codex.builtInSkills.status,
-    codex.hooks.sessionMappingScript.status, codex.hooks.registration.status, codex.hooks.mappingFile.status,
-    pi.executable.status, pi.globalConfig.status, pi.auth.status, pi.builtInSkills.status,
-    pi.hooks.sessionTracker.status,
-    claude.executable.status, claude.globalConfig.status, claude.auth.status, claude.builtInSkills.status,
-    claude.hooks.promptScript.status, claude.hooks.registration.status,
-    report.tmux.status, report.registries.project.status, report.registries.global.status,
-    report.channels.config.status, ...report.channels.connections.map(item => item.status),
-  ];
+  const agentStatuses = Object.values(report.agents)
+    .filter(agent => agent.executable.path !== null)
+    .flatMap(agent => [
+    agent.executable.status,
+    agent.globalConfig.status,
+    ...(agent.auth ? [agent.auth.status] : []),
+    ...(agent.integration ? [agent.integration.status] : []),
+  ]);
+  return [report.aiDevkit.status, report.project.config.status, ...agentStatuses, report.tmux.status];
 }
 
 export async function getStatusReport(options: StatusServiceOptions = {}): Promise<StatusReport> {
   const rt = runtime(options);
   const projectPromise = projectConfigCheck(rt);
-  const [project, codex, pi, claude, aiDevkit, tmux, globalRegistry, channels] = await Promise.all([
+  const agentOptions: AgentReadinessOptions = {
+    homeDir: rt.homeDir,
+    path: rt.path,
+    assetRoot: rt.assetRoot,
+    builtInSkillNames: BUILTIN_SKILL_NAMES,
+    skillRoots: STATUS_SKILL_ROOTS,
+    readFile: rt.readFile,
+    access: rt.access,
+    runCommand: rt.runCommand,
+    codexAuth: rt.codexAuth,
+  };
+  const [project, agents, aiDevkit, tmux, globalRegistry, channels] = await Promise.all([
     projectPromise,
-    agentCheck('codex', codexHooks(rt), codexAuthCheck(rt), rt),
-    agentCheck('pi', piHooks(rt), piAuthCheck(rt), rt),
-    agentCheck('claude', claudeHooks(rt), claudeAuthCheck(rt), rt),
+    getAgentReadinessReports(agentOptions),
     versionCheck(rt), tmuxCheck(rt), globalRegistries(rt), channelsCheck(rt),
   ]);
   const registries: RegistriesCheck = {
     project: projectRegistries(project.raw, project.check.path), global: globalRegistry,
-    status: worstStatus([project.raw ? 'pass' : 'fail', globalRegistry.status]),
   };
   const partial = {
     generatedAt: rt.now().toISOString(), aiDevkit,
-    project: { cwd: rt.cwd, config: project.check }, agents: { codex, pi, claude },
+    project: { cwd: rt.cwd, config: project.check }, agents,
     tmux, registries, channels,
   };
   const statuses = leafStatuses(partial);


### PR DESCRIPTION
## Summary
- Move agent-specific status readiness checks into agent-manager.
- Add adapter readiness coverage for installed executables, auth/provider state, built-in skills, and ai-devkit integrations.
- Refactor CLI status rendering so scored checks show ready/not ready/fail while reference-only sections remain info-only.

## Validation
- npm test --workspace=@ai-devkit/agent-manager -- --run src/__tests__/readiness/AgentReadiness.test.ts
- npm test --workspace=ai-devkit -- --run src/__tests__/commands/status.test.ts src/__tests__/services/status/status.service.test.ts
- npm run build --workspace=@ai-devkit/agent-manager
- npm run build --workspace=ai-devkit
- npm run lint --workspace=@ai-devkit/agent-manager
- npm run lint --workspace=ai-devkit
- npx ai-devkit@latest lint --feature status-agent-readiness
- node packages/cli/dist/cli.js status