### PR TITLE
fix(cli): surface tmux guidance after setup output

### DIFF
--- a/packages/cli/src/__tests__/commands/setup.test.ts
+++ b/packages/cli/src/__tests__/commands/setup.test.ts
@@ -105,7 +105,13 @@ describe('setup command', () => {
 
     await program.parseAsync(['node', 'test', 'setup']);
 
-    expect(mockUi.warning).toHaveBeenCalledWith(expect.stringContaining('sudo apt-get install tmux'));
+    expect(mockUi.text).toHaveBeenCalledWith('Next steps');
+    expect(mockUi.warning).toHaveBeenCalledWith(
+      'Next step: install tmux (sudo apt-get update && sudo apt-get install tmux), then run ai-devkit setup again to start managed agents.',
+    );
+    expect(mockInspectTmux.mock.invocationCallOrder[0]).toBeLessThan(mockSetupService.run.mock.invocationCallOrder[0]);
+    expect(mockUi.table.mock.invocationCallOrder[0]).toBeLessThan(mockUi.text.mock.invocationCallOrder[0]);
+    expect(mockUi.table.mock.invocationCallOrder[0]).toBeLessThan(mockUi.warning.mock.invocationCallOrder[0]);
     expect(mockSetupService.run).toHaveBeenCalledOnce();
     expect(process.exitCode).toBe(0);
   });
@@ -117,7 +123,12 @@ describe('setup command', () => {
 
     await program.parseAsync(['node', 'test', 'setup']);
 
-    expect(mockUi.warning).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+    expect(mockUi.text).toHaveBeenCalledWith('Next steps');
+    expect(mockUi.warning).toHaveBeenCalledWith(
+      'tmux check could not run (permission denied) — verify tmux works before starting agents.',
+    );
+    expect(mockInspectTmux.mock.invocationCallOrder[0]).toBeLessThan(mockSetupService.run.mock.invocationCallOrder[0]);
+    expect(mockUi.table.mock.invocationCallOrder[0]).toBeLessThan(mockUi.warning.mock.invocationCallOrder[0]);
     expect(mockSetupService.run).toHaveBeenCalledOnce();
     expect(process.exitCode).toBe(0);
   });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -31,15 +31,6 @@ export async function setupCommand(options: SetupCommandOptions = {}): Promise<v
 
   const tmuxDeps = createTmuxInspectionDeps();
   const tmux = await inspectTmux(tmuxDeps);
-  ui.text('Host Prerequisites');
-  if (tmux.state === 'available') {
-    ui.success(tmux.version ? `tmux ${tmux.version} available` : `${tmux.rawVersion} available`);
-  } else if (tmux.state === 'missing') {
-    const instructions = await resolveTmuxInstallInstructions(tmuxDeps);
-    ui.warning(`tmux is required for interactive managed agents. ${instructions.message} Setup will continue.`);
-  } else {
-    ui.warning(`Could not run tmux -V (${tmux.rawVersion}). Setup will continue.`);
-  }
 
   const report = await createSetupService().run({ agents });
   const counts = countStatuses(report.results.map(result => result.status));
@@ -62,6 +53,18 @@ export async function setupCommand(options: SetupCommandOptions = {}): Promise<v
       result.message,
     ]),
   });
+
+  if (tmux.state === 'available') {
+    ui.text('Host Prerequisites');
+    ui.success(tmux.version ? `tmux ${tmux.version} available` : `${tmux.rawVersion} available`);
+  } else if (tmux.state === 'missing') {
+    const instructions = await resolveTmuxInstallInstructions(tmuxDeps);
+    ui.text('Next steps');
+    ui.warning(`Next step: install tmux (${instructions.command}), then run ai-devkit setup again to start managed agents.`);
+  } else {
+    ui.text('Next steps');
+    ui.warning(`tmux check could not run (${tmux.rawVersion}) — verify tmux works before starting agents.`);
+  }
 
   process.exitCode = counts.failed > 0 ? 1 : 0;
 }


### PR DESCRIPTION
## Summary
- keep the tmux inspection before setup execution
- render tmux guidance after the setup summary and results table
- replace passive warnings with actionable next-step copy
- cover inspection and output ordering for missing and failed tmux checks

## Validation
- npm test --workspace packages/cli (92 files, 1117 tests)
- npm run build
- npm run lint (passes with 3 pre-existing warnings)
- npm run test:e2e (41 tests)

## Risks
- None known